### PR TITLE
fix: Derive dashboard paths from the actual mount point

### DIFF
--- a/guides/dashboard.md
+++ b/guides/dashboard.md
@@ -6,13 +6,13 @@ A web UI for managing documents and testing search. The dashboard consists of mu
 
 ### 1. Add TaskSupervisor to your supervision tree
 
-The dashboard requires `Arcana.TaskSupervisor` for async operations (Ask, Maintenance):
+The dashboard requires `ArcanaWeb.TaskSupervisor` for async operations (Ask, Maintenance):
 
 ```elixir
 # lib/my_app/application.ex
 children = [
   MyApp.Repo,
-  Arcana.TaskSupervisor,  # Required for dashboard
+  ArcanaWeb.TaskSupervisor,  # Required for dashboard
   # ...
 ]
 ```

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -49,12 +49,12 @@ Add Arcana components to your supervision tree:
 # application.ex
 children = [
   MyApp.Repo,
-  Arcana.TaskSupervisor,  # Required for dashboard async operations
+  ArcanaWeb.TaskSupervisor,  # Required for dashboard async operations
   Arcana.Embedder.Local   # Only if using local embeddings
 ]
 ```
 
-`Arcana.TaskSupervisor` is required for the dashboard's async operations (Ask, Maintenance).
+`ArcanaWeb.TaskSupervisor` is required for the dashboard's async operations (Ask, Maintenance).
 `Arcana.Embedder.Local` starts the local embedding model (only needed if using local embeddings).
 
 ### Available Models

--- a/guides/graphrag.md
+++ b/guides/graphrag.md
@@ -43,7 +43,7 @@ Add the NER serving to your supervision tree for entity extraction:
 # lib/my_app/application.ex
 children = [
   MyApp.Repo,
-  Arcana.TaskSupervisor,
+  ArcanaWeb.TaskSupervisor,
   Arcana.Embedder.Local,
   Arcana.Graph.NERServing  # Add this for GraphRAG
 ]

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -14,7 +14,7 @@ def start(_type, _args) do
 
   children = [
     MyApp.Repo,
-    Arcana.TaskSupervisor,
+    ArcanaWeb.TaskSupervisor,
     Arcana.Embedder.Local
   ]
 

--- a/lib/arcana/task_supervisor.ex
+++ b/lib/arcana/task_supervisor.ex
@@ -1,37 +1,25 @@
 defmodule Arcana.TaskSupervisor do
   @moduledoc """
-  Task supervisor for async operations in Arcana.
+  Deprecated alias for `ArcanaWeb.TaskSupervisor`.
 
-  Add to your application's supervision tree:
-
-      children = [
-        MyApp.Repo,
-        Arcana.Embedder.Local,
-        Arcana.TaskSupervisor
-      ]
-
-  This enables supervised async operations in the Arcana dashboard
-  (evaluation runs, test case generation, maintenance tasks) with:
-  - Graceful shutdown during deploys
-  - Visibility in Observer/LiveDashboard
-  - Proper crash logging with `$callers` metadata
+  The task supervisor only serves the dashboard's async operations, so it
+  lives under the `ArcanaWeb` namespace now. This module keeps existing
+  supervision trees working; update your children list to
+  `ArcanaWeb.TaskSupervisor`.
   """
 
-  def child_spec(_opts) do
-    %{
-      id: __MODULE__,
-      start: {Task.Supervisor, :start_link, [[name: __MODULE__]]},
-      type: :supervisor
-    }
+  require Logger
+
+  @deprecated "Use ArcanaWeb.TaskSupervisor instead"
+  def child_spec(opts) do
+    Logger.warning(
+      "Arcana.TaskSupervisor is deprecated, use ArcanaWeb.TaskSupervisor " <>
+        "in your supervision tree instead."
+    )
+
+    ArcanaWeb.TaskSupervisor.child_spec(opts)
   end
 
-  @doc """
-  Starts a fire-and-forget task under this supervisor.
-
-  The task is not linked to the caller, so crashes won't bring down
-  the calling process. Crashes are logged by the supervisor.
-  """
-  def start_child(fun) when is_function(fun, 0) do
-    Task.Supervisor.start_child(__MODULE__, fun)
-  end
+  @deprecated "Use ArcanaWeb.TaskSupervisor.start_child/1 instead"
+  defdelegate start_child(fun), to: ArcanaWeb.TaskSupervisor
 end

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -305,7 +305,7 @@ defmodule ArcanaWeb.AskLive do
     selected_collections = params["collections"] || []
     parent = self()
 
-    Arcana.TaskSupervisor.start_child(fn ->
+    ArcanaWeb.TaskSupervisor.start_child(fn ->
       handler_id = "pipeline-progress-#{inspect(parent)}"
       trace_handler_id = "trace-progress-#{inspect(parent)}"
       loop_handler_id = "loop-progress-#{inspect(parent)}"

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -1576,6 +1576,7 @@ defmodule ArcanaWeb.AskLive do
 
             <%= if Map.get(@ask_context, :graph_enhanced) do %>
               <.graph_context_section
+                prefix={@prefix}
                 matched_entities={Map.get(@ask_context, :matched_entities, [])}
                 matched_relationships={Map.get(@ask_context, :matched_relationships, [])}
                 expanded={@graph_context_expanded}
@@ -1587,6 +1588,7 @@ defmodule ArcanaWeb.AskLive do
               <div class="arcana-ask-section">
                 <h4>Retrieved Chunks (<%= length(all_results) %>)</h4>
                 <ChunkResultsComponent.chunk_results
+                  prefix={@prefix}
                   chunks={all_results}
                   document_titles={Map.get(@ask_context, :document_titles, %{})}
                   grounding={Map.get(@ask_context, :grounding)}
@@ -1625,7 +1627,7 @@ defmodule ArcanaWeb.AskLive do
                       <span class="arcana-entity-name"><%= entity.name %></span>
                       <span class="arcana-entity-type"><%= entity.type %></span>
                       <%= if Map.get(entity, :id) do %>
-                        <a href={"/arcana/graph?entity=#{entity.id}"} class="arcana-view-in-graph">
+                        <a href={"#{@prefix}/graph?entity=#{entity.id}"} class="arcana-view-in-graph">
                           View in Graph
                         </a>
                       <% end %>

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -179,7 +179,7 @@ defmodule ArcanaWeb.AskLive do
     # push_patch to the corresponding URL so the sub-tab selection is
     # shareable and survives page reloads. handle_params/3 will pick
     # up the new :sub_tab param and update the assigns.
-    {:noreply, push_patch(socket, to: "/arcana/ask/#{sub_tab}")}
+    {:noreply, push_patch(socket, to: "#{socket.assigns.prefix}/ask/#{sub_tab}")}
   end
 
   def handle_event("form_changed", params, socket) do
@@ -874,7 +874,7 @@ defmodule ArcanaWeb.AskLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:ask}>
+    <.dashboard_layout stats={@stats} current_tab={:ask} prefix={@prefix}>
       <div class="arcana-ask">
         <h2>Ask</h2>
         <p class="arcana-tab-description">

--- a/lib/arcana_web/live/chunk_results_component.ex
+++ b/lib/arcana_web/live/chunk_results_component.ex
@@ -16,6 +16,7 @@ defmodule ArcanaWeb.ChunkResultsComponent do
   ## Usage
 
       <ChunkResultsComponent.chunk_results
+        prefix={@prefix}
         chunks={@ask_context.results}
         document_titles={@ask_context.document_titles || %{}}
         grounding={Map.get(@ask_context, :grounding)}
@@ -23,6 +24,11 @@ defmodule ArcanaWeb.ChunkResultsComponent do
       />
   """
   use Phoenix.Component
+
+  attr(:prefix, :string,
+    required: true,
+    doc: "Dashboard mount prefix used to build document links"
+  )
 
   attr(:chunks, :list,
     required: true,
@@ -46,7 +52,7 @@ defmodule ArcanaWeb.ChunkResultsComponent do
           <header class="arcana-chunk-doc-header">
             <h5 class="arcana-chunk-doc-title">
               <%= if doc_id do %>
-                <.link navigate={"/arcana/documents?doc=#{doc_id}"} title={"Document " <> doc_id} class="arcana-chunk-doc-link"><%= document_label(doc_id, @document_titles) %></.link>
+                <.link navigate={"#{@prefix}/documents?doc=#{doc_id}"} title={"Document " <> doc_id} class="arcana-chunk-doc-link"><%= document_label(doc_id, @document_titles) %></.link>
               <% else %>
                 <span title="(unknown document)"><%= document_label(doc_id, @document_titles) %></span>
               <% end %>

--- a/lib/arcana_web/live/collections_live.ex
+++ b/lib/arcana_web/live/collections_live.ex
@@ -190,7 +190,7 @@ defmodule ArcanaWeb.CollectionsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:collections}>
+    <.dashboard_layout stats={@stats} current_tab={:collections} prefix={@prefix}>
       <div class="arcana-collections">
         <h2>Collections</h2>
         <p class="arcana-tab-description">

--- a/lib/arcana_web/live/dashboard_components.ex
+++ b/lib/arcana_web/live/dashboard_components.ex
@@ -9,11 +9,12 @@ defmodule ArcanaWeb.DashboardComponents do
   """
   attr(:stats, :map, required: true)
   attr(:current_tab, :atom, required: true)
+  attr(:prefix, :string, default: "/arcana")
   slot(:inner_block, required: true)
 
   def dashboard_layout(assigns) do
     ~H"""
-    <link rel="stylesheet" href={"/arcana/css-#{ArcanaWeb.Assets.current_hash(:css)}"} />
+    <link rel="stylesheet" href={"#{@prefix}/css-#{ArcanaWeb.Assets.current_hash(:css)}"} />
     <div class="arcana-dashboard">
       <div class="arcana-stats">
         <div class="arcana-brand">Arcana</div>
@@ -43,14 +44,14 @@ defmodule ArcanaWeb.DashboardComponents do
       </div>
 
       <nav class="arcana-tabs">
-        <.nav_link href="/arcana/documents" active={@current_tab == :documents}>Documents</.nav_link>
-        <.nav_link href="/arcana/collections" active={@current_tab == :collections}>Collections</.nav_link>
-        <.nav_link href="/arcana/graph" active={@current_tab == :graph}>Graph</.nav_link>
-        <.nav_link href="/arcana/search" active={@current_tab == :search}>Search</.nav_link>
-        <.nav_link href="/arcana/ask" active={@current_tab == :ask}>Ask</.nav_link>
-        <.nav_link href="/arcana/evaluation" active={@current_tab == :evaluation}>Evaluation</.nav_link>
-        <.nav_link href="/arcana/maintenance" active={@current_tab == :maintenance}>Maintenance</.nav_link>
-        <.nav_link href="/arcana/info" active={@current_tab == :info}>Info</.nav_link>
+        <.nav_link href={"#{@prefix}/documents"} active={@current_tab == :documents}>Documents</.nav_link>
+        <.nav_link href={"#{@prefix}/collections"} active={@current_tab == :collections}>Collections</.nav_link>
+        <.nav_link href={"#{@prefix}/graph"} active={@current_tab == :graph}>Graph</.nav_link>
+        <.nav_link href={"#{@prefix}/search"} active={@current_tab == :search}>Search</.nav_link>
+        <.nav_link href={"#{@prefix}/ask"} active={@current_tab == :ask}>Ask</.nav_link>
+        <.nav_link href={"#{@prefix}/evaluation"} active={@current_tab == :evaluation}>Evaluation</.nav_link>
+        <.nav_link href={"#{@prefix}/maintenance"} active={@current_tab == :maintenance}>Maintenance</.nav_link>
+        <.nav_link href={"#{@prefix}/info"} active={@current_tab == :info}>Info</.nav_link>
       </nav>
 
       <div class="arcana-content">

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -239,7 +239,7 @@ defmodule ArcanaWeb.DocumentsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:documents}>
+    <.dashboard_layout stats={@stats} current_tab={:documents} prefix={@prefix}>
       <div class="arcana-documents">
         <%= if @viewing_document do %>
           <.document_detail

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -210,7 +210,7 @@ defmodule ArcanaWeb.DocumentsLive do
 
     socket = assign(socket, graph_indexing: true)
 
-    Arcana.TaskSupervisor.start_child(fn ->
+    ArcanaWeb.TaskSupervisor.start_child(fn ->
       result = Arcana.Graph.build_and_persist(chunks, collection, repo, [])
       send(parent, {:graph_complete, result})
     end)

--- a/lib/arcana_web/live/evaluation_live.ex
+++ b/lib/arcana_web/live/evaluation_live.ex
@@ -109,7 +109,7 @@ defmodule ArcanaWeb.EvaluationLive do
         nil
       )
 
-      Task.Supervisor.start_child(Arcana.TaskSupervisor, fn ->
+      Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
         result = Evaluation.run(opts)
         :telemetry.detach(handler_id)
         send(parent, {:eval_run_complete, result})
@@ -143,7 +143,7 @@ defmodule ArcanaWeb.EvaluationLive do
         parent = self()
         opts = build_generate_opts(repo, llm, sample_size, collection)
 
-        Task.Supervisor.start_child(Arcana.TaskSupervisor, fn ->
+        Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
           result = Evaluation.generate_test_cases(opts)
           send(parent, {:eval_generate_complete, result})
         end)

--- a/lib/arcana_web/live/evaluation_live.ex
+++ b/lib/arcana_web/live/evaluation_live.ex
@@ -377,7 +377,7 @@ defmodule ArcanaWeb.EvaluationLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:evaluation}>
+    <.dashboard_layout stats={@stats} current_tab={:evaluation} prefix={@prefix}>
       <div class="arcana-evaluation">
         <h2>Evaluation</h2>
         <p class="arcana-tab-description">

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -587,6 +587,7 @@ defmodule ArcanaWeb.GraphLive do
           <%= case @current_subtab do %>
             <% :entities -> %>
               <.entities_view
+                prefix={@prefix}
                 entities={@entities}
                 entity_filter={@entity_filter}
                 entity_type_filter={@entity_type_filter}
@@ -692,7 +693,7 @@ defmodule ArcanaWeb.GraphLive do
       <% end %>
 
       <%= if @entity_details do %>
-        <.entity_detail_panel details={@entity_details} />
+        <.entity_detail_panel details={@entity_details} prefix={@prefix} />
       <% end %>
     </div>
     """
@@ -743,7 +744,7 @@ defmodule ArcanaWeb.GraphLive do
             <div class="arcana-mention-preview">
               <p><%= String.slice(mention.context || mention.chunk_text || "", 0, 200) %></p>
               <a
-                href={"/arcana/documents?doc=#{mention.document_id}"}
+                href={"#{@prefix}/documents?doc=#{mention.document_id}"}
                 class="arcana-view-in-docs"
               >
                 View in Documents →

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -500,7 +500,7 @@ defmodule ArcanaWeb.GraphLive do
       |> Enum.reject(fn {_k, v} -> is_nil(v) end)
       |> Enum.into(%{})
 
-    "/arcana/graph?" <> URI.encode_query(params)
+    "#{socket.assigns.prefix}/graph?" <> URI.encode_query(params)
   end
 
   defp has_any_graph_data?(collections) do
@@ -532,7 +532,7 @@ defmodule ArcanaWeb.GraphLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:graph}>
+    <.dashboard_layout stats={@stats} current_tab={:graph} prefix={@prefix}>
       <div class="arcana-graph">
         <h2>Graph</h2>
         <p class="arcana-tab-description">

--- a/lib/arcana_web/live/info_live.ex
+++ b/lib/arcana_web/live/info_live.ex
@@ -297,7 +297,7 @@ defmodule ArcanaWeb.InfoLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:info}>
+    <.dashboard_layout stats={@stats} current_tab={:info} prefix={@prefix}>
       <div class="arcana-info">
         <h2>Info</h2>
         <p class="arcana-tab-description">

--- a/lib/arcana_web/live/maintenance_live.ex
+++ b/lib/arcana_web/live/maintenance_live.ex
@@ -329,7 +329,7 @@ defmodule ArcanaWeb.MaintenanceLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:maintenance}>
+    <.dashboard_layout stats={@stats} current_tab={:maintenance} prefix={@prefix}>
       <div class="arcana-maintenance">
         <h2>Maintenance</h2>
         <p class="arcana-tab-description">

--- a/lib/arcana_web/live/maintenance_live.ex
+++ b/lib/arcana_web/live/maintenance_live.ex
@@ -104,7 +104,7 @@ defmodule ArcanaWeb.MaintenanceLive do
 
     socket = assign(socket, reembed_running: true, reembed_progress: %{current: 0, total: 0})
 
-    Arcana.TaskSupervisor.start_child(fn ->
+    ArcanaWeb.TaskSupervisor.start_child(fn ->
       progress_fn = fn current, total ->
         send(parent, {:reembed_progress, current, total})
       end
@@ -131,7 +131,7 @@ defmodule ArcanaWeb.MaintenanceLive do
     socket =
       assign(socket, rebuild_graph_running: true, rebuild_graph_progress: %{current: 0, total: 0})
 
-    Arcana.TaskSupervisor.start_child(fn ->
+    ArcanaWeb.TaskSupervisor.start_child(fn ->
       progress_fn = fn current, total ->
         send(parent, {:rebuild_graph_progress, current, total})
       end
@@ -161,7 +161,7 @@ defmodule ArcanaWeb.MaintenanceLive do
         detect_communities_progress: %{current: 0, total: 0}
       )
 
-    Arcana.TaskSupervisor.start_child(fn ->
+    ArcanaWeb.TaskSupervisor.start_child(fn ->
       progress_fn = fn current, total ->
         send(parent, {:detect_communities_progress, current, total})
       end

--- a/lib/arcana_web/live/search_live.ex
+++ b/lib/arcana_web/live/search_live.ex
@@ -114,7 +114,7 @@ defmodule ArcanaWeb.SearchLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:search}>
+    <.dashboard_layout stats={@stats} current_tab={:search} prefix={@prefix}>
       <div class="arcana-search">
         <%= if @viewing_document do %>
           <.search_document_detail viewing={@viewing_document} />

--- a/lib/arcana_web/router.ex
+++ b/lib/arcana_web/router.ex
@@ -47,9 +47,14 @@ defmodule ArcanaWeb.Router do
       end
 
     quote bind_quoted: binding() do
+      # Full mount prefix including enclosing scopes, e.g. "/admin/arcana"
+      # for `scope "/admin" do arcana_dashboard "/arcana" end`. Captured
+      # here so links and asset hrefs don't assume a "/arcana" mount.
+      prefix = Phoenix.Router.scoped_path(__MODULE__, path)
+
       scope path, alias: false, as: false do
         {session_name, session_opts, route_opts} =
-          ArcanaWeb.Router.__options__(opts)
+          ArcanaWeb.Router.__options__(opts, prefix)
 
         import Phoenix.Router, only: [get: 4]
         import Phoenix.LiveView.Router, only: [live: 4, live_session: 3]
@@ -83,18 +88,18 @@ defmodule ArcanaWeb.Router do
   defp expand_alias(other, _env), do: other
 
   @doc false
-  def __options__(options) do
+  def __options__(options, prefix) do
     live_socket_path = Keyword.get(options, :live_socket_path, "/live")
     repo = Keyword.get(options, :repo)
 
-    session_args = [repo]
+    session_args = [repo, prefix]
 
     {
       :arcana_dashboard,
       [
         session: {__MODULE__, :__session__, session_args},
         root_layout: {ArcanaWeb.Layouts, :root},
-        on_mount: options[:on_mount] || nil
+        on_mount: [ArcanaWeb.Router.Prefix | options[:on_mount] || []]
       ],
       [
         private: %{live_socket_path: live_socket_path},
@@ -104,7 +109,21 @@ defmodule ArcanaWeb.Router do
   end
 
   @doc false
-  def __session__(_conn, repo) do
-    %{"repo" => repo || Arcana.Config.get_env(:repo)}
+  def __session__(_conn, repo, prefix) do
+    %{
+      "repo" => repo || Arcana.Config.get_env(:repo),
+      "prefix" => prefix
+    }
+  end
+end
+
+defmodule ArcanaWeb.Router.Prefix do
+  @moduledoc false
+
+  # Assigns the dashboard's mount prefix (e.g. "/admin/arcana") to every
+  # dashboard LiveView so links and asset hrefs are built from the actual
+  # mount point instead of assuming "/arcana".
+  def on_mount(:default, _params, session, socket) do
+    {:cont, Phoenix.Component.assign(socket, :prefix, session["prefix"] || "/arcana")}
   end
 end

--- a/lib/arcana_web/router.ex
+++ b/lib/arcana_web/router.ex
@@ -49,8 +49,10 @@ defmodule ArcanaWeb.Router do
     quote bind_quoted: binding() do
       # Full mount prefix including enclosing scopes, e.g. "/admin/arcana"
       # for `scope "/admin" do arcana_dashboard "/arcana" end`. Captured
-      # here so links and asset hrefs don't assume a "/arcana" mount.
-      prefix = Phoenix.Router.scoped_path(__MODULE__, path)
+      # here so links and asset hrefs don't assume a "/arcana" mount. The
+      # trailing slash is trimmed so a root mount ("/") yields an empty
+      # prefix instead of turning hrefs into protocol-relative "//..." URLs.
+      prefix = String.trim_trailing(Phoenix.Router.scoped_path(__MODULE__, path), "/")
 
       scope path, alias: false, as: false do
         {session_name, session_opts, route_opts} =
@@ -99,7 +101,7 @@ defmodule ArcanaWeb.Router do
       [
         session: {__MODULE__, :__session__, session_args},
         root_layout: {ArcanaWeb.Layouts, :root},
-        on_mount: [ArcanaWeb.Router.Prefix | options[:on_mount] || []]
+        on_mount: [ArcanaWeb.Router.Prefix | List.wrap(options[:on_mount])]
       ],
       [
         private: %{live_socket_path: live_socket_path},

--- a/lib/arcana_web/task_supervisor.ex
+++ b/lib/arcana_web/task_supervisor.ex
@@ -1,0 +1,39 @@
+defmodule ArcanaWeb.TaskSupervisor do
+  @moduledoc """
+  Task supervisor for the Arcana dashboard's async operations.
+
+  Add to your application's supervision tree when using the dashboard:
+
+      children = [
+        MyApp.Repo,
+        Arcana.Embedder.Local,
+        ArcanaWeb.TaskSupervisor
+      ]
+
+  This enables supervised async operations in the dashboard (evaluation
+  runs, test case generation, maintenance tasks) with:
+  - Graceful shutdown during deploys
+  - Visibility in Observer/LiveDashboard
+  - Proper crash logging with `$callers` metadata
+
+  Only needed for the dashboard; the Arcana library itself doesn't use it.
+  """
+
+  def child_spec(_opts) do
+    %{
+      id: __MODULE__,
+      start: {Task.Supervisor, :start_link, [[name: __MODULE__]]},
+      type: :supervisor
+    }
+  end
+
+  @doc """
+  Starts a fire-and-forget task under this supervisor.
+
+  The task is not linked to the caller, so crashes won't bring down
+  the calling process. Crashes are logged by the supervisor.
+  """
+  def start_child(fun) when is_function(fun, 0) do
+    Task.Supervisor.start_child(__MODULE__, fun)
+  end
+end

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -70,7 +70,7 @@ if Code.ensure_loaded?(Igniter) do
           children = [
             #{inspect(repo_module)},
             Arcana.Embedder.Local,
-            Arcana.TaskSupervisor
+            ArcanaWeb.TaskSupervisor
           ]
 
          For in-memory vector store (no PostgreSQL required), also add:
@@ -406,7 +406,7 @@ else
           children = [
             MyApp.Repo,
             Arcana.Embedder.Local,
-            Arcana.TaskSupervisor
+            ArcanaWeb.TaskSupervisor
           ]
 
          For in-memory vector store (no PostgreSQL required), also add:

--- a/test/arcana_web/live/documents_graph_live_test.exs
+++ b/test/arcana_web/live/documents_graph_live_test.exs
@@ -8,7 +8,7 @@ defmodule ArcanaWeb.DocumentsGraphLiveTest do
 
   describe "graph indexing" do
     setup do
-      # Arcana.TaskSupervisor is started globally in test/test_helper.exs.
+      # ArcanaWeb.TaskSupervisor is started globally in test/test_helper.exs.
 
       # Enable graph for these tests, composing on the global base so the
       # fake entity_extractor from config/test.exs survives.

--- a/test/arcana_web/router_test.exs
+++ b/test/arcana_web/router_test.exs
@@ -1,0 +1,41 @@
+defmodule ArcanaWeb.RouterTest do
+  use ExUnit.Case, async: true
+
+  # arcana_dashboard mounted inside an enclosing scope: everything must be
+  # generated relative to /admin/arcana, and the live session must carry
+  # the prefix so links and asset hrefs don't assume /arcana (issue #101).
+  defmodule NestedRouter do
+    use Phoenix.Router
+    import Phoenix.LiveView.Router
+    import ArcanaWeb.Router
+
+    scope "/admin" do
+      arcana_dashboard("/arcana", repo: Arcana.TestRepo)
+    end
+  end
+
+  test "routes are generated under the enclosing scope" do
+    paths = NestedRouter |> Phoenix.Router.routes() |> Enum.map(& &1.path)
+
+    assert "/admin/arcana" in paths
+    assert "/admin/arcana/documents" in paths
+    assert "/admin/arcana/css-:hash" in paths
+    assert "/admin/arcana/js-:hash" in paths
+  end
+
+  test "live session carries the full mount prefix" do
+    route = NestedRouter |> Phoenix.Router.routes() |> Enum.find(&(&1.path == "/admin/arcana"))
+
+    {_module, _action, _opts, %{extra: %{session: session_mfa}}} =
+      route.metadata.phoenix_live_view
+
+    assert session_mfa == {ArcanaWeb.Router, :__session__, [Arcana.TestRepo, "/admin/arcana"]}
+  end
+
+  test "__session__ exposes the prefix to LiveViews" do
+    session = ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/admin/arcana")
+
+    assert session["prefix"] == "/admin/arcana"
+    assert session["repo"] == Arcana.TestRepo
+  end
+end

--- a/test/arcana_web/router_test.exs
+++ b/test/arcana_web/router_test.exs
@@ -38,4 +38,32 @@ defmodule ArcanaWeb.RouterTest do
     assert session["prefix"] == "/admin/arcana"
     assert session["repo"] == Arcana.TestRepo
   end
+
+  # Mounting at the root would otherwise capture "/" as the prefix and turn
+  # every href into a protocol-relative "//..." URL.
+  defmodule RootRouter do
+    use Phoenix.Router
+    import Phoenix.LiveView.Router
+    import ArcanaWeb.Router
+
+    arcana_dashboard("/", repo: Arcana.TestRepo)
+  end
+
+  test "root mount yields an empty prefix instead of a bare slash" do
+    route = RootRouter |> Phoenix.Router.routes() |> Enum.find(&(&1.path == "/documents"))
+
+    {_module, _action, _opts, %{extra: %{session: session_mfa}}} =
+      route.metadata.phoenix_live_view
+
+    assert session_mfa == {ArcanaWeb.Router, :__session__, [Arcana.TestRepo, ""]}
+  end
+
+  # Phoenix accepts a bare module for :on_mount, so prepending our Prefix
+  # hook must not build an improper list like [Prefix | Module].
+  test "__options__ wraps a single on_mount module into a proper list" do
+    {_name, session_opts, _route_opts} =
+      ArcanaWeb.Router.__options__([on_mount: SomeHook], "/arcana")
+
+    assert session_opts[:on_mount] == [ArcanaWeb.Router.Prefix, SomeHook]
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,8 +13,8 @@ Arcana.ConfigCase.enable()
 # Start the task supervisor used by LiveViews for async operations
 # (evaluation, Ask page submissions, maintenance tasks). Without this,
 # LiveView tests that trigger background tasks fail with "no process"
-# on Arcana.TaskSupervisor.
-{:ok, _} = Task.Supervisor.start_link(name: Arcana.TaskSupervisor)
+# on ArcanaWeb.TaskSupervisor.
+{:ok, _} = Task.Supervisor.start_link(name: ArcanaWeb.TaskSupervisor)
 
 # Start the endpoint for LiveView tests
 {:ok, _} = ArcanaWeb.Endpoint.start_link()


### PR DESCRIPTION
the dashboard's stylesheet link and every nav link hardcoded `/arcana`, so mounting `arcana_dashboard` anywhere else (like `/admin/arcana`) 404'd the CSS and rendered the whole thing unstyled, with nav links pointing at the wrong place.

the `arcana_dashboard` macro now captures the full mount prefix (including enclosing scopes) with `Phoenix.Router.scoped_path/2`, passes it through the live session, and an `on_mount` hook assigns it to every dashboard LiveView. The CSS href, nav links, graph tab URLs, and the ask sub-tab `push_patch` all build from the real prefix. Added a router test that mounts under `/admin` and asserts the generated routes and session.

second commit namespaces the task supervisor: it only serves the dashboard's async operations, so it's now `ArcanaWeb.TaskSupervisor`. `Arcana.TaskSupervisor` stays as a deprecated shim that starts the same registered process, so existing supervision trees keep working with a deprecation warning. Installer and guides updated.

related: the bundled dashboard JS still hardcodes the `/live` socket path even though the router takes a `:live_socket_path` option that currently goes nowhere. Same family of bug, but left for a separate issue.

Fixes #101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives dashboard asset and navigation URLs from the actual mount prefix so nested mounts work. Previously links and the stylesheet assumed "/arcana"; now the router captures the full prefix and LiveViews build URLs from it. Root mounts no longer generate protocol-relative "//" hrefs.

- `arcana_dashboard` uses `Phoenix.Router.scoped_path/2`, trims a trailing "/", passes `prefix` through the live session, and prepends `ArcanaWeb.Router.Prefix` to `on_mount` (wrapped via `List.wrap`).
- `dashboard_layout` and all links build from `@prefix`; swept remaining hardcoded paths (Ask sub-tab `push_patch`, graph URLs, chunk results doc links, graph entity mentions).
- Namespaces the task supervisor to `ArcanaWeb.TaskSupervisor`; adds router tests for nested/root mounts and updates LiveView tests to start `ArcanaWeb.TaskSupervisor`.

**Migration**
- Replace `Arcana.TaskSupervisor` with `ArcanaWeb.TaskSupervisor` in your supervision tree. A deprecated shim keeps existing setups working but emits a warning.

<sup>Written for commit 30b5e41202c1a2d807b02b78fa3fbdffe329127a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

