### PR TITLE
feat: Fail-closed collection scoping, one result shape, release-safe LLM config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ arcana-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+.claude/worktrees/

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -314,6 +314,31 @@ false
 )
 ```
 
+Every mode returns the same `Arcana.SearchResult` struct, with `id`, `text`,
+`document_id`, `chunk_index`, `score`, per-mode score breakdowns
+(`vector_score`/`keyword_score`, set by single-query hybrid search), and the
+chunk's stored `metadata`.
+
+### Strict Collection Scoping
+
+By default, searching a collection name that doesn't exist silently searches
+across all collections, and ingesting into one creates it on the fly. In
+multi-tenant apps that's dangerous: a typo'd tenant collection becomes a
+cross-tenant search. Turn on strict mode to make unknown collection names an
+error instead:
+
+```elixir
+config :arcana, strict_collections: true
+```
+
+With strict mode on, `Arcana.search/2`, `Arcana.ask/2`, `Arcana.ingest/2`,
+vector-store deletes, and maintenance tasks return
+`{:error, {:unknown_collection, name}}` for names that don't exist. Create
+collections explicitly with `Arcana.Collection.get_or_create/3`. The flag can
+also be passed per call (`strict_collections: false` opts out for one call).
+
+Strict mode will become the default in Arcana 3.0.
+
 ### Question Answering
 
 Use `Arcana.ask/2` to combine search with an LLM for answers:

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -332,10 +332,19 @@ config :arcana, strict_collections: true
 ```
 
 With strict mode on, `Arcana.search/2`, `Arcana.ask/2`, `Arcana.ingest/2`,
-vector-store deletes, and maintenance tasks return
+vector-store writes/deletes, and maintenance functions return
 `{:error, {:unknown_collection, name}}` for names that don't exist. Create
 collections explicitly with `Arcana.Collection.get_or_create/3`. The flag can
 also be passed per call (`strict_collections: false` opts out for one call).
+
+Two things to know:
+
+- Ingest without a `:collection` uses the implicit `"default"` collection,
+  which strict mode also requires to exist. Create it once at setup:
+  `Arcana.Collection.get_or_create("default", MyApp.Repo)`.
+- Without strict mode, an unknown name still searches unscoped on the
+  vector/keyword path (legacy behavior), but graph-enhanced context is
+  scoped to nothing rather than leaking across collections.
 
 Strict mode will become the default in Arcana 3.0.
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -331,13 +331,15 @@ error instead:
 config :arcana, strict_collections: true
 ```
 
-With strict mode on, `Arcana.search/2`, `Arcana.ask/2`, `Arcana.ingest/2`,
-vector-store writes/deletes, and maintenance functions return
-`{:error, {:unknown_collection, name}}` for names that don't exist. Create
+With strict mode on, `Arcana.search/2`, `Arcana.ingest/2`, vector-store
+writes/deletes, and maintenance functions return
+`{:error, {:unknown_collection, name}}` for names that don't exist —
+`Arcana.ask/2` wraps it as its usual
+`{:error, {:search_failed, {:unknown_collection, name}}}`. Create
 collections explicitly with `Arcana.Collection.get_or_create/3`. The flag can
 also be passed per call (`strict_collections: false` opts out for one call).
 
-Two things to know:
+Three things to know:
 
 - Ingest without a `:collection` uses the implicit `"default"` collection,
   which strict mode also requires to exist. Create it once at setup:
@@ -345,6 +347,9 @@ Two things to know:
 - Without strict mode, an unknown name still searches unscoped on the
   vector/keyword path (legacy behavior), but graph-enhanced context is
   scoped to nothing rather than leaking across collections.
+- Strict validation needs the repo-backed collection registry. The
+  `:memory` vector store has no registry: it always fails closed for
+  unknown collections (empty results) instead of returning the error.
 
 Strict mode will become the default in Arcana 3.0.
 

--- a/guides/llm-integration.md
+++ b/guides/llm-integration.md
@@ -44,6 +44,26 @@ Pass a model string directly to `Arcana.ask/2`:
 
 The model string format is `provider:model-name`. Req.LLM supports 45+ providers including OpenAI, Anthropic, Google, Groq, and OpenRouter.
 
+## Global LLM Configuration
+
+Instead of passing `:llm` on every call, set it once:
+
+```elixir
+config :arcana, llm: "openai:gpt-4o-mini"
+```
+
+For a custom adapter, use a `{module, function}` tuple. Unlike a captured
+function (`&MyApp.LLM.complete/3`), it serializes into a release's
+`sys.config`, so it works from `config.exs` without `runtime.exs` wiring:
+
+```elixir
+config :arcana, llm: {MyApp.LLM, :complete}
+```
+
+The function is called with `prompt`, `prompt, context`, or
+`prompt, context, opts` depending on its arity, and must return
+`{:ok, answer}` or `{:error, reason}`.
+
 ## Custom Prompts
 
 Use the `:prompt` option for custom system prompts:

--- a/lib/arcana/ask.ex
+++ b/lib/arcana/ask.ex
@@ -274,11 +274,14 @@ defmodule Arcana.Ask do
     end)
   end
 
+  # `nil` means unscoped; `[]` means the named collections resolved to
+  # nothing and downstream graph queries must match nothing. Strict
+  # validation already happened in Arcana.Search.search/2.
   defp resolve_collection_ids(opts, repo) do
-    case Arcana.Collection.names_from_opts(opts) |> Arcana.Collection.resolve_ids(repo) do
-      nil -> nil
-      [] -> nil
-      ids -> ids
-    end
+    {:ok, ids} =
+      Arcana.Collection.names_from_opts(opts)
+      |> Arcana.Collection.resolve_ids(repo)
+
+    ids
   end
 end

--- a/lib/arcana/collection.ex
+++ b/lib/arcana/collection.ex
@@ -69,24 +69,65 @@ defmodule Arcana.Collection do
   end
 
   @doc """
+  Fetches a collection by name.
+
+  Returns `{:ok, collection}` or `{:error, {:unknown_collection, name}}`.
+  """
+  def fetch(name, repo) when is_binary(name) do
+    case repo.get_by(__MODULE__, name: name) do
+      nil -> {:error, {:unknown_collection, name}}
+      collection -> {:ok, collection}
+    end
+  end
+
+  @doc """
   Resolves a list of collection names to their IDs.
 
-  Returns `nil` for unscoped queries (when collections is `[nil]`),
-  otherwise returns a list of UUIDs (possibly empty).
+  Returns `{:ok, nil}` for unscoped queries (when collections is `[nil]`),
+  otherwise `{:ok, ids}`. Unknown names are dropped, so the list can be
+  empty — callers must treat an empty list as "match nothing", never as
+  "no filter". With `strict: true`, the first unknown name returns
+  `{:error, {:unknown_collection, name}}` instead.
   """
-  def resolve_ids([nil], _repo), do: nil
+  def resolve_ids(names, repo, opts \\ [])
 
-  def resolve_ids(names, repo) when is_list(names) do
-    import Ecto.Query
+  def resolve_ids([nil], _repo, _opts), do: {:ok, nil}
+
+  def resolve_ids(names, repo, opts) when is_list(names) do
+    strict? = Keyword.get(opts, :strict, false)
 
     names
     |> Enum.reject(&is_nil/1)
-    |> Enum.flat_map(fn name ->
-      case repo.one(from(c in __MODULE__, where: c.name == ^name, select: c.id)) do
-        nil -> []
-        id -> [id]
+    |> Enum.reduce_while({:ok, []}, fn name, {:ok, acc} ->
+      case resolve_id(name, repo, strict?) do
+        {:ok, nil} -> {:cont, {:ok, acc}}
+        {:ok, id} -> {:cont, {:ok, [id | acc]}}
+        {:error, _} = error -> {:halt, error}
       end
     end)
+    |> case do
+      {:ok, ids} -> {:ok, Enum.reverse(ids)}
+      error -> error
+    end
+  end
+
+  @doc """
+  Resolves a single collection name to its ID.
+
+  Returns `{:ok, nil}` when `name` is `nil` (unscoped) or, in non-strict
+  mode, when the collection doesn't exist. With `strict?` set, an unknown
+  name returns `{:error, {:unknown_collection, name}}`.
+  """
+  def resolve_id(name, repo, strict? \\ false)
+
+  def resolve_id(nil, _repo, _strict?), do: {:ok, nil}
+
+  def resolve_id(name, repo, strict?) when is_binary(name) do
+    case repo.get_by(__MODULE__, name: name) do
+      nil when strict? -> {:error, {:unknown_collection, name}}
+      nil -> {:ok, nil}
+      collection -> {:ok, collection.id}
+    end
   end
 
   @doc """

--- a/lib/arcana/config.ex
+++ b/lib/arcana/config.ex
@@ -194,6 +194,7 @@ defmodule Arcana.Config do
       },
       vector_store: get_env(:vector_store, :pgvector),
       reranker: get_env(:reranker, Arcana.Reranker.LLM),
+      strict_collections: get_env(:strict_collections, false),
       graph: Arcana.Graph.config()
     }
   end
@@ -216,6 +217,24 @@ defmodule Arcana.Config do
   def graph_enabled?(opts) do
     case Keyword.get(opts, :graph) do
       nil -> Arcana.Graph.enabled?()
+      value -> value
+    end
+  end
+
+  @doc """
+  Returns whether strict collection scoping is enabled.
+
+  When strict, an unknown collection name is an error
+  (`{:error, {:unknown_collection, name}}`) instead of silently widening
+  the operation to every collection. Checks the `:strict_collections`
+  option in the provided opts first (so `strict_collections: false` can
+  override a global `true` per call), then falls back to
+  `config :arcana, strict_collections: true`. Defaults to `false`; the
+  default will flip to `true` in Arcana 3.0.
+  """
+  def strict_collections?(opts \\ []) do
+    case Keyword.get(opts, :strict_collections) do
+      nil -> get_env(:strict_collections, false)
       value -> value
     end
   end

--- a/lib/arcana/graph/entity_matcher/ner.ex
+++ b/lib/arcana/graph/entity_matcher/ner.ex
@@ -41,8 +41,10 @@ defmodule Arcana.Graph.EntityMatcher.NER do
   defp lookup_ids_by_name(entity_names, collection_ids, repo) do
     query = from(e in Entity, where: e.name in ^entity_names, select: e.id)
 
+    # nil means unscoped; a list scopes the query, and an empty list must
+    # match nothing (`in []` compiles to false) — never fall back to global.
     query =
-      if collection_ids && collection_ids != [] do
+      if is_list(collection_ids) do
         from(e in query, where: e.collection_id in ^collection_ids)
       else
         query

--- a/lib/arcana/graph/fusion_search.ex
+++ b/lib/arcana/graph/fusion_search.ex
@@ -25,7 +25,7 @@ defmodule Arcana.Graph.FusionSearch do
       {:ok, entities} = Arcana.Graph.EntityExtractor.NER.extract("Tell me about OpenAI", [])
 
       # Run vector search
-      vector_results = Arcana.search(repo, collection, query, top_k: 10)
+      {:ok, vector_results} = Arcana.search(query, repo: repo, collection: collection, limit: 10)
 
       # Combine with graph search
       FusionSearch.search(graph, entities, vector_results)

--- a/lib/arcana/graph/graph_store/ecto.ex
+++ b/lib/arcana/graph/graph_store/ecto.ex
@@ -114,8 +114,10 @@ defmodule Arcana.Graph.GraphStore.Ecto do
         }
       )
 
+    # nil means unscoped; a list scopes the query, and an empty list must
+    # match nothing (`in []` compiles to false) — never fall back to global.
     base =
-      if collection_ids && collection_ids != [] do
+      if is_list(collection_ids) do
         from(e in base, where: e.collection_id in ^collection_ids)
       else
         base
@@ -562,7 +564,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     query = from(e in Entity, where: e.name in ^entity_names, select: e.id)
 
     query =
-      if collection_ids && collection_ids != [],
+      if is_list(collection_ids),
         do: from(e in query, where: e.collection_id in ^collection_ids),
         else: query
 

--- a/lib/arcana/graph/graph_store/memory.ex
+++ b/lib/arcana/graph/graph_store/memory.ex
@@ -667,8 +667,9 @@ defmodule Arcana.Graph.GraphStore.Memory do
     end
   end
 
+  # nil means unscoped; [] means the caller named collections that resolved
+  # to nothing and must match nothing, never fall back to everything.
   defp filter_by_collections(entities_map, nil), do: entities_map
-  defp filter_by_collections(entities_map, []), do: entities_map
 
   defp filter_by_collections(entities_map, collection_ids) do
     Map.take(entities_map, collection_ids)

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -40,25 +40,29 @@ defmodule Arcana.Ingest do
     }
 
     :telemetry.span([:arcana, :ingest], start_metadata, fn ->
-      {:ok, collection} = Collection.get_or_create(collection_name, repo, collection_description)
+      case resolve_collection(collection_name, collection_description, repo, opts) do
+        {:ok, collection} ->
+          {:ok, document} =
+            %Document{}
+            |> Document.changeset(%{
+              content: text,
+              source_id: source_id,
+              metadata: metadata,
+              status: :processing,
+              collection_id: collection.id
+            })
+            |> repo.insert()
 
-      {:ok, document} =
-        %Document{}
-        |> Document.changeset(%{
-          content: text,
-          source_id: source_id,
-          metadata: metadata,
-          status: :processing,
-          collection_id: collection.id
-        })
-        |> repo.insert()
+          chunks = Chunker.chunk(chunker_config, text, chunk_opts)
+          result = embed_and_store_chunks(chunks, document, repo)
 
-      chunks = Chunker.chunk(chunker_config, text, chunk_opts)
-      result = embed_and_store_chunks(chunks, document, repo)
+          case result do
+            {:ok, chunk_records} ->
+              finalize_ingest(document, chunk_records, collection, repo, opts)
 
-      case result do
-        {:ok, chunk_records} ->
-          finalize_ingest(document, chunk_records, collection, repo, opts)
+            {:error, reason} ->
+              {{:error, reason}, %{error: reason}}
+          end
 
         {:error, reason} ->
           {{:error, reason}, %{error: reason}}
@@ -164,22 +168,33 @@ defmodule Arcana.Ingest do
     chunk_opts = Keyword.take(opts, [:chunk_size, :chunk_overlap, :format, :size_unit])
     chunker_config = Arcana.Config.resolve_chunker(opts)
 
-    {:ok, collection} = Collection.get_or_create(collection_name, repo)
-
-    {:ok, document} =
-      %Document{}
-      |> Document.changeset(%{
-        content: text,
+    with {:ok, collection} <- resolve_collection(collection_name, nil, repo, opts) do
+      do_ingest_with_file_attrs(text, collection, repo, %{
         source_id: source_id,
         metadata: metadata,
         file_path: file_path,
         content_type: content_type,
+        chunk_opts: chunk_opts,
+        chunker_config: chunker_config
+      })
+    end
+  end
+
+  defp do_ingest_with_file_attrs(text, collection, repo, attrs) do
+    {:ok, document} =
+      %Document{}
+      |> Document.changeset(%{
+        content: text,
+        source_id: attrs.source_id,
+        metadata: attrs.metadata,
+        file_path: attrs.file_path,
+        content_type: attrs.content_type,
         status: :processing,
         collection_id: collection.id
       })
       |> repo.insert()
 
-    chunks = Chunker.chunk(chunker_config, text, chunk_opts)
+    chunks = Chunker.chunk(attrs.chunker_config, text, attrs.chunk_opts)
     result = embed_and_store_chunks(chunks, document, repo)
 
     case result do
@@ -193,6 +208,17 @@ defmodule Arcana.Ingest do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  # Under strict_collections, ingest requires the collection to already
+  # exist (create explicitly with Collection.get_or_create/3); otherwise
+  # it is created on the fly.
+  defp resolve_collection(name, description, repo, opts) do
+    if Arcana.Config.strict_collections?(opts) do
+      Collection.fetch(name, repo)
+    else
+      Collection.get_or_create(name, repo, description)
     end
   end
 

--- a/lib/arcana/llm.ex
+++ b/lib/arcana/llm.ex
@@ -6,7 +6,13 @@ defprotocol Arcana.LLM do
 
   - Model strings via Req.LLM (e.g., `"openai:gpt-4o-mini"`, `"zai:glm-4.5-flash"`)
   - Tuples of `{model_string, opts}` for passing options like `:api_key`
+  - Tuples of `{module, function}` naming a function of arity 1, 2, or 3
+    (`prompt`, `prompt, context`, or `prompt, context, opts`)
   - Anonymous functions (for testing)
+
+  Prefer the `{module, function}` form for `config :arcana, :llm` — unlike
+  a captured function, it serializes into a release's `sys.config`, so it
+  doesn't have to be wired in `runtime.exs`.
 
   ## Examples
 
@@ -15,6 +21,9 @@ defprotocol Arcana.LLM do
 
       # With options
       Arcana.ask("question", llm: {"zai:glm-4.7", api_key: "key"}, repo: MyApp.Repo)
+
+      # Module/function tuple (release-safe for config)
+      config :arcana, llm: {MyApp.LLM, :complete}
 
       # Function (for testing)
       Arcana.ask("question", llm: fn _prompt -> {:ok, "answer"} end, repo: MyApp.Repo)
@@ -122,10 +131,33 @@ if Code.ensure_loaded?(ReqLLM) do
       end)
     end
   end
+end
 
-  defimpl Arcana.LLM, for: Tuple do
-    def complete({model, llm_opts}, prompt, context, opts) do
-      Arcana.LLM.complete(model, prompt, context, Keyword.merge(llm_opts, opts))
-    end
+defimpl Arcana.LLM, for: Tuple do
+  alias Arcana.LLM.Helpers
+
+  def complete({module, function}, prompt, context, opts)
+      when is_atom(module) and is_atom(function) do
+    Helpers.with_telemetry("#{inspect(module)}.#{function}", prompt, context, fn ->
+      Code.ensure_loaded(module)
+
+      cond do
+        function_exported?(module, function, 3) ->
+          apply(module, function, [prompt, context, opts])
+
+        function_exported?(module, function, 2) ->
+          apply(module, function, [prompt, context])
+
+        function_exported?(module, function, 1) ->
+          apply(module, function, [prompt])
+
+        true ->
+          {:error, {:invalid_llm_mfa, {module, function}}}
+      end
+    end)
+  end
+
+  def complete({model, llm_opts}, prompt, context, opts) when is_list(llm_opts) do
+    Arcana.LLM.complete(model, prompt, context, Keyword.merge(llm_opts, opts))
   end
 end

--- a/lib/arcana/llm.ex
+++ b/lib/arcana/llm.ex
@@ -139,9 +139,10 @@ defimpl Arcana.LLM, for: Tuple do
   def complete({module, function}, prompt, context, opts)
       when is_atom(module) and is_atom(function) do
     Helpers.with_telemetry("#{inspect(module)}.#{function}", prompt, context, fn ->
-      Code.ensure_loaded(module)
-
       cond do
+        not match?({:module, _}, Code.ensure_loaded(module)) ->
+          {:error, {:llm_module_not_found, module}}
+
         function_exported?(module, function, 3) ->
           apply(module, function, [prompt, context, opts])
 

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -178,17 +178,9 @@ defmodule Arcana.Loop do
     end
 
     # A {module, function} LLM (valid for ask/pipeline via Arcana.LLM) can't
-    # drive the tool loop: the controller needs ReqLLM tool calling.
-    case controller_llm do
-      {mod, fun} when is_atom(mod) and is_atom(fun) ->
-        raise ArgumentError,
-              "Arcana.Loop's controller can't use a {module, function} LLM " <>
-                "(#{inspect(controller_llm)}): the loop needs a ReqLLM model spec " <>
-                "for tool calling. Pass controller_llm: \"provider:model\" instead."
-
-      _ ->
-        :ok
-    end
+    # drive the loop: both roles go through ReqLLM message structures.
+    reject_mfa_llm!(controller_llm, ":controller_llm")
+    reject_mfa_llm!(answer_llm, ":answer_llm")
 
     # Force the resolved max_iterations into opts so the system prompt and
     # the loop see the same number, even when the caller didn't pass it.
@@ -384,6 +376,19 @@ defmodule Arcana.Loop do
   # `(messages, opts) -> {:ok, text} | {:error, reason}`. The default
   # appends a "synthesize now" instruction and calls the controller LLM
   # without tools so it has to produce text.
+  defp reject_mfa_llm!(llm, option) do
+    case llm do
+      {mod, fun} when is_atom(mod) and is_atom(fun) ->
+        raise ArgumentError,
+              "Arcana.Loop's #{option} can't use a {module, function} LLM " <>
+                "(#{inspect(llm)}): the loop needs a ReqLLM model spec. " <>
+                "Pass #{option} as \"provider:model\" instead."
+
+      _ ->
+        :ok
+    end
+  end
+
   defp maybe_synthesize_fallback(%Context{} = ctx, controller_llm, answer_llm, opts) do
     cond do
       ctx.terminated_by != :max_iterations ->

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -177,6 +177,19 @@ defmodule Arcana.Loop do
               "or set config :arcana, loop: [controller_llm: ...]"
     end
 
+    # A {module, function} LLM (valid for ask/pipeline via Arcana.LLM) can't
+    # drive the tool loop: the controller needs ReqLLM tool calling.
+    case controller_llm do
+      {mod, fun} when is_atom(mod) and is_atom(fun) ->
+        raise ArgumentError,
+              "Arcana.Loop's controller can't use a {module, function} LLM " <>
+                "(#{inspect(controller_llm)}): the loop needs a ReqLLM model spec " <>
+                "for tool calling. Pass controller_llm: \"provider:model\" instead."
+
+      _ ->
+        :ok
+    end
+
     # Force the resolved max_iterations into opts so the system prompt and
     # the loop see the same number, even when the caller didn't pass it.
     # Also surface the configured collections so the system prompt can

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -370,12 +370,6 @@ defmodule Arcana.Loop do
 
   defp enrich_source(source, _index), do: source
 
-  # Graceful degradation: if the controller hit max_iterations without
-  # calling `answer`, synthesize a final answer from the chunks we have.
-  # Disable with `fallback_synthesis: false`. The synthesizer is a function
-  # `(messages, opts) -> {:ok, text} | {:error, reason}`. The default
-  # appends a "synthesize now" instruction and calls the controller LLM
-  # without tools so it has to produce text.
   defp reject_mfa_llm!(llm, option) do
     case llm do
       {mod, fun} when is_atom(mod) and is_atom(fun) ->
@@ -389,6 +383,12 @@ defmodule Arcana.Loop do
     end
   end
 
+  # Graceful degradation: if the controller hit max_iterations without
+  # calling `answer`, synthesize a final answer from the chunks we have.
+  # Disable with `fallback_synthesis: false`. The synthesizer is a function
+  # `(messages, opts) -> {:ok, text} | {:error, reason}`. The default
+  # appends a "synthesize now" instruction and calls the controller LLM
+  # without tools so it has to produce text.
   defp maybe_synthesize_fallback(%Context{} = ctx, controller_llm, answer_llm, opts) do
     cond do
       ctx.terminated_by != :max_iterations ->

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -869,62 +869,70 @@ defmodule Arcana.Maintenance do
     # Validate the collection filter before requiring an LLM, so strict
     # callers get {:error, {:unknown_collection, name}} consistently.
     with {:ok, collections} <- fetch_collections(repo, collection_filter, strict?) do
-      if collections == [] do
-        {:ok, %{communities: 0, summaries: 0}}
-      else
-        # Normalize the LLM to a 3-arity function through the Arcana.LLM
-        # protocol, so every supported config shape (model string,
-        # {model, opts}, {module, function}, anonymous function) works here.
-        llm =
-          case Keyword.get_lazy(opts, :llm, fn -> Arcana.Config.get_env(:llm) end) do
-            nil ->
-              nil
+      summarize_fetched_collections(collections, repo, %{
+        opts: opts,
+        force: force,
+        concurrency: concurrency,
+        progress_fn: progress_fn
+      })
+    end
+  end
 
-            llm ->
-              fn prompt, context, call_opts ->
-                Arcana.LLM.complete(llm, prompt, context, call_opts)
-              end
-          end
+  defp summarize_fetched_collections([], _repo, _config) do
+    {:ok, %{communities: 0, summaries: 0}}
+  end
 
-        unless llm do
-          raise "No LLM configured. Set config :arcana, :llm or pass :llm option"
+  defp summarize_fetched_collections(collections, repo, config) do
+    %{opts: opts, force: force, concurrency: concurrency, progress_fn: progress_fn} = config
+    llm = resolve_summarizer_llm!(opts)
+    total_collections = length(collections)
+
+    results =
+      collections
+      |> Enum.with_index(1)
+      |> Enum.map(fn {collection, index} ->
+        result =
+          summarize_communities_for_collection(
+            collection,
+            repo,
+            llm,
+            force,
+            concurrency,
+            progress_fn
+          )
+
+        try do
+          progress_fn.(:collection_complete, %{
+            index: index,
+            total: total_collections,
+            collection: collection.name,
+            result: result
+          })
+        rescue
+          FunctionClauseError -> progress_fn.(index, total_collections)
         end
 
-        total_collections = length(collections)
+        result
+      end)
 
-        results =
-          collections
-          |> Enum.with_index(1)
-          |> Enum.map(fn {collection, index} ->
-            result =
-              summarize_communities_for_collection(
-                collection,
-                repo,
-                llm,
-                force,
-                concurrency,
-                progress_fn
-              )
+    total_communities = Enum.sum(Enum.map(results, & &1.communities))
+    total_summaries = Enum.sum(Enum.map(results, & &1.summaries))
 
-            try do
-              progress_fn.(:collection_complete, %{
-                index: index,
-                total: total_collections,
-                collection: collection.name,
-                result: result
-              })
-            rescue
-              FunctionClauseError -> progress_fn.(index, total_collections)
-            end
+    {:ok, %{communities: total_communities, summaries: total_summaries}}
+  end
 
-            result
-          end)
+  # Normalize the LLM to a 3-arity function through the Arcana.LLM
+  # protocol, so every supported config shape (model string, {model, opts},
+  # {module, function}, anonymous function) works here.
+  defp resolve_summarizer_llm!(opts) do
+    case Keyword.get_lazy(opts, :llm, fn -> Arcana.Config.get_env(:llm) end) do
+      nil ->
+        raise "No LLM configured. Set config :arcana, :llm or pass :llm option"
 
-        total_communities = Enum.sum(Enum.map(results, & &1.communities))
-        total_summaries = Enum.sum(Enum.map(results, & &1.summaries))
-
-        {:ok, %{communities: total_communities, summaries: total_summaries}}
-      end
+      llm ->
+        fn prompt, context, call_opts ->
+          Arcana.LLM.complete(llm, prompt, context, call_opts)
+        end
     end
   end
 

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -60,7 +60,21 @@ defmodule Arcana.Maintenance do
     collection_filter = Keyword.get(opts, :collection)
 
     embedder = Arcana.embedder()
-    collection_id = get_collection_id(repo, collection_filter)
+    strict? = Arcana.Config.strict_collections?(opts)
+
+    with {:ok, collection_id} <- Collection.resolve_id(collection_filter, repo, strict?) do
+      do_reembed(repo, embedder, collection_id, %{
+        batch_size: batch_size,
+        concurrency: concurrency,
+        skip: skip,
+        progress_fn: progress_fn
+      })
+    end
+  end
+
+  defp do_reembed(repo, embedder, collection_id, config) do
+    %{batch_size: batch_size, concurrency: concurrency, skip: skip, progress_fn: progress_fn} =
+      config
 
     # First, rechunk documents that have no chunks
     docs_without_chunks = fetch_docs_without_chunks(repo, collection_id)
@@ -91,15 +105,6 @@ defmodule Arcana.Maintenance do
        total_chunks: total_chunks,
        skipped: skipped
      }}
-  end
-
-  defp get_collection_id(_repo, nil), do: nil
-
-  defp get_collection_id(repo, collection_name) when is_binary(collection_name) do
-    case repo.one(from(c in Collection, where: c.name == ^collection_name, select: c.id)) do
-      nil -> nil
-      id -> id
-    end
   end
 
   defp fetch_docs_without_chunks(repo, nil) do
@@ -369,37 +374,31 @@ defmodule Arcana.Maintenance do
     embedder = Arcana.Config.embedder()
 
     query = from(e in Entity, order_by: e.id, select: [:id, :name, :description, :embedding])
+    strict? = Arcana.Config.strict_collections?(opts)
 
-    query =
-      if collection_filter do
-        collection_id =
-          repo.one(
-            from(c in Arcana.Collection, where: c.name == ^collection_filter, select: c.id)
-          )
-
+    with {:ok, collection_id} <- Collection.resolve_id(collection_filter, repo, strict?) do
+      query =
         if collection_id,
           do: from(e in query, where: e.collection_id == ^collection_id),
           else: query
-      else
-        query
-      end
 
-    query = if force, do: query, else: from(e in query, where: is_nil(e.embedding))
+      query = if force, do: query, else: from(e in query, where: is_nil(e.embedding))
 
-    entities = repo.all(query)
-    total = length(entities)
+      entities = repo.all(query)
+      total = length(entities)
 
-    # The reduce's return value is intentionally discarded: we use the
-    # accumulator for per-batch progress reporting, not as a final result.
-    _ =
-      entities
-      |> Enum.chunk_every(batch_size)
-      |> Enum.with_index(1)
-      |> Enum.reduce(0, fn {batch, _batch_idx}, count ->
-        maintenance_batch(batch, count, total, embedder, progress_fn, repo)
-      end)
+      # The reduce's return value is intentionally discarded: we use the
+      # accumulator for per-batch progress reporting, not as a final result.
+      _ =
+        entities
+        |> Enum.chunk_every(batch_size)
+        |> Enum.with_index(1)
+        |> Enum.reduce(0, fn {batch, _batch_idx}, count ->
+          maintenance_batch(batch, count, total, embedder, progress_fn, repo)
+        end)
 
-    {:ok, %{total: total}}
+      {:ok, %{total: total}}
+    end
   end
 
   defp maintenance_batch(batch, count, total, embedder, progress_fn, repo) do

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -476,28 +476,30 @@ defmodule Arcana.Maintenance do
     progress_fn = Keyword.get(opts, :progress, fn _, _ -> :ok end)
     collection_filter = Keyword.get(opts, :collection)
 
+    strict? = Arcana.Config.strict_collections?(opts)
+
     # Get collections (optionally filtered)
-    collections = fetch_collections(repo, collection_filter)
+    with {:ok, collections} <- fetch_collections(repo, collection_filter, strict?) do
+      if collections == [] do
+        {:ok, %{collections: 0, entities: 0, relationships: 0, skipped: 0}}
+      else
+        total_collections = length(collections)
 
-    if collections == [] do
-      {:ok, %{collections: 0, entities: 0, relationships: 0, skipped: 0}}
-    else
-      total_collections = length(collections)
+        results =
+          rebuild_graph_for_collections(collections, repo, opts, progress_fn, total_collections)
 
-      results =
-        rebuild_graph_for_collections(collections, repo, opts, progress_fn, total_collections)
+        total_entities = Enum.sum(Enum.map(results, & &1.entities))
+        total_relationships = Enum.sum(Enum.map(results, & &1.relationships))
+        total_skipped = Enum.sum(Enum.map(results, & &1.skipped))
 
-      total_entities = Enum.sum(Enum.map(results, & &1.entities))
-      total_relationships = Enum.sum(Enum.map(results, & &1.relationships))
-      total_skipped = Enum.sum(Enum.map(results, & &1.skipped))
-
-      {:ok,
-       %{
-         collections: total_collections,
-         entities: total_entities,
-         relationships: total_relationships,
-         skipped: total_skipped
-       }}
+        {:ok,
+         %{
+           collections: total_collections,
+           entities: total_entities,
+           relationships: total_relationships,
+           skipped: total_skipped
+         }}
+      end
     end
   end
 
@@ -615,12 +617,15 @@ defmodule Arcana.Maintenance do
     |> MapSet.new()
   end
 
-  defp fetch_collections(repo, nil) do
-    repo.all(from(c in Collection, select: c))
+  defp fetch_collections(repo, nil, _strict?) do
+    {:ok, repo.all(from(c in Collection, select: c))}
   end
 
-  defp fetch_collections(repo, collection_name) when is_binary(collection_name) do
-    repo.all(from(c in Collection, where: c.name == ^collection_name, select: c))
+  defp fetch_collections(repo, collection_name, strict?) when is_binary(collection_name) do
+    case repo.all(from(c in Collection, where: c.name == ^collection_name, select: c)) do
+      [] when strict? -> {:error, {:unknown_collection, collection_name}}
+      collections -> {:ok, collections}
+    end
   end
 
   @doc """
@@ -709,54 +714,56 @@ defmodule Arcana.Maintenance do
     min_size = Keyword.get(opts, :min_size, graph_config[:min_size] || 1)
     max_level = Keyword.get(opts, :max_level, graph_config[:community_levels] || 1)
 
-    collections = fetch_collections(repo, collection_filter)
+    strict? = Arcana.Config.strict_collections?(opts)
 
-    if collections == [] do
-      {:ok, %{collections: 0, communities: 0}}
-    else
-      total_collections = length(collections)
+    with {:ok, collections} <- fetch_collections(repo, collection_filter, strict?) do
+      if collections == [] do
+        {:ok, %{collections: 0, communities: 0}}
+      else
+        total_collections = length(collections)
 
-      detector_opts = [
-        resolution: resolution,
-        objective: objective,
-        iterations: iterations,
-        seed: seed,
-        min_size: min_size,
-        max_level: max_level
-      ]
+        detector_opts = [
+          resolution: resolution,
+          objective: objective,
+          iterations: iterations,
+          seed: seed,
+          min_size: min_size,
+          max_level: max_level
+        ]
 
-      detector_module = Arcana.Graph.CommunityDetector.Leiden
+        detector_module = Arcana.Graph.CommunityDetector.Leiden
 
-      results =
-        collections
-        |> Enum.with_index(1)
-        |> Enum.map(fn {collection, index} ->
-          result =
-            detect_communities_for_collection(
-              collection,
-              repo,
-              detector_module,
-              detector_opts,
-              progress_fn
-            )
+        results =
+          collections
+          |> Enum.with_index(1)
+          |> Enum.map(fn {collection, index} ->
+            result =
+              detect_communities_for_collection(
+                collection,
+                repo,
+                detector_module,
+                detector_opts,
+                progress_fn
+              )
 
-          try do
-            progress_fn.(:collection_complete, %{
-              index: index,
-              total: total_collections,
-              collection: collection.name,
-              result: result
-            })
-          rescue
-            FunctionClauseError -> progress_fn.(index, total_collections)
-          end
+            try do
+              progress_fn.(:collection_complete, %{
+                index: index,
+                total: total_collections,
+                collection: collection.name,
+                result: result
+              })
+            rescue
+              FunctionClauseError -> progress_fn.(index, total_collections)
+            end
 
-          result
-        end)
+            result
+          end)
 
-      total_communities = Enum.sum(Enum.map(results, & &1.communities))
+        total_communities = Enum.sum(Enum.map(results, & &1.communities))
 
-      {:ok, %{collections: total_collections, communities: total_communities}}
+        {:ok, %{collections: total_collections, communities: total_communities}}
+      end
     end
   end
 
@@ -857,60 +864,65 @@ defmodule Arcana.Maintenance do
     force = Keyword.get(opts, :force, false)
     concurrency = Keyword.get(opts, :concurrency, 1)
 
-    # Get LLM function from opts or config
+    # Normalize the LLM to a 3-arity function through the Arcana.LLM
+    # protocol, so every supported config shape (model string,
+    # {model, opts}, {module, function}, anonymous function) works here.
     llm =
-      Keyword.get_lazy(opts, :llm, fn ->
-        case Arcana.Config.get_env(:llm) do
-          {provider, llm_opts} -> build_llm_fn(provider, llm_opts)
-          nil -> nil
-          provider when is_binary(provider) -> build_llm_fn(provider, [])
-          fun when is_function(fun) -> fun
-        end
-      end)
+      case Keyword.get_lazy(opts, :llm, fn -> Arcana.Config.get_env(:llm) end) do
+        nil ->
+          nil
+
+        llm ->
+          fn prompt, context, call_opts ->
+            Arcana.LLM.complete(llm, prompt, context, call_opts)
+          end
+      end
 
     unless llm do
       raise "No LLM configured. Set config :arcana, :llm or pass :llm option"
     end
 
-    collections = fetch_collections(repo, collection_filter)
+    strict? = Arcana.Config.strict_collections?(opts)
 
-    if collections == [] do
-      {:ok, %{communities: 0, summaries: 0}}
-    else
-      total_collections = length(collections)
+    with {:ok, collections} <- fetch_collections(repo, collection_filter, strict?) do
+      if collections == [] do
+        {:ok, %{communities: 0, summaries: 0}}
+      else
+        total_collections = length(collections)
 
-      results =
-        collections
-        |> Enum.with_index(1)
-        |> Enum.map(fn {collection, index} ->
-          result =
-            summarize_communities_for_collection(
-              collection,
-              repo,
-              llm,
-              force,
-              concurrency,
-              progress_fn
-            )
+        results =
+          collections
+          |> Enum.with_index(1)
+          |> Enum.map(fn {collection, index} ->
+            result =
+              summarize_communities_for_collection(
+                collection,
+                repo,
+                llm,
+                force,
+                concurrency,
+                progress_fn
+              )
 
-          try do
-            progress_fn.(:collection_complete, %{
-              index: index,
-              total: total_collections,
-              collection: collection.name,
-              result: result
-            })
-          rescue
-            FunctionClauseError -> progress_fn.(index, total_collections)
-          end
+            try do
+              progress_fn.(:collection_complete, %{
+                index: index,
+                total: total_collections,
+                collection: collection.name,
+                result: result
+              })
+            rescue
+              FunctionClauseError -> progress_fn.(index, total_collections)
+            end
 
-          result
-        end)
+            result
+          end)
 
-      total_communities = Enum.sum(Enum.map(results, & &1.communities))
-      total_summaries = Enum.sum(Enum.map(results, & &1.summaries))
+        total_communities = Enum.sum(Enum.map(results, & &1.communities))
+        total_summaries = Enum.sum(Enum.map(results, & &1.summaries))
 
-      {:ok, %{communities: total_communities, summaries: total_summaries}}
+        {:ok, %{communities: total_communities, summaries: total_summaries}}
+      end
     end
   end
 
@@ -1025,19 +1037,6 @@ defmodule Arcana.Maintenance do
 
       {:error, _reason} ->
         :error
-    end
-  end
-
-  defp build_llm_fn(provider, llm_opts) when is_binary(provider) do
-    fn prompt, context, opts ->
-      Arcana.LLM.complete(provider, prompt, context, Keyword.merge(llm_opts, opts))
-    end
-  end
-
-  defp build_llm_fn({provider, provider_opts}, llm_opts) do
-    fn prompt, context, opts ->
-      merged = Keyword.merge(llm_opts, opts) |> Keyword.merge(provider_opts)
-      Arcana.LLM.complete(provider, prompt, context, merged)
     end
   end
 end

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -864,30 +864,32 @@ defmodule Arcana.Maintenance do
     force = Keyword.get(opts, :force, false)
     concurrency = Keyword.get(opts, :concurrency, 1)
 
-    # Normalize the LLM to a 3-arity function through the Arcana.LLM
-    # protocol, so every supported config shape (model string,
-    # {model, opts}, {module, function}, anonymous function) works here.
-    llm =
-      case Keyword.get_lazy(opts, :llm, fn -> Arcana.Config.get_env(:llm) end) do
-        nil ->
-          nil
-
-        llm ->
-          fn prompt, context, call_opts ->
-            Arcana.LLM.complete(llm, prompt, context, call_opts)
-          end
-      end
-
-    unless llm do
-      raise "No LLM configured. Set config :arcana, :llm or pass :llm option"
-    end
-
     strict? = Arcana.Config.strict_collections?(opts)
 
+    # Validate the collection filter before requiring an LLM, so strict
+    # callers get {:error, {:unknown_collection, name}} consistently.
     with {:ok, collections} <- fetch_collections(repo, collection_filter, strict?) do
       if collections == [] do
         {:ok, %{communities: 0, summaries: 0}}
       else
+        # Normalize the LLM to a 3-arity function through the Arcana.LLM
+        # protocol, so every supported config shape (model string,
+        # {model, opts}, {module, function}, anonymous function) works here.
+        llm =
+          case Keyword.get_lazy(opts, :llm, fn -> Arcana.Config.get_env(:llm) end) do
+            nil ->
+              nil
+
+            llm ->
+              fn prompt, context, call_opts ->
+                Arcana.LLM.complete(llm, prompt, context, call_opts)
+              end
+          end
+
+        unless llm do
+          raise "No LLM configured. Set config :arcana, :llm or pass :llm option"
+        end
+
         total_collections = length(collections)
 
         results =

--- a/lib/arcana/pipeline.ex
+++ b/lib/arcana/pipeline.ex
@@ -829,15 +829,13 @@ defmodule Arcana.Pipeline do
 
       chunks =
         case Arcana.Search.search(query, Keyword.put(search_opts, :collection, collection)) do
-          {:ok, results} -> Enum.map(results, &result_to_chunk/1)
+          {:ok, results} -> results
           {:error, _} -> []
         end
 
       %{question: query, collection: collection, chunks: chunks}
     end)
   end
-
-  defp result_to_chunk(r), do: Map.take(r, [:id, :text, :score])
 
   defp merge_results(existing_results, new_results) do
     all_results = (existing_results || []) ++ new_results

--- a/lib/arcana/reranker.ex
+++ b/lib/arcana/reranker.ex
@@ -33,11 +33,13 @@ defmodule Arcana.Reranker do
   @doc """
   Re-ranks chunks based on relevance to the question.
 
-  Chunks are `Arcana.SearchResult` structs. Returns chunks filtered by
+  Chunks from `Arcana.search/2` are `Arcana.SearchResult` structs, but
+  custom `Arcana.Searcher` implementations may supply plain maps, so
+  rerankers should not assume the struct. Returns chunks filtered by
   threshold and sorted by score (highest first). Rerankers that compute
-  an explicit score should store it in the `:rerank_score` field (as
-  `Arcana.Reranker.ColBERT` does); rerankers that only reorder or filter
-  can return the chunks unchanged.
+  an explicit score store it under `:rerank_score` (the built-in LLM and
+  ColBERT rerankers do); rerankers that only reorder or filter can
+  return the chunks unchanged.
 
   ## Options
 
@@ -47,7 +49,7 @@ defmodule Arcana.Reranker do
   """
   @callback rerank(
               question :: String.t(),
-              chunks :: [Arcana.SearchResult.t()],
+              chunks :: [Arcana.SearchResult.t() | map()],
               opts :: keyword()
-            ) :: {:ok, [Arcana.SearchResult.t()]} | {:error, term()}
+            ) :: {:ok, [Arcana.SearchResult.t() | map()]} | {:error, term()}
 end

--- a/lib/arcana/reranker.ex
+++ b/lib/arcana/reranker.ex
@@ -33,7 +33,11 @@ defmodule Arcana.Reranker do
   @doc """
   Re-ranks chunks based on relevance to the question.
 
-  Returns chunks filtered by threshold and sorted by score (highest first).
+  Chunks are `Arcana.SearchResult` structs. Returns chunks filtered by
+  threshold and sorted by score (highest first). Rerankers that compute
+  an explicit score should store it in the `:rerank_score` field (as
+  `Arcana.Reranker.ColBERT` does); rerankers that only reorder or filter
+  can return the chunks unchanged.
 
   ## Options
 
@@ -43,7 +47,7 @@ defmodule Arcana.Reranker do
   """
   @callback rerank(
               question :: String.t(),
-              chunks :: [map()],
+              chunks :: [Arcana.SearchResult.t()],
               opts :: keyword()
-            ) :: {:ok, [map()]} | {:error, term()}
+            ) :: {:ok, [Arcana.SearchResult.t()]} | {:error, term()}
 end

--- a/lib/arcana/reranker.ex
+++ b/lib/arcana/reranker.ex
@@ -37,9 +37,9 @@ defmodule Arcana.Reranker do
   custom `Arcana.Searcher` implementations may supply plain maps, so
   rerankers should not assume the struct. Returns chunks filtered by
   threshold and sorted by score (highest first). Rerankers that compute
-  an explicit score store it under `:rerank_score` (the built-in LLM and
-  ColBERT rerankers do); rerankers that only reorder or filter can
-  return the chunks unchanged.
+  an explicit score store it under `:rerank_score` (all the built-in
+  rerankers do); rerankers that only reorder or filter can return the
+  chunks unchanged.
 
   ## Options
 

--- a/lib/arcana/reranker/cross_encoder.ex
+++ b/lib/arcana/reranker/cross_encoder.ex
@@ -86,6 +86,8 @@ defmodule Arcana.Reranker.CrossEncoder do
         Enum.filter(scored, fn {_chunk, score} -> score >= threshold end)
       end
 
-    {:reply, {:ok, Enum.map(filtered, fn {chunk, _score} -> chunk end)}, state}
+    reranked = Enum.map(filtered, fn {chunk, score} -> Map.put(chunk, :rerank_score, score) end)
+
+    {:reply, {:ok, reranked}, state}
   end
 end

--- a/lib/arcana/reranker/llm.ex
+++ b/lib/arcana/reranker/llm.ex
@@ -116,7 +116,7 @@ defmodule Arcana.Reranker.LLM do
         end)
         |> Enum.filter(fn {_chunk, score} -> is_number(score) and score >= threshold end)
         |> Enum.sort_by(fn {_chunk, score} -> score end, :desc)
-        |> Enum.map(fn {chunk, _score} -> chunk end)
+        |> Enum.map(fn {chunk, score} -> Map.put(chunk, :rerank_score, score) end)
 
       _ ->
         Enum.map(passages, fn {_idx, chunk} -> chunk end)

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -389,15 +389,20 @@ defmodule Arcana.Search do
             []
 
           chunk ->
+            # Same normalization as the store-derived modes, so :metadata
+            # is shaped identically whether or not graph search produced
+            # the result.
             [
-              %SearchResult{
+              SearchResult.from_store_result(%{
                 id: chunk.id,
-                text: chunk.text,
-                document_id: chunk.document_id,
-                chunk_index: chunk.chunk_index,
                 score: score,
-                metadata: chunk.metadata || %{}
-              }
+                metadata:
+                  Map.merge(chunk.metadata || %{}, %{
+                    text: chunk.text,
+                    chunk_index: chunk.chunk_index,
+                    document_id: chunk.document_id
+                  })
+              })
             ]
         end
       end)

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -15,7 +15,7 @@ defmodule Arcana.Search do
 
   require Logger
 
-  alias Arcana.{Collection, Embedder, VectorStore}
+  alias Arcana.{Collection, Embedder, SearchResult, VectorStore}
   alias Arcana.VectorStore.Pgvector
 
   @valid_modes [:vector, :keyword, :hybrid]
@@ -49,8 +49,8 @@ defmodule Arcana.Search do
   @doc """
   Searches for chunks similar to the query.
 
-  Returns `{:ok, results}` where results is a list of maps containing chunk
-  information and similarity scores, or `{:error, reason}` on failure.
+  Returns `{:ok, results}` where results is a list of `Arcana.SearchResult`
+  structs (the same shape for every mode), or `{:error, reason}` on failure.
 
   ## Options
 
@@ -61,6 +61,9 @@ defmodule Arcana.Search do
     * `:mode` - Search mode: `:vector` (default), `:keyword`, or `:hybrid`.
       `:semantic` and `:fulltext` are deprecated aliases.
     * `:collection` - Filter results to a specific collection by name
+    * `:strict_collections` - When `true`, an unknown collection name
+      returns `{:error, {:unknown_collection, name}}` instead of searching
+      unscoped. Defaults to `config :arcana, strict_collections: false`.
     * `:vector_store` - Override the configured vector store backend
     * `:vector_weight` - Weight for vector scores in hybrid mode (default: 0.5)
     * `:keyword_weight` - Weight for keyword scores in hybrid mode (default: 0.5)
@@ -84,17 +87,45 @@ defmodule Arcana.Search do
     rewriter = Keyword.get(opts, :rewriter)
     vector_store_opt = Keyword.get(opts, :vector_store)
 
-    collections =
-      cond do
-        Keyword.has_key?(opts, :collections) -> Keyword.get(opts, :collections)
-        Keyword.has_key?(opts, :collection) -> [Keyword.get(opts, :collection)]
-        true -> [nil]
-      end
+    collections = Collection.names_from_opts(opts)
 
     unless mode in @valid_modes do
       raise ArgumentError,
             "invalid search mode: #{inspect(mode)}. Must be one of #{inspect(@valid_modes)}"
     end
+
+    with :ok <- validate_collections(collections, repo, opts) do
+      do_search_with_telemetry(query, collections, mode, repo, opts, %{
+        reranker: reranker,
+        limit: limit,
+        source_id: source_id,
+        threshold: threshold,
+        rewriter: rewriter,
+        vector_store_opt: vector_store_opt
+      })
+    end
+  end
+
+  defp validate_collections(collections, repo, opts) do
+    if repo && Arcana.Config.strict_collections?(opts) do
+      case Collection.resolve_ids(collections, repo, strict: true) do
+        {:ok, _ids} -> :ok
+        {:error, _} = error -> error
+      end
+    else
+      :ok
+    end
+  end
+
+  defp do_search_with_telemetry(query, collections, mode, repo, opts, config) do
+    %{
+      reranker: reranker,
+      limit: limit,
+      source_id: source_id,
+      threshold: threshold,
+      rewriter: rewriter,
+      vector_store_opt: vector_store_opt
+    } = config
 
     start_metadata = %{
       query: query,
@@ -327,12 +358,13 @@ defmodule Arcana.Search do
 
           chunk ->
             [
-              %{
+              %SearchResult{
                 id: chunk.id,
                 text: chunk.text,
                 document_id: chunk.document_id,
                 chunk_index: chunk.chunk_index,
-                score: score
+                score: score,
+                metadata: chunk.metadata || %{}
               }
             ]
         end
@@ -341,7 +373,13 @@ defmodule Arcana.Search do
     end
   end
 
-  defp resolve_collection_ids(collections, repo), do: Collection.resolve_ids(collections, repo)
+  # Strict validation already ran at the entry point, so unknown names can
+  # only appear here in non-strict mode; they resolve to [] which downstream
+  # graph queries treat as "match nothing".
+  defp resolve_collection_ids(collections, repo) do
+    {:ok, ids} = Collection.resolve_ids(collections, repo)
+    ids
+  end
 
   defp do_search(:vector, query, params) do
     case Embedder.embed(Arcana.Config.embedder(), query, intent: :query) do
@@ -401,17 +439,15 @@ defmodule Arcana.Search do
 
         {:ok,
          Enum.map(results, fn result ->
-           metadata = result.metadata || %{}
+           metadata =
+             (result.metadata || %{})
+             |> Map.update(:document_id, nil, &Ecto.UUID.cast!/1)
 
-           %{
+           SearchResult.from_store_result(%{
              id: Ecto.UUID.cast!(result.id),
-             text: metadata[:text] || "",
-             document_id: Ecto.UUID.cast!(metadata[:document_id]),
-             chunk_index: metadata[:chunk_index],
              score: result.score,
-             vector_score: metadata[:vector_score],
-             keyword_score: metadata[:keyword_score]
-           }
+             metadata: metadata
+           })
          end)}
 
       {:error, reason} ->
@@ -433,17 +469,7 @@ defmodule Arcana.Search do
   end
 
   defp transform_results(results) do
-    Enum.map(results, fn result ->
-      metadata = result.metadata || %{}
-
-      %{
-        id: result.id,
-        text: metadata[:text] || "",
-        document_id: metadata[:document_id],
-        chunk_index: metadata[:chunk_index],
-        score: result.score
-      }
-    end)
+    Enum.map(results, &SearchResult.from_store_result/1)
   end
 
   # Build vector_store opts by merging user-provided opts (so backend-specific

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -94,26 +94,39 @@ defmodule Arcana.Search do
             "invalid search mode: #{inspect(mode)}. Must be one of #{inspect(@valid_modes)}"
     end
 
-    with :ok <- validate_collections(collections, repo, opts) do
+    with {:ok, id_by_name} <- resolve_strict_ids(collections, repo, opts) do
       do_search_with_telemetry(query, collections, mode, repo, opts, %{
         reranker: reranker,
         limit: limit,
         source_id: source_id,
         threshold: threshold,
         rewriter: rewriter,
-        vector_store_opt: vector_store_opt
+        vector_store_opt: vector_store_opt,
+        id_by_name: id_by_name
       })
     end
   end
 
-  defp validate_collections(collections, repo, opts) do
+  # Under strict mode, resolve every named collection up front and keep the
+  # name => id map so backends query by the validated id instead of
+  # re-resolving the name (which could silently widen to a global search if
+  # the collection disappeared in between). Returns {:ok, nil} when strict
+  # is off or the search is unscoped.
+  defp resolve_strict_ids(collections, repo, opts) do
     if repo && Arcana.Config.strict_collections?(opts) do
       case Collection.resolve_ids(collections, repo, strict: true) do
-        {:ok, _ids} -> :ok
-        {:error, _} = error -> error
+        {:ok, nil} ->
+          {:ok, nil}
+
+        {:ok, ids} ->
+          names = Enum.reject(collections, &is_nil/1)
+          {:ok, names |> Enum.zip(ids) |> Map.new()}
+
+        {:error, _} = error ->
+          error
       end
     else
-      :ok
+      {:ok, nil}
     end
   end
 
@@ -124,7 +137,8 @@ defmodule Arcana.Search do
       source_id: source_id,
       threshold: threshold,
       rewriter: rewriter,
-      vector_store_opt: vector_store_opt
+      vector_store_opt: vector_store_opt,
+      id_by_name: id_by_name
     } = config
 
     start_metadata = %{
@@ -149,6 +163,7 @@ defmodule Arcana.Search do
         vector_store: vector_store_opt,
         vector_weight: Keyword.get(opts, :vector_weight, 0.5),
         keyword_weight: Keyword.get(opts, :keyword_weight, 0.5),
+        id_by_name: id_by_name,
         # Original opts so backends can pick up any extra knobs (e.g. :hnsw_ef_search)
         opts: opts
       }
@@ -245,7 +260,14 @@ defmodule Arcana.Search do
   end
 
   defp search_single_collection(mode, search_query, params, collection_name, acc) do
-    case do_search(mode, search_query, Map.put(params, :collection, collection_name)) do
+    collection_id = params.id_by_name && Map.get(params.id_by_name, collection_name)
+
+    params =
+      params
+      |> Map.put(:collection, collection_name)
+      |> Map.put(:collection_id, collection_id)
+
+    case do_search(mode, search_query, params) do
       {:ok, results} -> {:cont, {:ok, acc ++ results}}
       {:error, reason} -> {:halt, {:error, reason}}
     end
@@ -384,7 +406,9 @@ defmodule Arcana.Search do
   defp do_search(:vector, query, params) do
     case Embedder.embed(Arcana.Config.embedder(), query, intent: :query) do
       {:ok, query_embedding} ->
-        vector_store_opts = build_vector_store_opts(params, [:limit, :threshold, :source_id])
+        vector_store_opts =
+          build_vector_store_opts(params, [:limit, :threshold, :source_id, :collection_id])
+
         results = VectorStore.search(params.collection, query_embedding, vector_store_opts)
 
         {:ok, transform_results(results)}
@@ -395,7 +419,7 @@ defmodule Arcana.Search do
   end
 
   defp do_search(:keyword, query, params) do
-    vector_store_opts = build_vector_store_opts(params, [:limit, :source_id])
+    vector_store_opts = build_vector_store_opts(params, [:limit, :source_id, :collection_id])
     results = VectorStore.search_text(params.collection, query, vector_store_opts)
 
     {:ok, transform_results(results)}
@@ -425,6 +449,7 @@ defmodule Arcana.Search do
             limit: params.limit,
             source_id: params.source_id,
             threshold: params.threshold,
+            collection_id: Map.get(params, :collection_id),
             vector_weight: Map.get(params, :vector_weight, 0.5),
             keyword_weight: Map.get(params, :keyword_weight, 0.5)
           )

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -177,7 +177,7 @@ defmodule Arcana.Search do
           enhance_with_graph_search(
             collection_results,
             search_query,
-            collections,
+            {collections, id_by_name},
             repo,
             retrieval_opts
           )
@@ -291,12 +291,22 @@ defmodule Arcana.Search do
     {{:error, reason}, %{error: reason}}
   end
 
-  defp enhance_with_graph_search({:ok, vector_results}, query, collections, repo, opts) do
+  defp enhance_with_graph_search(
+         {:ok, vector_results},
+         query,
+         {collections, id_by_name},
+         repo,
+         opts
+       ) do
     limit = Keyword.get(opts, :limit, 10)
     graph_config = Arcana.Graph.config()
     rrf_k = graph_config[:rrf_k] || 60
     rrf_pool = graph_config[:rrf_pool_multiplier] || 2
-    collection_ids = resolve_collection_ids(collections, repo)
+
+    # Reuse the ids validated up front under strict mode instead of
+    # re-resolving names (which could pick up a recreated collection).
+    collection_ids =
+      if id_by_name, do: Map.values(id_by_name), else: resolve_collection_ids(collections, repo)
 
     {matcher, matcher_opts} = resolve_entity_matcher(opts, graph_config)
     matcher_opts = matcher_opts |> Keyword.put(:repo, repo) |> Keyword.merge(opts)

--- a/lib/arcana/search_result.ex
+++ b/lib/arcana/search_result.ex
@@ -88,17 +88,31 @@ defmodule Arcana.SearchResult do
   def fetch(%__MODULE__{}, _key), do: :error
 
   @impl Access
-  def get_and_update(%__MODULE__{} = result, key, fun) when is_atom(key) do
+  def get_and_update(%__MODULE__{} = result, key, fun) when is_map_key(result, key) do
     current = Map.get(result, key)
 
     case fun.(current) do
       {get, update} -> {get, Map.replace!(result, key, update)}
-      :pop -> {current, Map.replace!(result, key, nil)}
+      :pop -> pop(result, key)
     end
   end
 
+  def get_and_update(%__MODULE__{}, key, _fun) do
+    raise ArgumentError,
+          "Arcana.SearchResult only supports Access updates on its own fields, " <>
+            "got: #{inspect(key)}"
+  end
+
   @impl Access
-  def pop(%__MODULE__{} = result, key) when is_atom(key) do
+  def pop(%__MODULE__{} = result, :metadata), do: {result.metadata, %{result | metadata: %{}}}
+
+  def pop(%__MODULE__{} = result, key) when is_map_key(result, key) do
     {Map.get(result, key), Map.replace!(result, key, nil)}
+  end
+
+  def pop(%__MODULE__{}, key) do
+    raise ArgumentError,
+          "Arcana.SearchResult only supports Access updates on its own fields, " <>
+            "got: #{inspect(key)}"
   end
 end

--- a/lib/arcana/search_result.ex
+++ b/lib/arcana/search_result.ex
@@ -1,0 +1,104 @@
+defmodule Arcana.SearchResult do
+  @moduledoc """
+  Normalized search result returned by `Arcana.search/2` for every mode.
+
+  All modes (`:vector`, `:keyword`, `:hybrid`, and graph-enhanced search)
+  return the same struct, so integrators never need per-mode formatters.
+
+  ## Fields
+
+    * `:id` - Chunk id (UUID string)
+    * `:text` - Chunk text
+    * `:document_id` - Owning document id (UUID string)
+    * `:chunk_index` - Position of the chunk within its document
+    * `:score` - Final relevance score for the mode that produced it
+    * `:vector_score` - Vector similarity component. Only set by the
+      single-query hybrid search on the pgvector backend, `nil` elsewhere.
+    * `:keyword_score` - Keyword relevance component. Same availability
+      as `:vector_score`.
+    * `:rerank_score` - Score attached by rerankers that produce one
+      (e.g. `Arcana.Reranker.ColBERT`), `nil` otherwise.
+    * `:metadata` - The chunk's stored metadata with string keys.
+
+  The struct implements the `Access` behaviour for reads, so `result[:text]`
+  keeps working for code that used the previous plain maps. It is not
+  derived for `Jason.Encoder` or `JSON.Encoder`; encode `Map.from_struct/1`
+  if you need JSON.
+  """
+
+  @behaviour Access
+
+  defstruct [
+    :id,
+    :text,
+    :document_id,
+    :chunk_index,
+    :score,
+    :vector_score,
+    :keyword_score,
+    :rerank_score,
+    metadata: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          id: String.t() | term(),
+          text: String.t(),
+          document_id: String.t() | nil,
+          chunk_index: non_neg_integer() | nil,
+          score: number(),
+          vector_score: number() | nil,
+          keyword_score: number() | nil,
+          rerank_score: number() | nil,
+          metadata: map()
+        }
+
+  @known_keys [:text, :chunk_index, :document_id, :vector_score, :keyword_score]
+
+  @doc """
+  Builds a result from a vector-store backend map (`%{id, score, metadata}`).
+
+  Backend metadata mixes the chunk's stored metadata with well-known keys
+  (`:text`, `:chunk_index`, `:document_id`, and hybrid score components);
+  the well-known keys become struct fields and the rest is kept under
+  `:metadata` with keys normalized to strings.
+  """
+  def from_store_result(%{id: id, score: score} = result) do
+    metadata = Map.get(result, :metadata) || %{}
+
+    %__MODULE__{
+      id: id,
+      text: metadata[:text] || "",
+      document_id: metadata[:document_id],
+      chunk_index: metadata[:chunk_index],
+      score: score,
+      vector_score: metadata[:vector_score],
+      keyword_score: metadata[:keyword_score],
+      metadata: user_metadata(metadata)
+    }
+  end
+
+  defp user_metadata(metadata) do
+    metadata
+    |> Map.drop(@known_keys)
+    |> Map.new(fn {k, v} -> {to_string(k), v} end)
+  end
+
+  @impl Access
+  def fetch(%__MODULE__{} = result, key) when is_atom(key), do: Map.fetch(result, key)
+  def fetch(%__MODULE__{}, _key), do: :error
+
+  @impl Access
+  def get_and_update(%__MODULE__{} = result, key, fun) when is_atom(key) do
+    current = Map.get(result, key)
+
+    case fun.(current) do
+      {get, update} -> {get, Map.replace!(result, key, update)}
+      :pop -> {current, Map.replace!(result, key, nil)}
+    end
+  end
+
+  @impl Access
+  def pop(%__MODULE__{} = result, key) when is_atom(key) do
+    {Map.get(result, key), Map.replace!(result, key, nil)}
+  end
+end

--- a/lib/arcana/search_result.ex
+++ b/lib/arcana/search_result.ex
@@ -67,19 +67,29 @@ defmodule Arcana.SearchResult do
 
     %__MODULE__{
       id: id,
-      text: metadata[:text] || "",
-      document_id: metadata[:document_id],
-      chunk_index: metadata[:chunk_index],
+      text: known(metadata, :text) || "",
+      document_id: known(metadata, :document_id),
+      chunk_index: known(metadata, :chunk_index),
       score: score,
-      vector_score: metadata[:vector_score],
-      keyword_score: metadata[:keyword_score],
+      vector_score: known(metadata, :vector_score),
+      keyword_score: known(metadata, :keyword_score),
       metadata: user_metadata(metadata)
     }
+  end
+
+  # Backend metadata may carry well-known keys as atoms (Ecto select
+  # merge) or strings (JSONB round-trips, custom backends): accept both.
+  defp known(metadata, key) do
+    case Map.fetch(metadata, key) do
+      {:ok, value} -> value
+      :error -> Map.get(metadata, Atom.to_string(key))
+    end
   end
 
   defp user_metadata(metadata) do
     metadata
     |> Map.drop(@known_keys)
+    |> Map.drop(Enum.map(@known_keys, &Atom.to_string/1))
     |> Map.new(fn {k, v} -> {to_string(k), v} end)
   end
 
@@ -88,7 +98,8 @@ defmodule Arcana.SearchResult do
   def fetch(%__MODULE__{}, _key), do: :error
 
   @impl Access
-  def get_and_update(%__MODULE__{} = result, key, fun) when is_map_key(result, key) do
+  def get_and_update(%__MODULE__{} = result, key, fun)
+      when is_map_key(result, key) and key != :__struct__ do
     current = Map.get(result, key)
 
     case fun.(current) do
@@ -106,7 +117,7 @@ defmodule Arcana.SearchResult do
   @impl Access
   def pop(%__MODULE__{} = result, :metadata), do: {result.metadata, %{result | metadata: %{}}}
 
-  def pop(%__MODULE__{} = result, key) when is_map_key(result, key) do
+  def pop(%__MODULE__{} = result, key) when is_map_key(result, key) and key != :__struct__ do
     {Map.get(result, key), Map.replace!(result, key, nil)}
   end
 

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -35,9 +35,22 @@ defmodule Arcana.VectorStore.Pgvector do
   def store(collection, id, embedding, metadata, opts) do
     repo = Keyword.fetch!(opts, :repo)
 
-    # Get or create collection
-    {:ok, coll} = Collection.get_or_create(collection, repo)
+    # Auto-create the collection unless strict mode requires it to exist
+    case resolve_store_collection(collection, repo, opts) do
+      {:ok, coll} -> do_store(coll, id, embedding, metadata, opts, repo)
+      {:error, _} = error -> error
+    end
+  end
 
+  defp resolve_store_collection(collection, repo, opts) do
+    if Arcana.Config.strict_collections?(opts) do
+      Collection.fetch(collection, repo)
+    else
+      Collection.get_or_create(collection, repo)
+    end
+  end
+
+  defp do_store(coll, id, embedding, metadata, opts, repo) do
     # For standalone vector storage, we create a minimal document
     document_id = Keyword.get(opts, :document_id)
 
@@ -92,14 +105,7 @@ defmodule Arcana.VectorStore.Pgvector do
     threshold = Keyword.get(opts, :threshold, 0.0)
     source_id = Keyword.get(opts, :source_id)
 
-    # Get collection_id if collection name is provided
-    collection_id =
-      if collection do
-        case repo.get_by(Collection, name: collection) do
-          nil -> nil
-          coll -> coll.id
-        end
-      end
+    collection_id = resolve_filter_collection_id(collection, repo, opts)
 
     base_query =
       from(c in Chunk,
@@ -134,14 +140,7 @@ defmodule Arcana.VectorStore.Pgvector do
     limit = Keyword.get(opts, :limit, 10)
     source_id = Keyword.get(opts, :source_id)
 
-    # Get collection_id if collection name is provided
-    collection_id =
-      if collection do
-        case repo.get_by(Collection, name: collection) do
-          nil -> nil
-          coll -> coll.id
-        end
-      end
+    collection_id = resolve_filter_collection_id(collection, repo, opts)
 
     base_query =
       from(c in Chunk,
@@ -219,17 +218,15 @@ defmodule Arcana.VectorStore.Pgvector do
     keyword_weight = Keyword.get(opts, :keyword_weight, 0.5)
     threshold = Keyword.get(opts, :threshold, 0.0)
 
-    # Get collection_id if collection name is provided, convert to binary for SQL
+    # Resolve the collection filter, converted to binary for raw SQL
     collection_id =
-      if collection do
-        case repo.get_by(Collection, name: collection) do
-          nil ->
-            nil
+      case resolve_filter_collection_id(collection, repo, opts) do
+        nil ->
+          nil
 
-          coll ->
-            {:ok, binary_id} = Ecto.UUID.dump(coll.id)
-            binary_id
-        end
+        id ->
+          {:ok, binary_id} = Ecto.UUID.dump(id)
+          binary_id
       end
 
     # Use raw SQL for the hybrid query with CTEs for proper normalization
@@ -413,6 +410,24 @@ defmodule Arcana.VectorStore.Pgvector do
 
       true ->
         :ok
+    end
+  end
+
+  # Prefer a pre-resolved :collection_id (set by Arcana.Search under strict
+  # mode so the query is pinned to the validated id); otherwise resolve the
+  # name, keeping the historical no-filter fallback for unknown names.
+  defp resolve_filter_collection_id(collection, repo, opts) do
+    case Keyword.get(opts, :collection_id) do
+      nil ->
+        if collection do
+          case repo.get_by(Collection, name: collection) do
+            nil -> nil
+            coll -> coll.id
+          end
+        end
+
+      id ->
+        id
     end
   end
 

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -105,33 +105,35 @@ defmodule Arcana.VectorStore.Pgvector do
     threshold = Keyword.get(opts, :threshold, 0.0)
     source_id = Keyword.get(opts, :source_id)
 
-    collection_id = resolve_filter_collection_id(collection, repo, opts)
+    case resolve_filter_collection_id(collection, repo, opts) do
+      :unknown ->
+        []
 
-    base_query =
-      from(c in Chunk,
-        join: d in Document,
-        on: c.document_id == d.id,
-        select: %{
-          id: c.id,
-          metadata:
-            merge(c.metadata, %{
-              text: c.text,
-              chunk_index: c.chunk_index,
-              document_id: c.document_id
-            }),
-          score: fragment("1 - (? <=> ?)", c.embedding, ^query_embedding)
-        },
-        where: fragment("1 - (? <=> ?) > ?", c.embedding, ^query_embedding, ^threshold),
-        order_by: fragment("? <=> ?", c.embedding, ^query_embedding),
-        limit: ^limit
-      )
+      {:ok, collection_id} ->
+        base_query =
+          from(c in Chunk,
+            join: d in Document,
+            on: c.document_id == d.id,
+            select: %{
+              id: c.id,
+              metadata:
+                merge(c.metadata, %{
+                  text: c.text,
+                  chunk_index: c.chunk_index,
+                  document_id: c.document_id
+                }),
+              score: fragment("1 - (? <=> ?)", c.embedding, ^query_embedding)
+            },
+            where: fragment("1 - (? <=> ?) > ?", c.embedding, ^query_embedding, ^threshold),
+            order_by: fragment("? <=> ?", c.embedding, ^query_embedding),
+            limit: ^limit
+          )
 
-    final_query =
-      base_query
-      |> maybe_filter_source_id(source_id)
-      |> maybe_filter_collection_id(collection_id)
-
-    repo.all(final_query)
+        base_query
+        |> maybe_filter_source_id(source_id)
+        |> maybe_filter_collection_id(collection_id)
+        |> repo.all()
+    end
   end
 
   @impl true
@@ -140,50 +142,52 @@ defmodule Arcana.VectorStore.Pgvector do
     limit = Keyword.get(opts, :limit, 10)
     source_id = Keyword.get(opts, :source_id)
 
-    collection_id = resolve_filter_collection_id(collection, repo, opts)
+    case resolve_filter_collection_id(collection, repo, opts) do
+      :unknown ->
+        []
 
-    base_query =
-      from(c in Chunk,
-        join: d in Document,
-        on: c.document_id == d.id,
-        where:
-          fragment(
-            "to_tsvector('english', ?) @@ plainto_tsquery('english', ?)",
-            c.text,
-            ^query_text
-          ),
-        select: %{
-          id: c.id,
-          metadata:
-            merge(c.metadata, %{
-              text: c.text,
-              chunk_index: c.chunk_index,
-              document_id: c.document_id
-            }),
-          score:
-            fragment(
-              "ts_rank(to_tsvector('english', ?), plainto_tsquery('english', ?))",
-              c.text,
-              ^query_text
-            )
-        },
-        order_by: [
-          desc:
-            fragment(
-              "ts_rank(to_tsvector('english', ?), plainto_tsquery('english', ?))",
-              c.text,
-              ^query_text
-            )
-        ],
-        limit: ^limit
-      )
+      {:ok, collection_id} ->
+        base_query =
+          from(c in Chunk,
+            join: d in Document,
+            on: c.document_id == d.id,
+            where:
+              fragment(
+                "to_tsvector('english', ?) @@ plainto_tsquery('english', ?)",
+                c.text,
+                ^query_text
+              ),
+            select: %{
+              id: c.id,
+              metadata:
+                merge(c.metadata, %{
+                  text: c.text,
+                  chunk_index: c.chunk_index,
+                  document_id: c.document_id
+                }),
+              score:
+                fragment(
+                  "ts_rank(to_tsvector('english', ?), plainto_tsquery('english', ?))",
+                  c.text,
+                  ^query_text
+                )
+            },
+            order_by: [
+              desc:
+                fragment(
+                  "ts_rank(to_tsvector('english', ?), plainto_tsquery('english', ?))",
+                  c.text,
+                  ^query_text
+                )
+            ],
+            limit: ^limit
+          )
 
-    final_query =
-      base_query
-      |> maybe_filter_source_id(source_id)
-      |> maybe_filter_collection_id(collection_id)
-
-    repo.all(final_query)
+        base_query
+        |> maybe_filter_source_id(source_id)
+        |> maybe_filter_collection_id(collection_id)
+        |> repo.all()
+    end
   end
 
   @doc """
@@ -219,15 +223,41 @@ defmodule Arcana.VectorStore.Pgvector do
     threshold = Keyword.get(opts, :threshold, 0.0)
 
     # Resolve the collection filter, converted to binary for raw SQL
-    collection_id =
-      case resolve_filter_collection_id(collection, repo, opts) do
-        nil ->
-          nil
+    case resolve_filter_collection_id(collection, repo, opts) do
+      :unknown ->
+        []
 
-        id ->
-          {:ok, binary_id} = Ecto.UUID.dump(id)
-          binary_id
-      end
+      {:ok, resolved_id} ->
+        collection_id =
+          case resolved_id do
+            nil ->
+              nil
+
+            id ->
+              {:ok, binary_id} = Ecto.UUID.dump(id)
+              binary_id
+          end
+
+        do_search_hybrid(collection_id, query_embedding, query_text, %{
+          repo: repo,
+          limit: limit,
+          source_id: source_id,
+          vector_weight: vector_weight,
+          keyword_weight: keyword_weight,
+          threshold: threshold
+        })
+    end
+  end
+
+  defp do_search_hybrid(collection_id, query_embedding, query_text, params) do
+    %{
+      repo: repo,
+      limit: limit,
+      source_id: source_id,
+      vector_weight: vector_weight,
+      keyword_weight: keyword_weight,
+      threshold: threshold
+    } = params
 
     # Use raw SQL for the hybrid query with CTEs for proper normalization
     sql = """
@@ -415,19 +445,22 @@ defmodule Arcana.VectorStore.Pgvector do
 
   # Prefer a pre-resolved :collection_id (set by Arcana.Search under strict
   # mode so the query is pinned to the validated id); otherwise resolve the
-  # name, keeping the historical no-filter fallback for unknown names.
+  # name. For unknown names: under strict mode return :unknown so callers
+  # match nothing (direct backend calls bypass Arcana.Search's up-front
+  # validation), otherwise keep the historical no-filter fallback.
   defp resolve_filter_collection_id(collection, repo, opts) do
     case Keyword.get(opts, :collection_id) do
-      nil ->
-        if collection do
-          case repo.get_by(Collection, name: collection) do
-            nil -> nil
-            coll -> coll.id
-          end
-        end
+      nil -> resolve_filter_by_name(collection, repo, opts)
+      id -> {:ok, id}
+    end
+  end
 
-      id ->
-        id
+  defp resolve_filter_by_name(nil, _repo, _opts), do: {:ok, nil}
+
+  defp resolve_filter_by_name(collection, repo, opts) do
+    case repo.get_by(Collection, name: collection) do
+      nil -> if Arcana.Config.strict_collections?(opts), do: :unknown, else: {:ok, nil}
+      coll -> {:ok, coll.id}
     end
   end
 

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -326,16 +326,16 @@ defmodule Arcana.VectorStore.Pgvector do
   @impl true
   def delete(collection, id, opts) do
     repo = Keyword.fetch!(opts, :repo)
+    strict? = Arcana.Config.strict_collections?(opts)
 
     # Get collection_id to verify the chunk belongs to the collection
-    collection_id =
-      if collection do
-        case repo.get_by(Collection, name: collection) do
-          nil -> nil
-          coll -> coll.id
-        end
-      end
+    case Collection.resolve_id(collection, repo, strict?) do
+      {:ok, collection_id} -> do_delete(collection_id, id, repo)
+      {:error, _} = error -> error
+    end
+  end
 
+  defp do_delete(collection_id, id, repo) do
     query =
       from(c in Chunk,
         join: d in Document,
@@ -363,8 +363,12 @@ defmodule Arcana.VectorStore.Pgvector do
   @impl true
   def clear(collection, opts) do
     repo = Keyword.fetch!(opts, :repo)
+    strict? = Arcana.Config.strict_collections?(opts)
 
     case repo.get_by(Collection, name: collection) do
+      nil when strict? ->
+        {:error, {:unknown_collection, collection}}
+
       nil ->
         :ok
 

--- a/lib/arcana_web/live/search_live.ex
+++ b/lib/arcana_web/live/search_live.ex
@@ -102,7 +102,7 @@ defmodule ArcanaWeb.SearchLive do
 
   defp add_collection_opt(opts, []), do: opts
   defp add_collection_opt(opts, [single]), do: Keyword.put(opts, :collection, single)
-  defp add_collection_opt(opts, multiple), do: Keyword.put(opts, :collection, multiple)
+  defp add_collection_opt(opts, multiple), do: Keyword.put(opts, :collections, multiple)
 
   defp normalize_collections(nil), do: []
 

--- a/lib/mix/tasks/arcana.graph.detect_communities.ex
+++ b/lib/mix/tasks/arcana.graph.detect_communities.ex
@@ -131,12 +131,15 @@ defmodule Mix.Tasks.Arcana.Graph.DetectCommunities do
     detect_opts =
       if collection, do: Keyword.put(detect_opts, :collection, collection), else: detect_opts
 
-    {:ok, %{collections: collections, communities: communities}} =
-      Arcana.Maintenance.detect_communities(repo, detect_opts)
+    case Arcana.Maintenance.detect_communities(repo, detect_opts) do
+      {:ok, %{collections: collections, communities: communities}} ->
+        Mix.shell().info(
+          "\nDone! Processed #{collections} collection(s): #{communities} communities."
+        )
 
-    Mix.shell().info(
-      "\nDone! Processed #{collections} collection(s): #{communities} communities."
-    )
+      {:error, {:unknown_collection, name}} ->
+        Mix.raise("Collection #{inspect(name)} does not exist")
+    end
   end
 
   defp format_info(%{enabled: enabled, extractor_name: name, community_levels: levels}) do

--- a/lib/mix/tasks/arcana.graph.embed_entities.ex
+++ b/lib/mix/tasks/arcana.graph.embed_entities.ex
@@ -66,13 +66,22 @@ defmodule Mix.Tasks.Arcana.Graph.EmbedEntities do
         end
       end
 
-    {:ok, %{total: total}} =
+    embed_result =
       Arcana.Maintenance.embed_entities(repo,
         collection: collection,
         batch_size: batch_size,
         force: force,
         progress: progress_fn
       )
+
+    total =
+      case embed_result do
+        {:ok, %{total: total}} ->
+          total
+
+        {:error, {:unknown_collection, name}} ->
+          Mix.raise("Collection #{inspect(name)} does not exist")
+      end
 
     unless quiet do
       Mix.shell().info("\nDone! Embedded #{total} entities.")

--- a/lib/mix/tasks/arcana.graph.rebuild.ex
+++ b/lib/mix/tasks/arcana.graph.rebuild.ex
@@ -87,20 +87,23 @@ defmodule Mix.Tasks.Arcana.Graph.Rebuild do
 
     rebuild_opts = if resume, do: Keyword.put(rebuild_opts, :resume, true), else: rebuild_opts
 
-    {:ok,
-     %{
-       collections: collections,
-       entities: entities,
-       relationships: relationships,
-       skipped: skipped
-     }} =
-      Arcana.Maintenance.rebuild_graph(repo, rebuild_opts)
+    case Arcana.Maintenance.rebuild_graph(repo, rebuild_opts) do
+      {:ok,
+       %{
+         collections: collections,
+         entities: entities,
+         relationships: relationships,
+         skipped: skipped
+       }} ->
+        skip_msg = if skipped > 0, do: " (skipped #{skipped} already processed)", else: ""
 
-    skip_msg = if skipped > 0, do: " (skipped #{skipped} already processed)", else: ""
+        Mix.shell().info(
+          "\nDone! Processed #{collections} collection(s): #{entities} entities, #{relationships} relationships#{skip_msg}."
+        )
 
-    Mix.shell().info(
-      "\nDone! Processed #{collections} collection(s): #{entities} entities, #{relationships} relationships#{skip_msg}."
-    )
+      {:error, {:unknown_collection, name}} ->
+        Mix.raise("Collection #{inspect(name)} does not exist")
+    end
   end
 
   defp format_info(%{enabled: enabled, extractor_name: name, community_levels: levels}) do

--- a/lib/mix/tasks/arcana.graph.summarize_communities.ex
+++ b/lib/mix/tasks/arcana.graph.summarize_communities.ex
@@ -119,12 +119,15 @@ defmodule Mix.Tasks.Arcana.Graph.SummarizeCommunities do
         do: Keyword.put(summarize_opts, :collection, collection),
         else: summarize_opts
 
-    {:ok, %{communities: communities, summaries: summaries}} =
-      Arcana.Maintenance.summarize_communities(repo, summarize_opts)
+    case Arcana.Maintenance.summarize_communities(repo, summarize_opts) do
+      {:ok, %{communities: communities, summaries: summaries}} ->
+        Mix.shell().info(
+          "\nDone! Processed #{communities} communities, generated #{summaries} summaries."
+        )
 
-    Mix.shell().info(
-      "\nDone! Processed #{communities} communities, generated #{summaries} summaries."
-    )
+      {:error, {:unknown_collection, name}} ->
+        Mix.raise("Collection #{inspect(name)} does not exist")
+    end
   end
 
   defp format_info(%{enabled: enabled, extractor_name: name, community_levels: levels}) do

--- a/lib/mix/tasks/arcana.reembed_chunks.ex
+++ b/lib/mix/tasks/arcana.reembed_chunks.ex
@@ -91,8 +91,14 @@ defmodule Mix.Tasks.Arcana.ReembedChunks do
     reembed_opts =
       if collection, do: Keyword.put(reembed_opts, :collection, collection), else: reembed_opts
 
-    {:ok, %{rechunked_documents: docs, total_chunks: total, skipped: skipped}} =
-      Arcana.Maintenance.reembed(repo, reembed_opts)
+    {docs, total, skipped} =
+      case Arcana.Maintenance.reembed(repo, reembed_opts) do
+        {:ok, %{rechunked_documents: docs, total_chunks: total, skipped: skipped}} ->
+          {docs, total, skipped}
+
+        {:error, {:unknown_collection, name}} ->
+          Mix.raise("Collection #{inspect(name)} does not exist")
+      end
 
     unless quiet, do: IO.puts("")
 

--- a/test/arcana/ask_test.exs
+++ b/test/arcana/ask_test.exs
@@ -31,6 +31,16 @@ defmodule Arcana.AskTest do
       refute Enum.empty?(context)
     end
 
+    test "errors on an unknown collection under strict_collections", %{llm: llm} do
+      assert {:error, {:search_failed, {:unknown_collection, "strict-nope"}}} =
+               Arcana.ask("What are the Daleks?",
+                 repo: Repo,
+                 llm: llm,
+                 collection: "strict-nope",
+                 strict_collections: true
+               )
+    end
+
     test "uses custom prompt function", %{llm: llm} do
       custom_prompt = fn _question, _context ->
         "Custom system prompt"

--- a/test/arcana/graph/graph_store/ecto_test.exs
+++ b/test/arcana/graph/graph_store/ecto_test.exs
@@ -215,6 +215,35 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
       results = EctoStore.search(["Unknown"], nil, repo: Repo)
       assert results == []
     end
+
+    test "empty collection_ids matches nothing instead of searching globally" do
+      collection = create_collection()
+      document = create_document(collection)
+      chunk = create_chunk(document)
+      alice = create_entity(collection, "Alice")
+      create_mention(alice, chunk)
+
+      # nil is unscoped, [] means the caller named collections that resolved
+      # to nothing: leaking to a global search here is a cross-tenant bug
+      assert EctoStore.search(["Alice"], nil, repo: Repo) != []
+      assert EctoStore.search(["Alice"], [], repo: Repo) == []
+    end
+  end
+
+  describe "search_by_embedding/3" do
+    test "empty collection_ids matches nothing instead of searching globally" do
+      collection = create_collection()
+      entity = create_entity(collection, "Alice")
+
+      entity
+      |> Ecto.Changeset.change(embedding: Enum.map(1..384, fn _ -> 0.1 end))
+      |> Repo.update!()
+
+      query_embedding = Enum.map(1..384, fn _ -> 0.1 end)
+
+      refute EctoStore.search_by_embedding(query_embedding, nil, repo: Repo, threshold: 0.1) == []
+      assert EctoStore.search_by_embedding(query_embedding, [], repo: Repo, threshold: 0.1) == []
+    end
   end
 
   describe "find_entities/2" do

--- a/test/arcana/ingest_with_collection_test.exs
+++ b/test/arcana/ingest_with_collection_test.exs
@@ -3,6 +3,33 @@ defmodule Arcana.IngestWithCollectionTest do
 
   alias Arcana.Collection
 
+  describe "ingest/2 with strict collections" do
+    test "errors instead of auto-creating an unknown collection" do
+      assert {:error, {:unknown_collection, "strict-missing"}} =
+               Arcana.ingest("Test content",
+                 repo: Arcana.TestRepo,
+                 collection: "strict-missing",
+                 strict_collections: true
+               )
+
+      assert Arcana.TestRepo.get_by(Collection, name: "strict-missing") == nil
+    end
+
+    test "ingests into an explicitly created collection" do
+      {:ok, _} = Collection.get_or_create("strict-existing", Arcana.TestRepo)
+
+      {:ok, document} =
+        Arcana.ingest("Test content",
+          repo: Arcana.TestRepo,
+          collection: "strict-existing",
+          strict_collections: true
+        )
+
+      document = Arcana.TestRepo.preload(document, :collection)
+      assert document.collection.name == "strict-existing"
+    end
+  end
+
   describe "ingest/2 with collection" do
     test "ingests document into default collection when no collection specified" do
       {:ok, document} = Arcana.ingest("Test content", repo: Arcana.TestRepo)

--- a/test/arcana/llm_test.exs
+++ b/test/arcana/llm_test.exs
@@ -34,6 +34,31 @@ defmodule Arcana.LLMTest do
     end
   end
 
+  describe "{module, function} tuples" do
+    defmodule FakeLLM do
+      def complete(prompt, context, _opts), do: {:ok, "mfa3: #{prompt} (#{length(context)})"}
+      def complete_two(prompt, _context), do: {:ok, "mfa2: #{prompt}"}
+      def rewrite(prompt), do: {:ok, "mfa1: #{prompt}"}
+    end
+
+    test "dispatches to the highest supported arity" do
+      context = [%{text: "chunk1"}]
+
+      assert {:ok, "mfa3: q (1)"} = LLM.complete({FakeLLM, :complete}, "q", context, [])
+      assert {:ok, "mfa2: q"} = LLM.complete({FakeLLM, :complete_two}, "q", context, [])
+      assert {:ok, "mfa1: q"} = LLM.complete({FakeLLM, :rewrite}, "q", context, [])
+    end
+
+    test "returns an error for a function that doesn't exist" do
+      assert {:error, {:invalid_llm_mfa, {FakeLLM, :nope}}} =
+               LLM.complete({FakeLLM, :nope}, "q", [], [])
+    end
+
+    test "model string with opts still dispatches through the tuple impl" do
+      assert LLM.impl_for({"openai:gpt-4o-mini", api_key: "k"}) != nil
+    end
+  end
+
   describe "Req.LLM integration" do
     test "works with OpenAI model string" do
       # We can't actually call the API, but we can verify the string is accepted

--- a/test/arcana/llm_test.exs
+++ b/test/arcana/llm_test.exs
@@ -54,6 +54,11 @@ defmodule Arcana.LLMTest do
                LLM.complete({FakeLLM, :nope}, "q", [], [])
     end
 
+    test "distinguishes a module that doesn't exist from a wrong arity" do
+      assert {:error, {:llm_module_not_found, NoSuch.Module}} =
+               LLM.complete({NoSuch.Module, :complete}, "q", [], [])
+    end
+
     test "model string with opts still dispatches through the tuple impl" do
       assert LLM.impl_for({"openai:gpt-4o-mini", api_key: "k"}) != nil
     end

--- a/test/arcana/maintenance_test.exs
+++ b/test/arcana/maintenance_test.exs
@@ -16,5 +16,25 @@ defmodule Arcana.MaintenanceTest do
                  strict_collections: true
                )
     end
+
+    test "graph maintenance errors on an unknown collection instead of succeeding with zero work" do
+      opts = [collection: "strict-nope", strict_collections: true]
+
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Maintenance.rebuild_graph(Repo, opts)
+
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Maintenance.detect_communities(Repo, opts)
+
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Maintenance.summarize_communities(
+                 Repo,
+                 opts ++ [llm: fn _p, _c, _o -> {:ok, "summary"} end]
+               )
+    end
+
+    test "graph maintenance reports zero work for unknown collections when strict is off" do
+      assert {:ok, %{collections: 0}} = Maintenance.rebuild_graph(Repo, collection: "nope")
+    end
   end
 end

--- a/test/arcana/maintenance_test.exs
+++ b/test/arcana/maintenance_test.exs
@@ -1,0 +1,20 @@
+defmodule Arcana.MaintenanceTest do
+  use Arcana.DataCase, async: true
+
+  alias Arcana.Maintenance
+
+  describe "strict collections" do
+    test "reembed/2 errors on an unknown collection" do
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Maintenance.reembed(Repo, collection: "strict-nope", strict_collections: true)
+    end
+
+    test "embed_entities/2 errors on an unknown collection instead of embedding globally" do
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Maintenance.embed_entities(Repo,
+                 collection: "strict-nope",
+                 strict_collections: true
+               )
+    end
+  end
+end

--- a/test/arcana/search_result_test.exs
+++ b/test/arcana/search_result_test.exs
@@ -58,5 +58,23 @@ defmodule Arcana.SearchResultTest do
       assert old == 1.0
       assert updated.score == 2.0
     end
+
+    test "updates on unknown keys raise a clear error" do
+      result = %SearchResult{id: "x", text: "hello", score: 1.0}
+
+      assert_raise ArgumentError, ~r/only supports Access updates/, fn ->
+        Access.get_and_update(result, :not_a_field, fn v -> {v, 1} end)
+      end
+
+      assert_raise ArgumentError, ~r/only supports Access updates/, fn ->
+        Access.pop(result, "text")
+      end
+    end
+
+    test "popping metadata resets it to an empty map" do
+      result = %SearchResult{id: "x", text: "t", score: 1.0, metadata: %{"a" => 1}}
+
+      assert {%{"a" => 1}, %SearchResult{metadata: %{}}} = Access.pop(result, :metadata)
+    end
   end
 end

--- a/test/arcana/search_result_test.exs
+++ b/test/arcana/search_result_test.exs
@@ -31,6 +31,19 @@ defmodule Arcana.SearchResultTest do
       assert result.metadata == %{"team" => "zoology", "custom" => 1}
     end
 
+    test "accepts well-known keys as strings (JSONB round-trips, custom backends)" do
+      result =
+        SearchResult.from_store_result(%{
+          id: "chunk-3",
+          score: 0.5,
+          metadata: %{"text" => "string keyed", "document_id" => "doc-9", "team" => "zoology"}
+        })
+
+      assert result.text == "string keyed"
+      assert result.document_id == "doc-9"
+      assert result.metadata == %{"team" => "zoology"}
+    end
+
     test "tolerates nil metadata and missing keys" do
       result = SearchResult.from_store_result(%{id: "chunk-2", score: 0.1, metadata: nil})
 
@@ -68,6 +81,10 @@ defmodule Arcana.SearchResultTest do
 
       assert_raise ArgumentError, ~r/only supports Access updates/, fn ->
         Access.pop(result, "text")
+      end
+
+      assert_raise ArgumentError, ~r/only supports Access updates/, fn ->
+        Access.get_and_update(result, :__struct__, fn v -> {v, SomethingElse} end)
       end
     end
 

--- a/test/arcana/search_result_test.exs
+++ b/test/arcana/search_result_test.exs
@@ -1,0 +1,62 @@
+defmodule Arcana.SearchResultTest do
+  use ExUnit.Case, async: true
+
+  alias Arcana.SearchResult
+
+  describe "from_store_result/1" do
+    test "extracts well-known keys and keeps the rest as string-keyed metadata" do
+      result =
+        SearchResult.from_store_result(%{
+          id: "chunk-1",
+          score: 0.87,
+          metadata: %{
+            :text => "some chunk text",
+            :chunk_index => 2,
+            :document_id => "doc-1",
+            :vector_score => 0.9,
+            :keyword_score => 0.4,
+            "team" => "zoology",
+            :custom => 1
+          }
+        })
+
+      assert %SearchResult{} = result
+      assert result.id == "chunk-1"
+      assert result.text == "some chunk text"
+      assert result.chunk_index == 2
+      assert result.document_id == "doc-1"
+      assert result.score == 0.87
+      assert result.vector_score == 0.9
+      assert result.keyword_score == 0.4
+      assert result.metadata == %{"team" => "zoology", "custom" => 1}
+    end
+
+    test "tolerates nil metadata and missing keys" do
+      result = SearchResult.from_store_result(%{id: "chunk-2", score: 0.1, metadata: nil})
+
+      assert result.text == ""
+      assert is_nil(result.document_id)
+      assert is_nil(result.vector_score)
+      assert result.metadata == %{}
+    end
+  end
+
+  describe "Access" do
+    test "bracket reads work like the previous plain maps" do
+      result = %SearchResult{id: "x", text: "hello", score: 1.0}
+
+      assert result[:text] == "hello"
+      assert result[:score] == 1.0
+      assert is_nil(result[:document_id])
+      assert is_nil(result[:not_a_field])
+    end
+
+    test "get_and_update replaces existing fields" do
+      result = %SearchResult{id: "x", text: "hello", score: 1.0}
+
+      {old, updated} = Access.get_and_update(result, :score, fn s -> {s, s * 2} end)
+      assert old == 1.0
+      assert updated.score == 2.0
+    end
+  end
+end

--- a/test/arcana/search_test.exs
+++ b/test/arcana/search_test.exs
@@ -80,8 +80,7 @@ defmodule Arcana.SearchTest do
       first = hd(results)
 
       # Single-query hybrid should include both score breakdowns
-      assert Map.has_key?(first, :vector_score)
-      assert Map.has_key?(first, :keyword_score)
+      # (every mode carries the fields now, so assert on values, not keys)
       assert is_number(first.vector_score)
       assert is_number(first.keyword_score)
     end
@@ -157,6 +156,94 @@ defmodule Arcana.SearchTest do
       assert Enum.any?(texts, &String.contains?(&1, "Go"))
       assert Enum.any?(texts, &String.contains?(&1, "Rust"))
       refute Enum.any?(texts, &String.contains?(&1, "JavaScript"))
+    end
+  end
+
+  describe "search/2 result shape" do
+    setup do
+      {:ok, doc} = Arcana.ingest("Elixir is a functional programming language.", repo: Repo)
+      %{doc: doc}
+    end
+
+    test "all modes return SearchResult structs" do
+      for mode <- [:vector, :keyword, :hybrid] do
+        {:ok, results} = Arcana.search("Elixir functional", repo: Repo, mode: mode, graph: false)
+
+        refute Enum.empty?(results), "no results for mode #{mode}"
+        assert Enum.all?(results, &match?(%Arcana.SearchResult{}, &1))
+      end
+    end
+
+    test "score components are nil outside single-query hybrid" do
+      {:ok, [first | _]} = Arcana.search("Elixir", repo: Repo, mode: :vector)
+
+      assert is_nil(first.vector_score)
+      assert is_nil(first.keyword_score)
+      assert is_nil(first.rerank_score)
+    end
+  end
+
+  describe "search/2 strict collections" do
+    setup do
+      {:ok, doc} =
+        Arcana.ingest("Elixir is a functional programming language.",
+          repo: Repo,
+          collection: "strict-known"
+        )
+
+      %{doc: doc}
+    end
+
+    test "unknown collection errors in every mode when strict" do
+      for mode <- [:vector, :keyword, :hybrid] do
+        assert {:error, {:unknown_collection, "strict-nope"}} =
+                 Arcana.search("Elixir",
+                   repo: Repo,
+                   mode: mode,
+                   collection: "strict-nope",
+                   strict_collections: true
+                 )
+      end
+    end
+
+    test "unknown collection still searches unscoped when strict is off" do
+      {:ok, results} = Arcana.search("Elixir", repo: Repo, collection: "strict-nope")
+
+      refute Enum.empty?(results)
+    end
+
+    test "a single unknown name in a collections list fails the whole search" do
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Arcana.search("Elixir",
+                 repo: Repo,
+                 collections: ["strict-known", "strict-nope"],
+                 strict_collections: true
+               )
+    end
+
+    test "known collection passes under strict" do
+      {:ok, results} =
+        Arcana.search("Elixir",
+          repo: Repo,
+          collection: "strict-known",
+          strict_collections: true
+        )
+
+      refute Enum.empty?(results)
+    end
+
+    test "global flag is honored and per-call false overrides it" do
+      put_arcana_env(:strict_collections, true)
+
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Arcana.search("Elixir", repo: Repo, collection: "strict-nope")
+
+      assert {:ok, _results} =
+               Arcana.search("Elixir",
+                 repo: Repo,
+                 collection: "strict-nope",
+                 strict_collections: false
+               )
     end
   end
 

--- a/test/arcana/vector_store/pgvector_test.exs
+++ b/test/arcana/vector_store/pgvector_test.exs
@@ -203,9 +203,47 @@ defmodule Arcana.VectorStore.PgvectorTest do
       fake_id = Ecto.UUID.generate()
       assert {:error, :not_found} = Pgvector.delete("any", fake_id, repo: repo)
     end
+
+    test "with strict_collections, an unknown collection blocks the delete" do
+      repo = Arcana.TestRepo
+
+      {:ok, collection} = Collection.get_or_create("strict-delete-test", repo)
+
+      {:ok, doc} =
+        %Document{}
+        |> Document.changeset(%{
+          content: "test",
+          status: :completed,
+          collection_id: collection.id
+        })
+        |> repo.insert()
+
+      {:ok, chunk} =
+        %Chunk{}
+        |> Chunk.changeset(%{
+          text: "kept",
+          embedding: List.duplicate(0.5, 384),
+          document_id: doc.id
+        })
+        |> repo.insert()
+
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Pgvector.delete("strict-nope", chunk.id, repo: repo, strict_collections: true)
+
+      assert repo.get(Chunk, chunk.id)
+    end
   end
 
   describe "clear/2" do
+    test "with strict_collections, an unknown collection is an error instead of a no-op" do
+      repo = Arcana.TestRepo
+
+      assert :ok = Pgvector.clear("strict-nope", repo: repo)
+
+      assert {:error, {:unknown_collection, "strict-nope"}} =
+               Pgvector.clear("strict-nope", repo: repo, strict_collections: true)
+    end
+
     test "removes all chunks in collection" do
       repo = Arcana.TestRepo
 

--- a/test/arcana/vector_store/pgvector_test.exs
+++ b/test/arcana/vector_store/pgvector_test.exs
@@ -183,31 +183,70 @@ defmodule Arcana.VectorStore.PgvectorTest do
   describe "search/3 with a pre-resolved collection id" do
     test "the :collection_id opt pins the query instead of re-resolving the name" do
       repo = Arcana.TestRepo
+      embedding = List.duplicate(0.5, 384)
 
       {:ok, collection} = Collection.get_or_create("pinned-coll", repo)
+      {:ok, other} = Collection.get_or_create("pinned-other", repo)
+
+      for {coll, text} <- [{collection, "pinned chunk"}, {other, "foreign chunk"}] do
+        {:ok, doc} =
+          %Document{}
+          |> Document.changeset(%{content: "x", status: :completed, collection_id: coll.id})
+          |> repo.insert()
+
+        %Chunk{}
+        |> Chunk.changeset(%{text: text, embedding: embedding, document_id: doc.id})
+        |> repo.insert!()
+      end
+
+      # The name doesn't resolve, but the id filter must still apply: the
+      # equally-similar chunk in the other collection must be excluded
+      # (without the pin this query would widen and return both).
+      results =
+        Pgvector.search("renamed-since-validation", embedding,
+          repo: repo,
+          collection_id: collection.id
+        )
+
+      assert [%{metadata: %{text: "pinned chunk"}}] = results
+    end
+
+    test "under strict mode a direct backend call with an unknown name matches nothing" do
+      repo = Arcana.TestRepo
+
+      {:ok, collection} = Collection.get_or_create("strict-direct", repo)
 
       {:ok, doc} =
         %Document{}
         |> Document.changeset(%{content: "x", status: :completed, collection_id: collection.id})
         |> repo.insert()
 
-      {:ok, _chunk} =
-        %Chunk{}
-        |> Chunk.changeset(%{
-          text: "pinned chunk",
-          embedding: List.duplicate(0.5, 384),
-          document_id: doc.id
-        })
-        |> repo.insert()
+      %Chunk{}
+      |> Chunk.changeset(%{
+        text: "in collection",
+        embedding: List.duplicate(0.5, 384),
+        document_id: doc.id
+      })
+      |> repo.insert!()
 
-      # The name doesn't resolve, but the id filter must still apply
-      results =
-        Pgvector.search("renamed-since-validation", List.duplicate(0.5, 384),
-          repo: repo,
-          collection_id: collection.id
-        )
+      # Non-strict keeps the historical fail-open (global) behavior
+      refute Pgvector.search("strict-nope", List.duplicate(0.5, 384), repo: repo) == []
 
-      assert [%{metadata: %{text: "pinned chunk"}}] = results
+      # Strict fails closed instead of widening to a global search
+      assert Pgvector.search("strict-nope", List.duplicate(0.5, 384),
+               repo: repo,
+               strict_collections: true
+             ) == []
+
+      assert Pgvector.search_text("strict-nope", "collection",
+               repo: repo,
+               strict_collections: true
+             ) == []
+
+      assert Pgvector.search_hybrid("strict-nope", List.duplicate(0.5, 384), "collection",
+               repo: repo,
+               strict_collections: true
+             ) == []
     end
   end
 

--- a/test/arcana/vector_store/pgvector_test.exs
+++ b/test/arcana/vector_store/pgvector_test.exs
@@ -165,6 +165,52 @@ defmodule Arcana.VectorStore.PgvectorTest do
     end
   end
 
+  describe "store/5 with strict collections" do
+    test "errors instead of auto-creating an unknown collection" do
+      repo = Arcana.TestRepo
+      embedding = List.duplicate(0.5, 384)
+
+      assert {:error, {:unknown_collection, "strict-store-nope"}} =
+               Pgvector.store("strict-store-nope", Ecto.UUID.generate(), embedding, %{},
+                 repo: repo,
+                 strict_collections: true
+               )
+
+      assert repo.get_by(Collection, name: "strict-store-nope") == nil
+    end
+  end
+
+  describe "search/3 with a pre-resolved collection id" do
+    test "the :collection_id opt pins the query instead of re-resolving the name" do
+      repo = Arcana.TestRepo
+
+      {:ok, collection} = Collection.get_or_create("pinned-coll", repo)
+
+      {:ok, doc} =
+        %Document{}
+        |> Document.changeset(%{content: "x", status: :completed, collection_id: collection.id})
+        |> repo.insert()
+
+      {:ok, _chunk} =
+        %Chunk{}
+        |> Chunk.changeset(%{
+          text: "pinned chunk",
+          embedding: List.duplicate(0.5, 384),
+          document_id: doc.id
+        })
+        |> repo.insert()
+
+      # The name doesn't resolve, but the id filter must still apply
+      results =
+        Pgvector.search("renamed-since-validation", List.duplicate(0.5, 384),
+          repo: repo,
+          collection_id: collection.id
+        )
+
+      assert [%{metadata: %{text: "pinned chunk"}}] = results
+    end
+  end
+
   describe "delete/3" do
     test "removes chunk from collection" do
       repo = Arcana.TestRepo


### PR DESCRIPTION
covers items 1, 4, and 8 from the #94 wishlist.

**Strict collection scoping (item 1).** An unknown collection name used to silently resolve to no filter, so a typo'd tenant name searched (or deleted across) every collection. New opt-in `config :arcana, strict_collections: true` makes unknown names return `{:error, {:unknown_collection, name}}` across search, ask, ingest, vector-store delete/clear, and maintenance. Also works per call, and `strict_collections: false` per call overrides a global true. Under strict mode ingest stops auto-creating collections too, so apps create them explicitly with `Collection.get_or_create/3`. The default flips in 3.0.

One fix ships unconditionally: named collections that resolve to nothing now match nothing in the graph path (`ask` graph context, `GraphStore.Ecto`) instead of widening to a global search. That one was a straight bug.

**One search result shape (item 4).** All modes now return `%Arcana.SearchResult{}` with the same fields: `vector_score`/`keyword_score` are nil outside single-query hybrid, `rerank_score` is a declared field (ColBERT writes it), and chunk metadata comes along with string keys. The struct implements `Access` so `result[:text]` bracket reads keep working. Mildly breaking if you relied on results being plain maps, noted in the docs.

**Release-safe LLM config (item 8).** `config :arcana, llm: {MyApp.LLM, :complete}` now works: the tuple dispatches through the `Arcana.LLM` protocol by arity (1, 2, or 3), same as anonymous functions. Unlike a captured function it serializes into a release's `sys.config`, so no `runtime.exs` wiring needed.

also fixes a doc example in `fusion_search.ex` that called a nonexistent `Arcana.search/4`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closed collection scoping and a single `%Arcana.SearchResult` shape across all search modes; LLM config now release-safe. Strict mode now errors on unknown collections across search/ask/ingest/vector-store/maintenance, pgvector direct search/text/hybrid calls fail closed instead of widening, graph path treats empty scopes as match-nothing, validated collection IDs are pinned to backends, rerankers persist `:rerank_score`, and `{module, function}` LLMs are supported with clear errors; `Arcana.Loop` requires model strings.

- Migration
  - Create required collections up front (including "default") with `Arcana.Collection.get_or_create/3`. To bypass temporarily, pass `strict_collections: false`.
  - If you encode results to JSON or relied on maps, convert with `Map.from_struct/1`. Read reranker scores from `:rerank_score`.
  - For the tool loop, pass `:controller_llm` and `:answer_llm` as model strings, not `{module, function}`.

<sup>Written for commit 9fc2d1c541767dd4014e37d702162af456a9b1cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

