### PR TITLE
feat: Add replace: true to ingest for atomic re-ingest by source_id

### DIFF
--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -20,12 +20,34 @@ defmodule Arcana.Ingest do
     * `:chunk_overlap` - Overlap between chunks (default: 200)
     * `:collection` - Collection name (string) or map with name and description (default: "default")
     * `:graph` - Enable GraphRAG extraction (default: from config)
+    * `:replace` - When true, atomically replaces any prior document with the
+      same `(collection, source_id)` once the new ingest completes. Requires
+      `:source_id`. See "Replacing documents" below.
 
+  ## Replacing documents
+
+  With `replace: true`, `source_id` becomes a stable document identity:
+  re-ingesting the same identity supersedes earlier documents instead of
+  accumulating next to them. The new document is ingested first and
+  predecessors (including `:failed`/`:processing` leftovers from crashed
+  attempts) are deleted only after it completes, so the old chunks stay
+  searchable until the replacement lands and their rows cascade away with
+  the document.
+
+  The swap runs in a transaction under a per-identity advisory lock, so
+  callers don't need their own mutex for correctness. If two ingests for the
+  same identity run concurrently, the first to complete wins and the other
+  returns `{:error, :replaced_by_concurrent_ingest}` (or may fail while
+  storing chunks whose document was already replaced).
   """
   def ingest(text, opts) when is_binary(text) do
     repo = require_repo!(opts)
     source_id = Keyword.get(opts, :source_id)
     metadata = Keyword.get(opts, :metadata, %{})
+
+    if Keyword.get(opts, :replace, false) and (is_nil(source_id) or source_id == "") do
+      raise ArgumentError, "replace: true requires a :source_id document identity"
+    end
 
     {collection_name, collection_description} =
       parse_collection_opt(Keyword.get(opts, :collection, "default"))
@@ -109,12 +131,62 @@ defmodule Arcana.Ingest do
   defp finalize_ingest(document, chunk_records, collection, repo, opts) do
     maybe_build_graph(chunk_records, collection, repo, opts)
 
-    {:ok, document} =
-      document
-      |> Document.changeset(%{status: :completed, chunk_count: length(chunk_records)})
-      |> repo.update()
+    if Keyword.get(opts, :replace, false) do
+      finalize_replace(document, chunk_records, repo)
+    else
+      {:ok, document} =
+        document
+        |> Document.changeset(%{status: :completed, chunk_count: length(chunk_records)})
+        |> repo.update()
 
-    {{:ok, document}, %{document: document, chunk_count: length(chunk_records)}}
+      {{:ok, document}, %{document: document, chunk_count: length(chunk_records)}}
+    end
+  end
+
+  # The replace swap: delete every other document with the same
+  # (collection_id, source_id) — completed predecessors and crashed-attempt
+  # leftovers alike (chunks cascade via FK) — then mark the new document
+  # completed. Runs under a per-identity transaction-scoped advisory lock so
+  # concurrent replaces serialize HERE, at the fast DB-only step, never
+  # around chunking/embedding. A run whose document was already deleted by a
+  # faster concurrent replace loses cleanly.
+  defp finalize_replace(document, chunk_records, repo) do
+    result =
+      repo.transaction(fn ->
+        repo.query!("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+          "arcana:replace:#{document.collection_id}:#{document.source_id}"
+        ])
+
+        if repo.get(Document, document.id) do
+          import Ecto.Query, only: [from: 2]
+
+          repo.delete_all(
+            from(d in Document,
+              where:
+                d.collection_id == ^document.collection_id and
+                  d.source_id == ^document.source_id and
+                  d.id != ^document.id
+            )
+          )
+
+          {:ok, document} =
+            document
+            |> Document.changeset(%{status: :completed, chunk_count: length(chunk_records)})
+            |> repo.update()
+
+          document
+        else
+          repo.rollback(:replaced_by_concurrent_ingest)
+        end
+      end)
+
+    case result do
+      {:ok, document} ->
+        {{:ok, document}, %{document: document, chunk_count: length(chunk_records)}}
+
+      {:error, :replaced_by_concurrent_ingest} ->
+        {{:error, :replaced_by_concurrent_ingest}, %{error: :replaced_by_concurrent_ingest}}
+    end
   end
 
   defp maybe_build_graph(chunk_records, collection, repo, opts) do

--- a/test/arcana/ingest_test.exs
+++ b/test/arcana/ingest_test.exs
@@ -88,4 +88,69 @@ defmodule Arcana.IngestTest do
       assert {:error, :not_found} = Arcana.delete(fake_id, repo: Repo)
     end
   end
+
+  describe "ingest/2 with replace: true" do
+    test "re-ingesting the same identity replaces the document and its chunks" do
+      {:ok, old} = Arcana.ingest("old text", repo: Repo, source_id: "doc-1", replace: true)
+      {:ok, new} = Arcana.ingest("new text", repo: Repo, source_id: "doc-1", replace: true)
+
+      assert old.id != new.id
+      assert Repo.get(Arcana.Document, old.id) == nil
+
+      assert [document] = Repo.all(Arcana.Document)
+      assert document.id == new.id
+      assert document.content == "new text"
+      assert document.status == :completed
+
+      # the replaced document's chunks cascaded away with it
+      chunks = Repo.all(Arcana.Chunk)
+      assert Enum.all?(chunks, fn c -> c.document_id == new.id end)
+    end
+
+    test "only replaces within the same (collection, source_id) identity" do
+      {:ok, other_source} = Arcana.ingest("keep me", repo: Repo, source_id: "doc-2")
+
+      {:ok, other_collection} =
+        Arcana.ingest("keep me too", repo: Repo, source_id: "doc-1", collection: "other")
+
+      {:ok, _v1} = Arcana.ingest("v1", repo: Repo, source_id: "doc-1", replace: true)
+      {:ok, v2} = Arcana.ingest("v2", repo: Repo, source_id: "doc-1", replace: true)
+
+      surviving_ids = Repo.all(Arcana.Document) |> Enum.map(& &1.id) |> Enum.sort()
+      assert surviving_ids == Enum.sort([other_source.id, other_collection.id, v2.id])
+    end
+
+    test "sweeps failed and processing leftovers from crashed prior attempts" do
+      {:ok, collection} = Arcana.Collection.get_or_create("default", Repo)
+
+      for status <- [:failed, :processing] do
+        %Arcana.Document{}
+        |> Arcana.Document.changeset(%{
+          content: "crashed attempt",
+          source_id: "doc-1",
+          status: status,
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+      end
+
+      {:ok, document} = Arcana.ingest("recovered", repo: Repo, source_id: "doc-1", replace: true)
+
+      assert [%{id: id, status: :completed}] = Repo.all(Arcana.Document)
+      assert id == document.id
+    end
+
+    test "without replace, documents for the same identity accumulate (unchanged behavior)" do
+      {:ok, _} = Arcana.ingest("v1", repo: Repo, source_id: "doc-1")
+      {:ok, _} = Arcana.ingest("v2", repo: Repo, source_id: "doc-1")
+
+      assert Repo.aggregate(Arcana.Document, :count) == 2
+    end
+
+    test "requires a source_id identity" do
+      assert_raise ArgumentError, ~r/requires a :source_id/, fn ->
+        Arcana.ingest("text", repo: Repo, replace: true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implements item 3 of #94: atomic re-ingest by document identity, so integrators stop hand-rolling insert-then-delete-others with their own locking rules.

## What it does

With `replace: true`, `source_id` becomes a stable document identity:

```elixir
{:ok, doc} = Arcana.ingest(text, repo: Repo, collection: "kb", source_id: "article:42", replace: true)
```

- The new document is ingested first; predecessors for the same `(collection, source_id)` — including `:failed`/`:processing` leftovers from crashed attempts — are deleted only after it completes. Old chunks stay searchable until the replacement lands, and their rows cascade away with the document.
- The swap (delete-others + mark-completed) runs in a transaction under a per-identity advisory lock (`pg_advisory_xact_lock`), so concurrent replaces serialize at the fast DB-only step, never around chunking/embedding. First to complete wins; a slower concurrent run gets `{:error, :replaced_by_concurrent_ingest}` instead of corrupting state.
- Without `replace: true` nothing changes — documents for the same identity accumulate exactly as before.

## Why the advisory lock (and not job-queue uniqueness)

Before this, safe replacement required the *caller* to serialize ingests per identity (e.g. Oban uniqueness including the `:executing` state) — a correctness rule living outside the library, easy to break without noticing. With the lock inside the swap, host-side dedup becomes an optimization, not a requirement.

Known race window, documented in the moduledoc: a run whose document is replaced while it's still storing chunks can fail with an FK error rather than the clean `:replaced_by_concurrent_ingest`. Closing that fully would mean checking document liveness on every chunk batch; didn't seem worth it for a losing run.

## Tests

Five new cases in `ingest_test.exs`: replace-by-identity (chunks cascade), identity scoping across collections/source_ids, crashed-leftover sweep, unchanged accumulate behavior without the flag, and `ArgumentError` without a `source_id`. Full suite green, credo --strict clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds atomic re-ingest by document identity. Previously, documents accumulated for the same (collection, source_id). With replace: true, the new ingest supersedes predecessors once it completes, and old chunks remain searchable until the swap.

- Adds a replace: true option to ingest; requires source_id or raises ArgumentError.
- After completion, deletes predecessors for the same (collection, source_id); chunks cascade.
- Serializes concurrent replaces under a per-identity advisory lock; slower runs return {:error, :replaced_by_concurrent_ingest}.
- Default behavior is unchanged without replace: true.
- Known side effect: a losing concurrent run may hit an FK error while writing chunks; documented.

<sup>Written for commit d50dd9190a4317278e1e623c8f0cd1547d2f8cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

