### PR TITLE
feat: Public API for listing and reading documents

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -284,6 +284,29 @@ false
 > **Note:** PDF support requires a PDF parser. The default uses Poppler's `pdftotext`.
 > See [PDF Parsing Configuration](#pdf-parsing-configuration) for installation and custom parsers.
 
+### Listing and Reading Documents
+
+Build admin surfaces or assert on ingestion outcomes without touching
+Arcana's schemas directly:
+
+```elixir
+# List a collection's documents (newest first, collection preloaded)
+{:ok, docs} = Arcana.list_documents(repo: MyApp.Repo, collection: "products")
+
+# Filter by status or source, paginate
+{:ok, failed} = Arcana.list_documents(repo: MyApp.Repo, status: :failed)
+{:ok, page2} = Arcana.list_documents(repo: MyApp.Repo, limit: 20, offset: 20)
+{:ok, total} = Arcana.count_documents(repo: MyApp.Repo, collection: "products")
+
+# Read one, delete one
+{:ok, document} = Arcana.get_document(id, repo: MyApp.Repo)
+:ok = Arcana.delete(id, repo: MyApp.Repo)
+```
+
+`Arcana.Document` is the stable public shape: `id`, `status`, `chunk_count`,
+`metadata`, `source_id`, `content_type`, timestamps, and the preloaded
+`collection`.
+
 ### Searching
 
 ```elixir

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -118,9 +118,7 @@ defmodule Arcana do
 
   """
   def delete(document_id, opts) do
-    repo =
-      opts[:repo] || Arcana.Config.get_env(:repo) ||
-        raise ArgumentError, "repo is required"
+    repo = Arcana.Config.require_repo!(opts)
 
     case repo.get(Document, document_id) do
       nil -> {:error, :not_found}

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -94,6 +94,22 @@ defmodule Arcana do
   # === Document Management ===
 
   @doc """
+  Lists documents, newest first. See `Arcana.Documents.list_documents/1`.
+  """
+  defdelegate list_documents(opts), to: Arcana.Documents
+
+  @doc """
+  Counts documents matching the `list_documents/1` filters.
+  See `Arcana.Documents.count_documents/1`.
+  """
+  defdelegate count_documents(opts), to: Arcana.Documents
+
+  @doc """
+  Fetches a document by id. See `Arcana.Documents.get_document/2`.
+  """
+  defdelegate get_document(id, opts), to: Arcana.Documents
+
+  @doc """
   Deletes a document and all its chunks.
 
   ## Options

--- a/lib/arcana/config.ex
+++ b/lib/arcana/config.ex
@@ -240,6 +240,15 @@ defmodule Arcana.Config do
   end
 
   @doc """
+  Returns the repo from opts or the global config, raising when neither
+  is set.
+  """
+  def require_repo!(opts) do
+    opts[:repo] || get_env(:repo) ||
+      raise ArgumentError, "repo is required"
+  end
+
+  @doc """
   Returns the value for `key` from opts, falling back to the global app env.
 
   Used to thread configuration like `:repo` and `:llm` from per-call opts

--- a/lib/arcana/documents.ex
+++ b/lib/arcana/documents.ex
@@ -1,0 +1,120 @@
+defmodule Arcana.Documents do
+  @moduledoc """
+  Public read API for documents.
+
+  Lets host apps build admin surfaces (list a collection's documents,
+  show ingestion status, paginate) and assert on ingestion outcomes in
+  tests without querying Arcana's schemas through Ecto directly.
+
+  `Arcana.Document` is the stable public shape: `id`, `status`,
+  `chunk_count`, `metadata`, `source_id`, `content_type`, timestamps,
+  and the preloaded `collection`.
+  """
+
+  import Ecto.Query
+
+  alias Arcana.Document
+
+  @doc """
+  Lists documents, newest first.
+
+  ## Options
+
+    * `:repo` - The Ecto repo to use (required unless configured globally)
+    * `:collection` - Filter by collection name. A name that doesn't
+      exist matches nothing.
+    * `:status` - Filter by status (`:pending`, `:processing`,
+      `:completed`, `:failed`)
+    * `:source_id` - Filter by source id
+    * `:limit` - Maximum documents to return (default: 50)
+    * `:offset` - Number of documents to skip (default: 0)
+
+  ## Examples
+
+      {:ok, docs} = Arcana.list_documents(repo: MyApp.Repo, collection: "products")
+      {:ok, failed} = Arcana.list_documents(repo: MyApp.Repo, status: :failed)
+      {:ok, page2} = Arcana.list_documents(repo: MyApp.Repo, limit: 20, offset: 20)
+
+  """
+  def list_documents(opts) do
+    repo = require_repo!(opts)
+    limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
+
+    documents =
+      opts
+      |> base_query()
+      |> order_by([d], desc: d.inserted_at, desc: d.id)
+      |> limit(^limit)
+      |> offset(^offset)
+      |> preload([:collection])
+      |> repo.all()
+
+    {:ok, documents}
+  end
+
+  @doc """
+  Counts documents matching the same filters as `list_documents/1`
+  (`:collection`, `:status`, `:source_id`), for building pagination.
+
+  ## Examples
+
+      {:ok, total} = Arcana.count_documents(repo: MyApp.Repo, collection: "products")
+
+  """
+  def count_documents(opts) do
+    repo = require_repo!(opts)
+
+    {:ok, opts |> base_query() |> repo.aggregate(:count)}
+  end
+
+  @doc """
+  Fetches a single document by id, with its collection preloaded.
+
+  Returns `{:ok, document}` or `{:error, :not_found}`.
+
+  ## Options
+
+    * `:repo` - The Ecto repo to use (required unless configured globally)
+
+  ## Examples
+
+      {:ok, document} = Arcana.get_document(id, repo: MyApp.Repo)
+
+  """
+  def get_document(id, opts) do
+    repo = require_repo!(opts)
+
+    case repo.one(from(d in Document, where: d.id == ^id, preload: [:collection])) do
+      nil -> {:error, :not_found}
+      document -> {:ok, document}
+    end
+  end
+
+  defp base_query(opts) do
+    Document
+    |> filter_collection(Keyword.get(opts, :collection))
+    |> filter_status(Keyword.get(opts, :status))
+    |> filter_source_id(Keyword.get(opts, :source_id))
+  end
+
+  defp filter_collection(query, nil), do: query
+
+  defp filter_collection(query, collection_name) do
+    from(d in query,
+      join: c in assoc(d, :collection),
+      where: c.name == ^collection_name
+    )
+  end
+
+  defp filter_status(query, nil), do: query
+  defp filter_status(query, status), do: from(d in query, where: d.status == ^status)
+
+  defp filter_source_id(query, nil), do: query
+  defp filter_source_id(query, source_id), do: from(d in query, where: d.source_id == ^source_id)
+
+  defp require_repo!(opts) do
+    opts[:repo] || Arcana.Config.get_env(:repo) ||
+      raise ArgumentError, "repo is required"
+  end
+end

--- a/lib/arcana/documents.ex
+++ b/lib/arcana/documents.ex
@@ -38,8 +38,8 @@ defmodule Arcana.Documents do
   """
   def list_documents(opts) do
     repo = require_repo!(opts)
-    limit = Keyword.get(opts, :limit, 50)
-    offset = Keyword.get(opts, :offset, 0)
+    limit = validate_non_neg_integer!(opts, :limit, 50)
+    offset = validate_non_neg_integer!(opts, :offset, 0)
 
     documents =
       opts
@@ -85,9 +85,13 @@ defmodule Arcana.Documents do
   def get_document(id, opts) do
     repo = require_repo!(opts)
 
-    case repo.one(from(d in Document, where: d.id == ^id, preload: [:collection])) do
-      nil -> {:error, :not_found}
-      document -> {:ok, document}
+    with {:ok, uuid} <- Ecto.UUID.cast(id),
+         %Document{} = document <-
+           repo.one(from(d in Document, where: d.id == ^uuid, preload: [:collection])) do
+      {:ok, document}
+    else
+      # Malformed ids can't match anything, same outcome as a missing row
+      _ -> {:error, :not_found}
     end
   end
 
@@ -114,4 +118,15 @@ defmodule Arcana.Documents do
   defp filter_source_id(query, source_id), do: from(d in query, where: d.source_id == ^source_id)
 
   defp require_repo!(opts), do: Arcana.Config.require_repo!(opts)
+
+  defp validate_non_neg_integer!(opts, key, default) do
+    case Keyword.get(opts, key, default) do
+      value when is_integer(value) and value >= 0 ->
+        value
+
+      other ->
+        raise ArgumentError,
+              "#{inspect(key)} must be a non-negative integer, got: #{inspect(other)}"
+    end
+  end
 end

--- a/lib/arcana/documents.ex
+++ b/lib/arcana/documents.ex
@@ -113,8 +113,5 @@ defmodule Arcana.Documents do
   defp filter_source_id(query, nil), do: query
   defp filter_source_id(query, source_id), do: from(d in query, where: d.source_id == ^source_id)
 
-  defp require_repo!(opts) do
-    opts[:repo] || Arcana.Config.get_env(:repo) ||
-      raise ArgumentError, "repo is required"
-  end
+  defp require_repo!(opts), do: Arcana.Config.require_repo!(opts)
 end

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -104,9 +104,7 @@ defmodule Arcana.Ingest do
 
   # Private functions
 
-  defp require_repo!(opts) do
-    Arcana.Config.get(opts, :repo) || raise ArgumentError, "repo is required"
-  end
+  defp require_repo!(opts), do: Arcana.Config.require_repo!(opts)
 
   defp finalize_ingest(document, chunk_records, collection, repo, opts) do
     maybe_build_graph(chunk_records, collection, repo, opts)

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -51,37 +51,19 @@ defmodule ArcanaWeb.DocumentsLive do
   end
 
   defp load_documents(socket) do
-    repo = socket.assigns.repo
     page = socket.assigns.page
     per_page = socket.assigns.per_page
-    filter_collection = socket.assigns.filter_collection
 
-    base_query =
-      from(d in Document,
-        order_by: [desc: d.inserted_at],
-        preload: [:collection]
-      )
+    filters = [
+      repo: socket.assigns.repo,
+      collection: socket.assigns.filter_collection
+    ]
 
-    filtered_query =
-      if filter_collection do
-        from(d in base_query,
-          join: c in assoc(d, :collection),
-          where: c.name == ^filter_collection
-        )
-      else
-        base_query
-      end
-
-    total_count = repo.aggregate(filtered_query, :count)
+    {:ok, total_count} = Arcana.count_documents(filters)
     total_pages = max(1, ceil(total_count / per_page))
 
-    documents =
-      repo.all(
-        from(d in filtered_query,
-          offset: ^((page - 1) * per_page),
-          limit: ^per_page
-        )
-      )
+    {:ok, documents} =
+      Arcana.list_documents(filters ++ [limit: per_page, offset: (page - 1) * per_page])
 
     assign(socket,
       documents: documents,

--- a/test/arcana/documents_test.exs
+++ b/test/arcana/documents_test.exs
@@ -79,5 +79,21 @@ defmodule Arcana.DocumentsTest do
     test "returns not_found for a missing id" do
       assert {:error, :not_found} = Arcana.get_document(Ecto.UUID.generate(), repo: Repo)
     end
+
+    test "returns not_found for a malformed id instead of raising" do
+      assert {:error, :not_found} = Arcana.get_document("not-a-uuid", repo: Repo)
+    end
+  end
+
+  describe "list_documents/1 argument validation" do
+    test "rejects negative or non-integer limit/offset" do
+      assert_raise ArgumentError, ~r/must be a non-negative integer/, fn ->
+        Arcana.list_documents(repo: Repo, limit: -1)
+      end
+
+      assert_raise ArgumentError, ~r/must be a non-negative integer/, fn ->
+        Arcana.list_documents(repo: Repo, offset: "20")
+      end
+    end
   end
 end

--- a/test/arcana/documents_test.exs
+++ b/test/arcana/documents_test.exs
@@ -1,0 +1,83 @@
+defmodule Arcana.DocumentsTest do
+  use Arcana.DataCase, async: true
+
+  alias Arcana.Document
+
+  describe "list_documents/1" do
+    test "lists documents newest first with collection preloaded" do
+      {:ok, _} = Arcana.ingest("First document", repo: Repo, collection: "docs-api")
+      {:ok, _} = Arcana.ingest("Second document", repo: Repo, collection: "docs-api")
+
+      {:ok, [newest, oldest]} = Arcana.list_documents(repo: Repo, collection: "docs-api")
+
+      assert newest.inserted_at >= oldest.inserted_at
+      assert newest.collection.name == "docs-api"
+      assert newest.status == :completed
+      assert newest.chunk_count > 0
+    end
+
+    test "filters by collection and matches nothing for unknown names" do
+      {:ok, _} = Arcana.ingest("In collection A", repo: Repo, collection: "docs-a")
+      {:ok, _} = Arcana.ingest("In collection B", repo: Repo, collection: "docs-b")
+
+      {:ok, docs} = Arcana.list_documents(repo: Repo, collection: "docs-a")
+      assert [%Document{}] = docs
+
+      assert {:ok, []} = Arcana.list_documents(repo: Repo, collection: "docs-nope")
+    end
+
+    test "filters by status" do
+      {:ok, _} = Arcana.ingest("Completed doc", repo: Repo, collection: "docs-status")
+
+      {:ok, failed_doc} =
+        %Document{}
+        |> Document.changeset(%{content: "Failed doc", status: :failed})
+        |> Repo.insert()
+
+      {:ok, [only]} = Arcana.list_documents(repo: Repo, status: :failed)
+      assert only.id == failed_doc.id
+
+      {:ok, completed} = Arcana.list_documents(repo: Repo, status: :completed)
+      refute Enum.any?(completed, &(&1.id == failed_doc.id))
+    end
+
+    test "filters by source_id" do
+      {:ok, doc} = Arcana.ingest("Sourced doc", repo: Repo, source_id: "book-42")
+      {:ok, _} = Arcana.ingest("Other doc", repo: Repo)
+
+      assert {:ok, [%Document{id: id}]} = Arcana.list_documents(repo: Repo, source_id: "book-42")
+      assert id == doc.id
+    end
+
+    test "paginates with limit and offset, count covers the full set" do
+      for i <- 1..3 do
+        {:ok, _} = Arcana.ingest("Paginated #{i}", repo: Repo, collection: "docs-page")
+      end
+
+      filters = [repo: Repo, collection: "docs-page"]
+
+      {:ok, page1} = Arcana.list_documents(filters ++ [limit: 2, offset: 0])
+      {:ok, page2} = Arcana.list_documents(filters ++ [limit: 2, offset: 2])
+
+      assert length(page1) == 2
+      assert length(page2) == 1
+      assert Enum.uniq(Enum.map(page1 ++ page2, & &1.id)) |> length() == 3
+
+      assert {:ok, 3} = Arcana.count_documents(filters)
+    end
+  end
+
+  describe "get_document/2" do
+    test "returns the document with collection preloaded" do
+      {:ok, doc} = Arcana.ingest("Fetch me", repo: Repo, collection: "docs-get")
+
+      assert {:ok, fetched} = Arcana.get_document(doc.id, repo: Repo)
+      assert fetched.id == doc.id
+      assert fetched.collection.name == "docs-get"
+    end
+
+    test "returns not_found for a missing id" do
+      assert {:error, :not_found} = Arcana.get_document(Ecto.UUID.generate(), repo: Repo)
+    end
+  end
+end


### PR DESCRIPTION
adds `Arcana.list_documents/1`, `Arcana.count_documents/1`, and `Arcana.get_document/2` so admin surfaces and tests can stay on the public API instead of querying `Arcana.Document`/`Arcana.Chunk` through Ecto directly.

filters: `:collection` (by name, unknown names match nothing), `:status`, `:source_id`, plus `:limit`/`:offset` pagination. Results come back newest first with the collection preloaded. `Arcana.Document` is the documented stable read shape, same deal as the existing `Arcana.delete/2` being the write half.

the dashboard's DocumentsLive now goes through `list_documents`/`count_documents` for its listing, so the public API has a real consumer and there's one query path.

once #103 lands, a small follow-up can make `:collection` respect `strict_collections` (error on unknown names instead of matching nothing). The `{:ok, _}` return shape already leaves room for that.

Closes #102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public read API for documents and switches the dashboard to use it. This replaces direct Ecto queries with a stable, safe read path and hardens input handling.

- Adds `Arcana.list_documents/1`, `Arcana.count_documents/1`, and `Arcana.get_document/2`: filter by `:collection` (unknown names match nothing), `:status`, and `:source_id`; paginate with `:limit`/`:offset`; return newest first with `:collection` preloaded. `Arcana.Document` remains the stable read shape.
- Hardens inputs: `get_document/2` casts IDs and returns `{:error, :not_found}` for malformed or missing IDs; `list_documents/1` enforces non-negative integer `:limit`/`:offset` and raises `ArgumentError` when invalid.
- Centralizes repo resolution via `Arcana.Config.require_repo!/1`; used by `list_documents/1`, `count_documents/1`, `get_document/2`, `Arcana.delete/2`, and ingest. Migration: callers must pass `:repo` or configure it globally.
- Replaces direct queries in the admin UI; `ArcanaWeb.DocumentsLive` now calls the public API. Updates getting-started docs and tests to use the API.

<sup>Written for commit 260ec82917001165866f8470fe0b05daa3e193f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

