### PR TITLE
fix: Adds support to all forms of llm configuration on `maintenance.ex`

### DIFF
--- a/guides/graphrag.md
+++ b/guides/graphrag.md
@@ -651,11 +651,22 @@ mix arcana.graph.summarize_communities --concurrency 4
 mix arcana.graph.summarize_communities --quiet
 ```
 
-Requires an LLM to be configured:
+Requires an LLM to be configured. All standard `:llm` config formats are supported:
 
 ```elixir
+# String format (simplest, uses req_llm config for API key)
+config :arcana, :llm, "openai:gpt-4o-mini"
+
+# Tuple with options (explicit API key)
 config :arcana, :llm, {"openai:gpt-4o-mini", api_key: "..."}
+
+# Function (full control)
+config :arcana, :llm, fn prompt, context, opts ->
+  {:ok, MyApp.LLM.complete(prompt)}
+end
 ```
+
+See the [LLM Integration guide](llm-integration.md) for more details.
 
 ### Typical Workflow
 

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -767,6 +767,8 @@ defmodule Arcana.Maintenance do
         case Application.get_env(:arcana, :llm) do
           {provider, llm_opts} -> build_llm_fn(provider, llm_opts)
           nil -> nil
+          provider when is_binary(provider) -> build_llm_fn(provider, [])
+          fun when is_function(fun) -> fun
         end
       end)
 

--- a/lib/mix/tasks/arcana.graph.summarize_communities.ex
+++ b/lib/mix/tasks/arcana.graph.summarize_communities.ex
@@ -33,9 +33,12 @@ defmodule Mix.Tasks.Arcana.Graph.SummarizeCommunities do
 
   ## Requirements
 
-  This task requires an LLM to be configured:
-
-      config :arcana, :llm, {"openai:gpt-4o-mini", api_key: "..."}
+  This task requires an LLM to be configured. Supported formats:
+    config :arcana, :llm, "openai:gpt-4o-mini"
+    config :arcana, :llm, {"openai:gpt-4o-mini", api_key: "..."}
+    config :arcana, :llm, fn prompt, context, opts ->
+      {:ok, MyApp.LLM.complete(prompt)}
+    end
 
   """
 
@@ -76,7 +79,16 @@ defmodule Mix.Tasks.Arcana.Graph.SummarizeCommunities do
       No LLM configured for community summarization.
       Add to your config:
 
+          # String format (simplest)
+          config :arcana, :llm, "openai:gpt-4o-mini"
+
+          # Or tuple with options
           config :arcana, :llm, {"openai:gpt-4o-mini", api_key: "..."}
+
+          # Or function
+          config :arcana, :llm, fn prompt, context, opts ->
+            {:ok, MyApp.LLM.complete(prompt)}
+          end
       """)
     end
 


### PR DESCRIPTION
# Context

Based on the [lib/arcana/llm.ex](https://github.com/georgeguimaraes/arcana/blob/main/lib/arcana/llm.ex#L84-L131) protocol, the library should support three formats for the LLM configuration:
```elixir
# Function (arity 1, 2, or 3)
config :arcana, :llm, fn prompt -> {:ok, response} end

# String
config :arcana, :llm, "openai:gpt-4o-mini"

# Tuple (string + options)
config :arcana, :llm, {"openai:gpt-4o-mini", api_key: "..."}
```

But the [lib/arcana/maintenance.ex](https://github.com/georgeguimaraes/arcana/blob/main/lib/arcana/maintenance.ex#L764-L771) module only accepts a Tuple configuration:
https://github.com/georgeguimaraes/arcana/blob/149bfacbe342918bcd145eb89ee3a89520f1c39a/lib/arcana/maintenance.ex#L764-L771

As a consequence, when running the `arcana.graph.summarize_communities.ex` mix task with a String or Function configurations, it fails. For example, using a configuration like this:

```elixir
config :req_llm, :openai, api_key: System.get_env("OPENAI_API_KEY")

config :arcana,
  repo: Adept.Repo,
  embedder: :local,
  llm: "openai:gpt-4o-mini",
  graph: [
    enabled: true,
    extractor: Arcana.Graph.GraphExtractor.LLM,
    community_levels: 5,
    resolution: 1.0
  ]
```

When running the `mix arcana.graph.summarize_communities` task, it raises a CaseClauseError:
```
** (CaseClauseError) no case clause matching:

    "openai:gpt-4o-mini"

    (arcana 1.3.0) lib/arcana/maintenance.ex:767: anonymous fn/0 in Arcana.Maintenance.summarize_communities/2
    (arcana 1.3.0) lib/arcana/maintenance.ex:766: Arcana.Maintenance.summarize_communities/2
    (arcana 1.3.0) lib/mix/tasks/arcana.graph.summarize_communities.ex:111: Mix.Tasks.Arcana.Graph.SummarizeCommunities.run/1
    (mix 1.19.4) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.19.4) lib/mix/cli.ex:129: Mix.CLI.run_task/2
```

# Proposed Solution

- Add the missing cases for `String` and `Function` `:llm` configurations to the  `Arcana.Maintenance.summarize_communities/2` function;
- Update the `guides.graphrag.md` documentation to also include the other valid ways to set the `:llm` configuration
- Update the documentation and error message on `lib/mix/tasks/arcana.graph.summarize_communities.ex`
