### PR TITLE
fix: Force GitHub to re-register release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 
+# Triggers when a release PR is merged with the 'autorelease: pending' label
 on:
   pull_request:
     types: [closed]


### PR DESCRIPTION
## Summary
- GitHub Actions failed to properly register the release workflow, showing file path instead of workflow name
- All 27 runs were triggered by `push` events instead of `pull_request` events
- This prevented the workflow from triggering when PR #2 was merged

Adding a comment forces GitHub to re-parse and properly register the `pull_request: types: [closed]` trigger.