### PR TITLE
feat: Make bumblebee and req_llm optional dependencies

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -18,7 +18,7 @@ This adds the dependency, creates migrations, configures your repo, and sets up 
 ```elixir
 def deps do
   [
-    {:arcana, "~> 1.0"}
+    {:arcana, "~> 2.0"}
   ]
 end
 ```

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -33,6 +33,24 @@ mix ecto.migrate
 
 Arcana uses local embeddings by default via Bumblebee. No API keys needed.
 
+`bumblebee` is an optional dependency, so add it (plus a backend) when
+using the default local embedder:
+
+```elixir
+def deps do
+  [
+    {:arcana, "~> 2.0"},
+    {:bumblebee, "~> 0.6"},
+    {:exla, "~> 0.10"}
+  ]
+end
+```
+
+Apps that bring their own embedder (the `Arcana.Embedder` behaviour) can
+skip both and avoid compiling the Bumblebee/tokenizers toolchain. The same
+goes for `req_llm`: it's optional and only needed when using model strings
+(like `"openai:gpt-4o-mini"`) as the LLM or `Arcana.Loop`.
+
 ```elixir
 # config/config.exs
 

--- a/lib/arcana/embedder/local.ex
+++ b/lib/arcana/embedder/local.ex
@@ -48,6 +48,8 @@ defmodule Arcana.Embedder.Local do
 
   @behaviour Arcana.Embedder
 
+  @compile {:no_warn_undefined, [Bumblebee, Bumblebee.Text.TextEmbedding]}
+
   alias Bumblebee.Text.TextEmbedding
 
   @default_model "BAAI/bge-small-en-v1.5"
@@ -99,6 +101,7 @@ defmodule Arcana.Embedder.Local do
   are passed (or merges when some opts are passed).
   """
   def start_link(opts \\ []) do
+    ensure_bumblebee!()
     opts = merge_global_opts(opts)
     model = Keyword.get(opts, :model, @default_model)
     serving_name = serving_name(model)
@@ -145,6 +148,7 @@ defmodule Arcana.Embedder.Local do
 
   @impl Arcana.Embedder
   def embed(text, opts) do
+    ensure_bumblebee!()
     model = Keyword.get(opts, :model, @default_model)
     intent = Keyword.get(opts, :intent)
     serving_name = serving_name(model)
@@ -207,6 +211,24 @@ defmodule Arcana.Embedder.Local do
     case embed("test", opts) do
       {:ok, embedding} -> length(embedding)
       _ -> raise "Could not detect dimensions for local model"
+    end
+  end
+
+  defp ensure_bumblebee! do
+    unless Code.ensure_loaded?(Bumblebee) do
+      raise """
+      Bumblebee is required for Arcana.Embedder.Local (the default embedder)
+      but not available.
+
+      Add it and a backend to your dependencies:
+
+          {:bumblebee, "~> 0.6"},
+          {:exla, "~> 0.10"}
+
+      Or configure a different embedder:
+
+          config :arcana, embedder: {MyApp.Embedder, []}
+      """
     end
   end
 end

--- a/lib/arcana/embeddings/serving.ex
+++ b/lib/arcana/embeddings/serving.ex
@@ -5,6 +5,8 @@ defmodule Arcana.Embeddings.Serving do
   Uses BAAI/bge-small-en-v1.5 which produces 384-dimensional embeddings by default.
   """
 
+  @compile {:no_warn_undefined, [Bumblebee, Bumblebee.Text.TextEmbedding]}
+
   alias Bumblebee.Text.TextEmbedding
 
   @default_model "BAAI/bge-small-en-v1.5"
@@ -22,6 +24,17 @@ defmodule Arcana.Embeddings.Serving do
   end
 
   def start_link(opts \\ []) do
+    unless Code.ensure_loaded?(Bumblebee) do
+      raise """
+      Bumblebee is required for Arcana.Embeddings.Serving but not available.
+
+      Add it and a backend to your dependencies:
+
+          {:bumblebee, "~> 0.6"},
+          {:exla, "~> 0.10"}
+      """
+    end
+
     model = Keyword.get(opts, :model, @default_model)
     tokenizer_model = Keyword.get(opts, :tokenizer, model)
 

--- a/lib/arcana/graph/entity_extractor/llm.ex
+++ b/lib/arcana/graph/entity_extractor/llm.ex
@@ -149,7 +149,7 @@ defmodule Arcana.Graph.EntityExtractor.LLM do
       |> String.replace(~r/\n?```$/, "")
       |> String.trim()
 
-    case Jason.decode(cleaned) do
+    case JSON.decode(cleaned) do
       {:ok, entities} when is_list(entities) ->
         validated =
           entities

--- a/lib/arcana/graph/graph_extractor/llm.ex
+++ b/lib/arcana/graph/graph_extractor/llm.ex
@@ -139,7 +139,7 @@ defmodule Arcana.Graph.GraphExtractor.LLM do
       |> String.replace(~r/\n?```$/, "")
       |> String.trim()
 
-    case Jason.decode(cleaned) do
+    case JSON.decode(cleaned) do
       {:ok, %{"entities" => entities, "relationships" => relationships}}
       when is_list(entities) and is_list(relationships) ->
         normalized_entities = Enum.map(entities, &normalize_entity/1)

--- a/lib/arcana/graph/ner_serving.ex
+++ b/lib/arcana/graph/ner_serving.ex
@@ -55,6 +55,8 @@ defmodule Arcana.Graph.NERServing do
 
   # Private
 
+  @compile {:no_warn_undefined, [Bumblebee, Bumblebee.Text]}
+
   defp start_serving do
     # Use a global lock to prevent race conditions
     :global.trans({__MODULE__, :start}, fn ->
@@ -66,6 +68,17 @@ defmodule Arcana.Graph.NERServing do
   end
 
   defp do_start_serving do
+    unless Code.ensure_loaded?(Bumblebee) do
+      raise """
+      Bumblebee is required for NER entity extraction but not available.
+
+      Add it and a backend to your dependencies:
+
+          {:bumblebee, "~> 0.6"},
+          {:exla, "~> 0.10"}
+      """
+    end
+
     {:ok, model_info} = Bumblebee.load_model({:hf, @model_id})
     {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, @model_id})
 

--- a/lib/arcana/graph/relationship_extractor/llm.ex
+++ b/lib/arcana/graph/relationship_extractor/llm.ex
@@ -105,7 +105,7 @@ defmodule Arcana.Graph.RelationshipExtractor.LLM do
       |> String.replace(~r/\n?```$/, "")
       |> String.trim()
 
-    case Jason.decode(cleaned) do
+    case JSON.decode(cleaned) do
       {:ok, relationships} when is_list(relationships) ->
         validated =
           relationships

--- a/lib/arcana/grounder/llm_judge.ex
+++ b/lib/arcana/grounder/llm_judge.ex
@@ -94,13 +94,15 @@ defmodule Arcana.Grounder.LLMJudge do
     end
   end
 
+  @compile {:no_warn_undefined, [ReqLLM, ReqLLM.Context, ReqLLM.Response]}
+
   defp call_req_llm(question, answer, chunks, opts) do
     unless Code.ensure_loaded?(ReqLLM) do
       raise """
       Arcana.Grounder.LLMJudge requires ReqLLM.
 
       Add to mix.exs:
-        {:req_llm, "~> 1.6"}
+        {:req_llm, "~> 1.2"}
       """
     end
 
@@ -148,7 +150,7 @@ defmodule Arcana.Grounder.LLMJudge do
         {:error, :invalid_judge_response}
 
       json ->
-        case Jason.decode(json) do
+        case JSON.decode(json) do
           {:ok, map} when is_map(map) -> {:ok, normalize_top_level(map)}
           _ -> {:error, :invalid_judge_response}
         end

--- a/lib/arcana/llm.ex
+++ b/lib/arcana/llm.ex
@@ -131,6 +131,23 @@ if Code.ensure_loaded?(ReqLLM) do
       end)
     end
   end
+else
+  defimpl Arcana.LLM, for: BitString do
+    def complete(model, _prompt, _context, _opts) do
+      raise """
+      req_llm is required to use model strings like #{inspect(model)} as
+      the LLM but not available.
+
+      Add it to your dependencies:
+
+          {:req_llm, "~> 1.2"}
+
+      Or configure a custom LLM function instead:
+
+          config :arcana, llm: {MyApp.LLM, :complete}
+      """
+    end
+  end
 end
 
 defimpl Arcana.LLM, for: Tuple do
@@ -160,28 +177,5 @@ defimpl Arcana.LLM, for: Tuple do
 
   def complete({model, llm_opts}, prompt, context, opts) when is_list(llm_opts) do
     Arcana.LLM.complete(model, prompt, context, Keyword.merge(llm_opts, opts))
-  end
-else
-  defimpl Arcana.LLM, for: BitString do
-    def complete(model, _prompt, _context, _opts) do
-      raise """
-      req_llm is required to use model strings like #{inspect(model)} as
-      the LLM but not available.
-
-      Add it to your dependencies:
-
-          {:req_llm, "~> 1.2"}
-
-      Or configure a custom LLM function instead:
-
-          config :arcana, llm: {MyApp.LLM, :complete}
-      """
-    end
-  end
-
-  defimpl Arcana.LLM, for: Tuple do
-    def complete({model, llm_opts}, prompt, context, opts) when is_list(llm_opts) do
-      Arcana.LLM.complete(model, prompt, context, Keyword.merge(llm_opts, opts))
-    end
   end
 end

--- a/lib/arcana/llm.ex
+++ b/lib/arcana/llm.ex
@@ -11,8 +11,8 @@ defprotocol Arcana.LLM do
   - Anonymous functions (for testing)
 
   Prefer the `{module, function}` form for `config :arcana, :llm` — unlike
-  a captured function, it serializes into a release's `sys.config`, so it
-  doesn't have to be wired in `runtime.exs`.
+  a captured function, it serializes into a release's `sys.config`, and it
+  works without req_llm.
 
   ## Examples
 

--- a/lib/arcana/llm.ex
+++ b/lib/arcana/llm.ex
@@ -161,4 +161,27 @@ defimpl Arcana.LLM, for: Tuple do
   def complete({model, llm_opts}, prompt, context, opts) when is_list(llm_opts) do
     Arcana.LLM.complete(model, prompt, context, Keyword.merge(llm_opts, opts))
   end
+else
+  defimpl Arcana.LLM, for: BitString do
+    def complete(model, _prompt, _context, _opts) do
+      raise """
+      req_llm is required to use model strings like #{inspect(model)} as
+      the LLM but not available.
+
+      Add it to your dependencies:
+
+          {:req_llm, "~> 1.2"}
+
+      Or configure a custom LLM function instead:
+
+          config :arcana, llm: {MyApp.LLM, :complete}
+      """
+    end
+  end
+
+  defimpl Arcana.LLM, for: Tuple do
+    def complete({model, llm_opts}, prompt, context, opts) when is_list(llm_opts) do
+      Arcana.LLM.complete(model, prompt, context, Keyword.merge(llm_opts, opts))
+    end
+  end
 end

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -64,6 +64,16 @@ defmodule Arcana.Loop do
   alias Arcana.Loop.{Context, SystemPrompt, Tools}
   alias ReqLLM.Message.ContentPart
 
+  @compile {:no_warn_undefined,
+            [
+              ReqLLM,
+              ReqLLM.Context,
+              ReqLLM.Message,
+              ReqLLM.Message.ContentPart,
+              ReqLLM.Response,
+              ReqLLM.ToolCall
+            ]}
+
   @doc """
   Builds a new `Arcana.Loop.Context` for `run/2`.
 
@@ -164,6 +174,16 @@ defmodule Arcana.Loop do
   """
   @spec run(Context.t(), keyword()) :: {:ok, Context.t()}
   def run(%Context{} = ctx, opts \\ []) do
+    unless Code.ensure_loaded?(ReqLLM) do
+      raise """
+      req_llm is required for Arcana.Loop but not available.
+
+      Add it to your dependencies:
+
+          {:req_llm, "~> 1.2"}
+      """
+    end
+
     opts = Arcana.Config.merge_app_opts(opts, :loop)
 
     tools = Keyword.get(opts, :tools) || Tools.default(ctx.collections)
@@ -684,15 +704,18 @@ defmodule Arcana.Loop do
 
     canonical_tool_calls = Enum.map(tool_calls, &to_canonical_tool_call/1)
 
-    msg = %ReqLLM.Message{
-      role: :assistant,
-      content: content,
-      name: nil,
-      tool_call_id: nil,
-      tool_calls: canonical_tool_calls,
-      metadata: %{},
-      reasoning_details: nil
-    }
+    # struct!/2 instead of a struct literal so this module compiles when
+    # req_llm (optional dep) is absent; run/2 guards against that upfront.
+    msg =
+      struct!(ReqLLM.Message,
+        role: :assistant,
+        content: content,
+        name: nil,
+        tool_call_id: nil,
+        tool_calls: canonical_tool_calls,
+        metadata: %{},
+        reasoning_details: nil
+      )
 
     ReqLLM.Context.append(messages, msg)
   end

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -727,7 +727,7 @@ defmodule Arcana.Loop do
     args_json =
       cond do
         is_binary(args) -> args
-        is_map(args) -> Jason.encode!(args)
+        is_map(args) -> JSON.encode!(args)
         true -> "{}"
       end
 

--- a/lib/arcana/loop/tools.ex
+++ b/lib/arcana/loop/tools.ex
@@ -50,6 +50,8 @@ defmodule Arcana.Loop.Tools do
   alias Arcana.Loop.Context
   alias ReqLLM.Tool
 
+  @compile {:no_warn_undefined, ReqLLM.Tool}
+
   @no_op_callback {__MODULE__, :no_op_callback}
 
   @doc """

--- a/lib/arcana/pipeline.ex
+++ b/lib/arcana/pipeline.ex
@@ -187,7 +187,7 @@ defmodule Arcana.Pipeline do
   end
 
   defp parse_gate_response(response) do
-    case Jason.decode(response) do
+    case JSON.decode(response) do
       {:ok, %{"needs_retrieval" => needs_retrieval, "reasoning" => reasoning}} ->
         {not needs_retrieval, reasoning}
 
@@ -795,7 +795,7 @@ defmodule Arcana.Pipeline do
   end
 
   defp parse_sufficiency_response(response) do
-    case Jason.decode(response) do
+    case JSON.decode(response) do
       {:ok, %{"sufficient" => true, "reasoning" => reasoning}} ->
         {:sufficient, reasoning}
 
@@ -1181,7 +1181,7 @@ defmodule Arcana.Pipeline do
   end
 
   defp parse_evaluation_response(response) do
-    case Jason.decode(response) do
+    case JSON.decode(response) do
       {:ok, %{"grounded" => true}} ->
         {:ok, :grounded}
 

--- a/lib/arcana/reranker/cross_encoder.ex
+++ b/lib/arcana/reranker/cross_encoder.ex
@@ -40,6 +40,8 @@ defmodule Arcana.Reranker.CrossEncoder do
 
   use GenServer
 
+  @compile {:no_warn_undefined, Bumblebee}
+
   @default_model "cross-encoder/ms-marco-MiniLM-L-6-v2"
 
   def start_link(opts \\ []) do
@@ -48,6 +50,17 @@ defmodule Arcana.Reranker.CrossEncoder do
 
   @impl GenServer
   def init(opts) do
+    unless Code.ensure_loaded?(Bumblebee) do
+      raise """
+      Bumblebee is required for Arcana.Reranker.CrossEncoder but not available.
+
+      Add it and a backend to your dependencies:
+
+          {:bumblebee, "~> 0.6"},
+          {:exla, "~> 0.10"}
+      """
+    end
+
     model = Keyword.get(opts, :model, @default_model)
     sequence_length = Keyword.get(opts, :sequence_length, 512)
 

--- a/lib/arcana/reranker/cross_encoder.ex
+++ b/lib/arcana/reranker/cross_encoder.ex
@@ -40,7 +40,7 @@ defmodule Arcana.Reranker.CrossEncoder do
 
   use GenServer
 
-  @compile {:no_warn_undefined, Bumblebee}
+  @compile {:no_warn_undefined, [Bumblebee, Axon]}
 
   @default_model "cross-encoder/ms-marco-MiniLM-L-6-v2"
 

--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule Arcana.MixProject do
       {:ecto_sql, "~> 3.12"},
       {:postgrex, "~> 0.19"},
       {:pgvector, "~> 0.3"},
-      {:bumblebee, "~> 0.6"},
+      {:bumblebee, "~> 0.6", optional: true},
       {:nx, "~> 0.9"},
       {:exla, "~> 0.10", optional: true},
       {:emlx, "~> 0.2", optional: true},
@@ -93,7 +93,7 @@ defmodule Arcana.MixProject do
       {:igniter, "~> 0.5", optional: true},
 
       # LLM integrations via Req.LLM
-      {:req_llm, "~> 1.2"},
+      {:req_llm, "~> 1.2", optional: true},
 
       # Optional: In-memory vector store with HNSW
       {:hnswlib, "~> 0.1", optional: true},


### PR DESCRIPTION
apps that bring their own embedder (the `Arcana.Embedder` behaviour) and their own `:llm` never execute either dep, but carried ~13 transitive packages including the tokenizers Rust NIF into every build. Both are optional now, following the pattern exla already uses.

**Clear errors instead of UndefinedFunctionError** on every path that needs them:
- `Arcana.Embedder.Local` (plus `Embeddings.Serving`, the NER serving, and the CrossEncoder reranker) raise pointing at `{:bumblebee, ...}` + a backend, or at configuring a custom embedder
- model strings as the LLM raise pointing at `{:req_llm, ...}` via a fallback `Arcana.LLM` BitString impl, suggesting the `{module, function}` config alternative
- `Arcana.Loop.run/2` raises upfront (its `%ReqLLM.Message{}` struct literal became `struct!/2` so the module still compiles without the dep)

**Jason is gone too:** it was never declared in mix.exs and only rode in transitively via req_llm, so making req_llm optional would have crashed 9 call sites (pipeline JSON parsing, loop tool args, graph extractors, llm judge). All swapped to Elixir 1.18's built-in `JSON`, which arcana already used in five other files anyway.

**Verified in a real host app** with arcana as the only dep (plus phoenix_live_view): bumblebee/req_llm/tokenizers/jason absent from `mix deps.tree`, zero undefined-function warnings in the arcana compile (the only remaining ones are the pre-existing MDEx/Hallmark ones for deps that were already optional), and all three runtime probes raise the friendly messages.

found while verifying, not addressed here: `phoenix_live_view`/`phoenix_html` are declared optional on main, but `lib/arcana_web/assets.ex` reads their files at compile time and the arcana_web modules `use Phoenix.LiveView` unguarded, so a host without phoenix can't compile arcana at all. That's pre-existing and deserves its own issue.

heads up for merge order: this overlaps with #103 in `lib/arcana/llm.ex` and `lib/arcana/loop.ex` (both mine, I'll rebase whichever lands second) and with the dependabot req_llm bump #92 in mix.exs.

Closes #99

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `bumblebee` and `req_llm` optional to keep host builds lean and replace `Jason` with Elixir’s `JSON`. Previously both deps were required and leaked ~13 transitives; now Arcana compiles without them using no-warn guards and raises clear runtime errors only on paths that need them. `Arcana.LLM` supports `{module, function}` and works without `req_llm`; using model strings or `Arcana.Loop` raises actionable messages if `req_llm` is missing.

- Added `@compile {:no_warn_undefined, ...}` and upfront checks in the local embedder, embeddings/NER serving, cross-encoder reranker, and LLM judge; `Arcana.Loop` uses `struct!/2` to avoid compile-time coupling to `ReqLLM`. Replaced `Jason` with `JSON` across pipelines, graph extractors, loop tools, and the judge. Guides now show `{:arcana, "~> 2.0"}` and document optional deps.

**Migration**
- To use the default local embedder, NER, embeddings serving, or the cross-encoder reranker, add `{:bumblebee, "~> 0.6"}` and a backend like `{:exla, "~> 0.10"}`.
- To use model strings (for example, "openai:gpt-4o-mini") or `Arcana.Loop`, add `{:req_llm, "~> 1.2"}`; otherwise set `config :arcana, llm: {MyApp.LLM, :complete}`.
- Elixir 1.18+ is required due to `JSON`.

<sup>Written for commit 7222efe0911ba55fd0866820367eff55d828e11c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

