### PR TITLE
fix: Compile without phoenix, gating the dashboard behind LiveView

### DIFF
--- a/guides/dashboard.md
+++ b/guides/dashboard.md
@@ -4,6 +4,19 @@ A web UI for managing documents and testing search. The dashboard consists of mu
 
 ## Setup
 
+### 0. Add the phoenix dependencies
+
+Phoenix is an optional dependency: arcana's RAG core works in any app, and
+only the dashboard needs it. Phoenix apps already have these; otherwise add:
+
+```elixir
+{:phoenix_live_view, "~> 1.0"},
+{:phoenix_html, "~> 4.1"}
+```
+
+If arcana was compiled before these were added, force a recompile once:
+`mix deps.compile arcana --force`.
+
 ### 1. Add TaskSupervisor to your supervision tree
 
 The dashboard requires `ArcanaWeb.TaskSupervisor` for async operations (Ask, Maintenance):

--- a/lib/arcana_web/assets.ex
+++ b/lib/arcana_web/assets.ex
@@ -1,3833 +1,3838 @@
-defmodule ArcanaWeb.Assets do
-  @moduledoc false
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  @behaviour Plug
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.Assets do
+    @moduledoc false
 
-  # Bundle Phoenix LiveView JavaScript at compile time
-  @external_resource phoenix_js = Application.app_dir(:phoenix, "priv/static/phoenix.min.js")
-  @external_resource phoenix_html_js =
-                       Application.app_dir(:phoenix_html, "priv/static/phoenix_html.js")
-  @external_resource live_view_js =
-                       Application.app_dir(
-                         :phoenix_live_view,
-                         "priv/static/phoenix_live_view.min.js"
-                       )
+    @behaviour Plug
 
-  @phoenix_js File.read!(phoenix_js)
-  @phoenix_html_js File.read!(phoenix_html_js)
-  @live_view_js File.read!(live_view_js)
+    # Bundle Phoenix LiveView JavaScript at compile time
+    @external_resource phoenix_js = Application.app_dir(:phoenix, "priv/static/phoenix.min.js")
+    @external_resource phoenix_html_js =
+                         Application.app_dir(:phoenix_html, "priv/static/phoenix_html.js")
+    @external_resource live_view_js =
+                         Application.app_dir(
+                           :phoenix_live_view,
+                           "priv/static/phoenix_live_view.min.js"
+                         )
 
-  @app_js """
-  // CmdEnterSubmit: when the user presses Cmd+Enter (or Ctrl+Enter on
-  // non-mac) inside the bound element (typically a textarea), find the
-  // closest form and submit it. Used by the Ask page so the user can
-  // submit a question without reaching for the mouse.
-  let Hooks = {
-    CmdEnterSubmit: {
-      mounted() {
-        this.handler = (e) => {
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-            e.preventDefault()
-            const form = this.el.closest("form")
-            if (form) {
-              form.dispatchEvent(new Event("submit", {bubbles: true, cancelable: true}))
+    @phoenix_js File.read!(phoenix_js)
+    @phoenix_html_js File.read!(phoenix_html_js)
+    @live_view_js File.read!(live_view_js)
+
+    @app_js """
+    // CmdEnterSubmit: when the user presses Cmd+Enter (or Ctrl+Enter on
+    // non-mac) inside the bound element (typically a textarea), find the
+    // closest form and submit it. Used by the Ask page so the user can
+    // submit a question without reaching for the mouse.
+    let Hooks = {
+      CmdEnterSubmit: {
+        mounted() {
+          this.handler = (e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault()
+              const form = this.el.closest("form")
+              if (form) {
+                form.dispatchEvent(new Event("submit", {bubbles: true, cancelable: true}))
+              }
             }
           }
+          this.el.addEventListener("keydown", this.handler)
+        },
+        destroyed() {
+          this.el.removeEventListener("keydown", this.handler)
         }
-        this.el.addEventListener("keydown", this.handler)
-      },
-      destroyed() {
-        this.el.removeEventListener("keydown", this.handler)
       }
     }
-  }
 
-  let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket, {hooks: Hooks})
-  liveSocket.connect()
-  window.liveSocket = liveSocket
-  """
-
-  @js [@phoenix_js, @phoenix_html_js, @live_view_js, @app_js] |> Enum.join("\n")
-  @js_hash :crypto.hash(:md5, @js) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-
-  @css """
-  .arcana-dashboard {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 1.5rem;
-    color: #1f2937;
-  }
-
-  .arcana-tabs {
-    display: flex;
-    gap: 0.5rem;
-    border-bottom: 2px solid #e5e7eb;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-tab {
-    padding: 0.75rem 1.5rem;
-    border: none;
-    background: transparent;
-    font-size: 1rem;
-    font-weight: 500;
-    color: #6b7280;
-    cursor: pointer;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -2px;
-    transition: all 0.15s ease;
-    text-decoration: none;
-  }
-
-  .arcana-tab:hover {
-    color: #7c3aed;
-  }
-
-  .arcana-tab.active {
-    color: #7c3aed;
-    border-bottom-color: #7c3aed;
-  }
-
-  .arcana-dashboard h2 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: #111827;
-    margin: 0 0 1rem 0;
-  }
-
-  .arcana-ingest-form,
-  .arcana-search-form {
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 1rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-ingest-form textarea,
-  .arcana-search-form input[type="text"] {
-    width: 100%;
-    padding: 0.75rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    margin-bottom: 0.75rem;
-    box-sizing: border-box;
-  }
-
-  .arcana-ingest-form textarea:focus,
-  .arcana-search-form input:focus,
-  .arcana-search-form select:focus {
-    outline: none;
-    border-color: #7c3aed;
-    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
-  }
-
-  .arcana-search-options {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-    margin-bottom: 0.75rem;
-  }
-
-  .arcana-search-options label {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: #6b7280;
-  }
-
-  .arcana-search-options select,
-  .arcana-search-options input[type="number"] {
-    padding: 0.5rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    min-width: 100px;
-  }
-
-  .arcana-ingest-form button,
-  .arcana-search-form button {
-    background: #7c3aed;
-    color: white;
-    padding: 0.625rem 1.25rem;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background-color 0.15s ease;
-  }
-
-  .arcana-ingest-form button:hover,
-  .arcana-search-form button:hover {
-    background: #6d28d9;
-  }
-
-  .arcana-ingest-options {
-    display: flex;
-    gap: 1rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .arcana-ingest-options label {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: #6b7280;
-  }
-
-  .arcana-ingest-options select {
-    padding: 0.5rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    min-width: 120px;
-  }
-
-  .arcana-ingest-options select:focus {
-    outline: none;
-    border-color: #7c3aed;
-    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
-  }
-
-  .arcana-empty {
-    color: #6b7280;
-    font-style: italic;
-    padding: 2rem;
-    text-align: center;
-    background: #f9fafb;
-    border-radius: 0.5rem;
-  }
-
-  .arcana-documents-table,
-  .arcana-results-table,
-  .arcana-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.875rem;
-  }
-
-  .arcana-documents-table th,
-  .arcana-results-table th,
-  .arcana-table th {
-    text-align: left;
-    padding: 0.75rem;
-    background: #f3f4f6;
-    border-bottom: 2px solid #e5e7eb;
-    font-weight: 600;
-    color: #374151;
-  }
-
-  .arcana-documents-table td,
-  .arcana-results-table td,
-  .arcana-table td {
-    padding: 0.75rem;
-    border-bottom: 1px solid #e5e7eb;
-    vertical-align: middle;
-  }
-
-  .arcana-documents-table td:nth-child(1) {
-    max-width: 120px;
-    word-break: break-all;
-  }
-
-  .arcana-documents-table td:nth-child(2) {
-    max-width: 300px;
-  }
-
-  .arcana-documents-table td:nth-child(5),
-  .arcana-documents-table td:nth-child(6),
-  .arcana-documents-table td:nth-child(7) {
-    white-space: nowrap;
-  }
-
-  .arcana-documents-table tr:hover,
-  .arcana-results-table tr:hover,
-  .arcana-table tr:hover {
-    background: #f9fafb;
-  }
-
-  .arcana-documents-table code,
-  .arcana-results-table code,
-  .arcana-table code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
-    font-size: 0.75rem;
-    background: #ede9fe;
-    color: #6d28d9;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-  }
-
-  .arcana-metadata {
-    font-size: 0.75rem;
-    color: #6b7280;
-    max-width: 200px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .arcana-stats {
-    display: flex;
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-    padding: 1rem;
-    background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
-    border-radius: 0.5rem;
-    color: white;
-    align-items: center;
-  }
-
-  .arcana-brand {
-    font-size: 1.5rem;
-    font-weight: 700;
-    letter-spacing: -0.025em;
-    padding-right: 1.5rem;
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
-    margin-right: 0.5rem;
-    display: flex;
-    align-items: center;
-    align-self: center;
-  }
-
-  .arcana-stat {
-    text-align: center;
-  }
-
-  .arcana-stat-value {
-    font-size: 1.5rem;
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
-    letter-spacing: -0.01em;
-  }
-
-  .arcana-stat-label {
-    font-size: 0.75rem;
-    opacity: 0.9;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-  .arcana-stat-divider {
-    width: 1px;
-    height: 2rem;
-    background: rgba(255, 255, 255, 0.3);
-    margin: 0 0.5rem;
-  }
-
-  .arcana-pagination {
-    display: flex;
-    gap: 0.375rem;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid #e5e7eb;
-  }
-
-  .arcana-page-btn {
-    padding: 0.5rem 0.75rem;
-    min-width: 2.5rem;
-    border: 1px solid #d1d5db;
-    background: white;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-variant-numeric: tabular-nums;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-page-btn:hover:not(:disabled) {
-    border-color: #7c3aed;
-    color: #7c3aed;
-  }
-
-  .arcana-page-btn.active {
-    background: #7c3aed;
-    border-color: #7c3aed;
-    color: white;
-  }
-
-  .arcana-page-btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .arcana-page-ellipsis {
-    padding: 0.5rem 0.25rem;
-    color: #9ca3af;
-    font-size: 0.875rem;
-    user-select: none;
-  }
-
-  .arcana-view-btn {
-    background: transparent;
-    color: #7c3aed;
-    border: 1px solid #7c3aed;
-  }
-
-  .arcana-view-btn:hover {
-    background: #7c3aed;
-    color: white;
-  }
-
-  .arcana-filter-bar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    padding: 0.75rem 1rem;
-    background: #f3f4f6;
-    border-radius: 0.5rem;
-    margin-bottom: 1rem;
-  }
-
-  .arcana-filter-label {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: #6b7280;
-    margin-right: 0.5rem;
-  }
-
-  .arcana-filter-btn {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
-    border: 1px solid #d1d5db;
-    border-radius: 9999px;
-    background: white;
-    color: #374151;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-filter-btn:hover {
-    border-color: #7c3aed;
-    color: #7c3aed;
-  }
-
-  .arcana-filter-btn.active {
-    background: #7c3aed;
-    border-color: #7c3aed;
-    color: white;
-  }
-
-  .arcana-filter-clear {
-    background: #fef2f2;
-    border-color: #fecaca;
-    color: #dc2626;
-  }
-
-  .arcana-filter-clear:hover {
-    background: #fee2e2;
-    border-color: #dc2626;
-  }
-
-  .arcana-doc-detail {
-    /* No background - inherits from page */
-  }
-
-  .arcana-doc-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-doc-header h2 {
-    margin: 0;
-  }
-
-  .arcana-close-btn {
-    background: transparent;
-    color: #6b7280;
-    border: 1px solid #d1d5db;
-    padding: 0.5rem 1rem;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    text-decoration: none;
-  }
-
-  .arcana-close-btn:hover {
-    border-color: #7c3aed;
-    color: #7c3aed;
-  }
-
-  .arcana-doc-info {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    padding: 1rem;
-    border-radius: 0.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-doc-field label {
-    display: block;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: #6b7280;
-    margin-bottom: 0.25rem;
-  }
-
-  .arcana-doc-section {
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-doc-section h3 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: #374151;
-    margin: 0 0 0.75rem 0;
-  }
-
-  .arcana-doc-content {
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    padding: 1rem;
-    border-radius: 0.5rem;
-    font-size: 0.875rem;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    margin: 0;
-    max-height: 300px;
-    overflow-y: auto;
-  }
-
-  /* Info page grid layout */
-  .arcana-info-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-info-section {
-    background: #ffffff;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 1rem;
-  }
-
-  .arcana-info-section h3 {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #7c3aed;
-    margin: 0 0 0.75rem 0;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid #f3e8ff;
-  }
-
-  .arcana-info-section .arcana-doc-info {
-    margin-bottom: 0;
-    background: transparent;
-    border: none;
-    padding: 0;
-  }
-
-  .arcana-info-full {
-    grid-column: 1 / -1;
-  }
-
-  .arcana-not-configured {
-    color: #9ca3af;
-  }
-
-  .arcana-status-badge {
-    display: inline-block;
-    padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 500;
-  }
-
-  .arcana-status-badge.enabled {
-    background: #d1fae5;
-    color: #065f46;
-  }
-
-  .arcana-status-badge.disabled {
-    background: #f3f4f6;
-    color: #6b7280;
-  }
-
-  /* Maintenance page styles */
-  .arcana-maintenance-section {
-    background: #ffffff;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 1.25rem;
-    margin-bottom: 2rem;
-  }
-
-  .arcana-maintenance-section h3 {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #7c3aed;
-    margin: 0 0 0.75rem 0;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid #f3e8ff;
-  }
-
-  .arcana-maintenance-section .arcana-doc-info {
-    margin-bottom: 0;
-    background: transparent;
-    border: none;
-    padding: 0;
-  }
-
-  .arcana-orphan-section {
-    background: #fef3c7;
-    border-color: #f59e0b;
-  }
-  .arcana-orphan-section h3 {
-    color: #b45309;
-    border-bottom-color: #fcd34d;
-  }
-  .arcana-orphan-count {
-    font-weight: 600;
-    color: #b45309;
-  }
-
-  .arcana-chunks-list {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .arcana-chunk {
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    overflow: hidden;
-  }
-
-  .arcana-chunk-header {
-    display: flex;
-    justify-content: space-between;
-    padding: 0.5rem 1rem;
-    background: #f3f4f6;
-    font-size: 0.75rem;
-    font-weight: 500;
-  }
-
-  .arcana-chunk-index {
-    color: #7c3aed;
-  }
-
-  .arcana-chunk-tokens {
-    color: #6b7280;
-  }
-
-  .arcana-chunk-text {
-    padding: 1rem;
-    margin: 0;
-    font-size: 0.875rem;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    background: #f9fafb;
-  }
-
-  .arcana-btn {
-    background: transparent;
-    color: #374151;
-    border: 1px solid #d1d5db;
-    padding: 0.375rem 0.75rem;
-    border-radius: 0.25rem;
-    font-size: 0.75rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-btn:hover {
-    border-color: #7c3aed;
-    color: #7c3aed;
-  }
-
-  .arcana-btn-primary {
-    background: #7c3aed;
-    color: white;
-    border-color: #7c3aed;
-  }
-
-  .arcana-btn-primary:hover {
-    background: #6d28d9;
-    border-color: #6d28d9;
-    color: white;
-  }
-
-  .arcana-btn-danger {
-    background: transparent;
-    color: #dc2626;
-    border-color: #dc2626;
-  }
-
-  .arcana-btn-danger:hover {
-    background: #dc2626;
-    color: white;
-  }
-
-  .arcana-form-row {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
-  .arcana-input {
-    padding: 0.5rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-  }
-
-  .arcana-input:focus {
-    outline: none;
-    border-color: #7c3aed;
-    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
-  }
-
-  .arcana-confirm-delete {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-
-  .arcana-confirm-delete span {
-    font-size: 0.75rem;
-    color: #dc2626;
-    font-weight: 500;
-  }
-
-  /* Evaluation styles */
-  .arcana-eval-nav {
-    display: flex;
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-    border-bottom: 1px solid #e5e7eb;
-  }
-
-  .arcana-eval-nav-btn {
-    position: relative;
-    padding: 0.625rem 0;
-    border: none;
-    background: transparent;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    color: #6b7280;
-    cursor: pointer;
-    transition: color 0.15s ease;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -1px;
-  }
-
-  .arcana-eval-nav-btn:hover {
-    color: #7c3aed;
-  }
-
-  .arcana-eval-nav-btn.active {
-    color: #7c3aed;
-    border-bottom-color: #7c3aed;
-    font-weight: 600;
-  }
-
-  .arcana-eval-message {
-    padding: 0.75rem 1rem;
-    border-radius: 0.375rem;
-    margin-bottom: 1rem;
-    font-size: 0.875rem;
-  }
-
-  .arcana-eval-message.success {
-    background: #d1fae5;
-    color: #065f46;
-    border: 1px solid #a7f3d0;
-  }
-
-  .arcana-eval-message.error {
-    background: #fee2e2;
-    color: #991b1b;
-    border: 1px solid #fecaca;
-  }
-
-  /* Evaluation run form: vertical stack of sections, radio cards for
-     retriever, options row for mode + evaluate_answers toggle, a
-     prominent Run Evaluation button bottom-right. Replaces the old
-     flex-end one-liner that smushed inputs of different heights next
-     to each other. */
-  .arcana-eval-run-intro {
-    margin: 0 0 1.25rem;
-    color: #4b5563;
-    font-size: 0.9375rem;
-  }
-
-  .arcana-eval-run-intro strong {
-    color: #111827;
-    font-weight: 600;
-  }
-
-  .arcana-eval-run-form {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.75rem;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-eval-field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .arcana-eval-field-label {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #374151;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin: 0;
-  }
-
-  .arcana-eval-hint {
-    font-size: 0.75rem;
-    color: #6b7280;
-    line-height: 1.4;
-  }
-
-  .arcana-eval-option-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.75rem;
-  }
-
-  .arcana-eval-option-card {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-    padding: 1rem 1rem 1rem 1rem;
-    background: #fafafa;
-    border: 2px solid #e5e7eb;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-eval-option-card input[type="radio"] {
-    position: absolute;
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  .arcana-eval-option-card:hover {
-    border-color: #c4b5fd;
-    background: #faf5ff;
-  }
-
-  .arcana-eval-option-card:has(input:checked) {
-    border-color: #7c3aed;
-    background: #ede9fe;
-  }
-
-  .arcana-eval-option-card:has(input:checked) .arcana-eval-option-title {
-    color: #6d28d9;
-  }
-
-  .arcana-eval-option-title {
-    font-size: 0.9375rem;
-    font-weight: 600;
-    color: #111827;
-  }
-
-  .arcana-eval-option-desc {
-    font-size: 0.8125rem;
-    color: #6b7280;
-    line-height: 1.4;
-  }
-
-  .arcana-eval-option-desc code {
-    font-size: 0.75rem;
-    padding: 0.0625rem 0.25rem;
-    background: #f3f4f6;
-    border-radius: 0.1875rem;
-    color: #374151;
-  }
-
-  .arcana-eval-options-row {
-    display: grid;
-    grid-template-columns: minmax(0, 240px) minmax(0, 1fr);
-    gap: 1.5rem;
-    align-items: start;
-  }
-
-  .arcana-eval-select {
-    padding: 0.5rem 0.75rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    background: white;
-    color: #111827;
-  }
-
-  .arcana-eval-toggle {
-    position: relative;
-    display: flex;
-    align-items: flex-start;
-    gap: 0.625rem;
-    padding: 0.75rem 1rem;
-    background: #fafafa;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-eval-toggle input[type="checkbox"] {
-    position: absolute;
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  .arcana-eval-toggle-indicator {
-    flex-shrink: 0;
-    width: 1rem;
-    height: 1rem;
-    margin-top: 0.125rem;
-    border: 2px solid #9ca3af;
-    border-radius: 0.25rem;
-    background: white;
-    transition: all 0.15s ease;
-    position: relative;
-  }
-
-  .arcana-eval-toggle:has(input:checked) {
-    border-color: #7c3aed;
-    background: #ede9fe;
-  }
-
-  .arcana-eval-toggle:has(input:checked) .arcana-eval-toggle-indicator {
-    border-color: #7c3aed;
-    background: #7c3aed;
-  }
-
-  .arcana-eval-toggle:has(input:checked) .arcana-eval-toggle-indicator::after {
-    content: "";
-    position: absolute;
-    left: 3px;
-    top: 0px;
-    width: 4px;
-    height: 8px;
-    border: solid white;
-    border-width: 0 2px 2px 0;
-    transform: rotate(45deg);
-  }
-
-  .arcana-eval-toggle-content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-
-  .arcana-eval-toggle-title {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #111827;
-  }
-
-  .arcana-eval-actions {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-    border-top: 1px solid #f3f4f6;
-    padding-top: 1.25rem;
-    margin-top: 0.25rem;
-  }
-
-  .arcana-eval-progress {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-    min-width: 0;
-  }
-
-  .arcana-eval-progress-label {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.8125rem;
-    color: #4b5563;
-  }
-
-  .arcana-eval-progress-elapsed {
-    color: #6b7280;
-    font-variant-numeric: tabular-nums;
-  }
-
-  .arcana-eval-progress-bar {
-    height: 6px;
-    background: #ede9fe;
-    border-radius: 3px;
-    overflow: hidden;
-  }
-
-  .arcana-eval-progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #8b5cf6, #7c3aed);
-    border-radius: 3px;
-    transition: width 0.3s ease;
-  }
-
-  .arcana-eval-progress-current {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.8125rem;
-    color: #6d28d9;
-    margin-top: 0.125rem;
-  }
-
-  .arcana-eval-progress-current-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    min-width: 0;
-  }
-
-  .arcana-eval-progress-spinner {
-    display: inline-block;
-    width: 0.75rem;
-    height: 0.75rem;
-    border: 2px solid #ede9fe;
-    border-top-color: #7c3aed;
-    border-radius: 50%;
-    flex-shrink: 0;
-    animation: arcana-eval-spin 0.8s linear infinite;
-  }
-
-  @keyframes arcana-eval-spin {
-    to { transform: rotate(360deg); }
-  }
-
-  .arcana-eval-run-btn {
-    background: #7c3aed;
-    color: white;
-    padding: 0.625rem 1.5rem;
-    border: none;
-    border-radius: 0.5rem;
-    font-size: 0.9375rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background-color 0.15s ease;
-  }
-
-  .arcana-eval-run-btn:hover:not(:disabled) {
-    background: #6d28d9;
-  }
-
-  .arcana-eval-run-btn:disabled {
-    background: #9ca3af;
-    cursor: not-allowed;
-    opacity: 0.7;
-  }
-
-  @media (max-width: 640px) {
-    .arcana-eval-option-grid,
-    .arcana-eval-options-row {
-      grid-template-columns: 1fr;
+    let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket, {hooks: Hooks})
+    liveSocket.connect()
+    window.liveSocket = liveSocket
+    """
+
+    @js [@phoenix_js, @phoenix_html_js, @live_view_js, @app_js] |> Enum.join("\n")
+    @js_hash :crypto.hash(:md5, @js) |> Base.encode16(case: :lower) |> binary_part(0, 8)
+
+    @css """
+    .arcana-dashboard {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1.5rem;
+      color: #1f2937;
     }
-  }
 
-  .arcana-metrics-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-metric-card {
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 1rem;
-    text-align: center;
-  }
-
-  .arcana-metric-value {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #7c3aed;
-  }
-
-  .arcana-metric-label {
-    font-size: 0.75rem;
-    color: #6b7280;
-    margin-top: 0.25rem;
-  }
-
-  /* Empty state for the test cases view when no test cases exist. */
-  .arcana-eval-empty-state {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 3rem 1rem;
-    background: #fafafa;
-    border: 1px dashed #d1d5db;
-    border-radius: 0.75rem;
-    text-align: center;
-    color: #6b7280;
-  }
-
-  .arcana-eval-empty-state h4 {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-    color: #374151;
-  }
-
-  .arcana-eval-empty-state p {
-    margin: 0;
-    font-size: 0.875rem;
-  }
-
-  .arcana-eval-empty-state code {
-    background: #f3f4f6;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    font-size: 0.8125rem;
-  }
-
-  .arcana-eval-empty-icon {
-    font-size: 2.5rem;
-    color: #d1d5db;
-    line-height: 1;
-  }
-
-  /* Test case list: compact rows that expand on click to show the
-     reference answer (when present) and the relevant chunks. */
-  .arcana-test-case-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-    margin-top: 1.5rem;
-  }
-
-  .arcana-test-case {
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    overflow: hidden;
-    transition: border-color 0.15s ease;
-  }
-
-  .arcana-test-case.expanded {
-    border-color: #c4b5fd;
-  }
-
-  .arcana-test-case-row {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.625rem 0.875rem;
-  }
-
-  .arcana-test-case-row-main {
-    display: grid;
-    grid-template-columns: auto 1fr auto auto auto;
-    align-items: center;
-    gap: 0.75rem;
-    flex: 1;
-    min-width: 0;
-    cursor: pointer;
-    padding: 0.125rem 0;
-    border-radius: 0.25rem;
-    transition: background-color 0.15s ease;
-  }
-
-  .arcana-test-case-row-main:hover {
-    background: #fafafa;
-  }
-
-  .arcana-test-case.expanded .arcana-test-case-row {
-    background: #faf5ff;
-    border-bottom: 1px solid #ede9fe;
-  }
-
-  .arcana-test-case-chevron {
-    color: #9ca3af;
-    font-size: 0.75rem;
-    width: 0.75rem;
-    text-align: center;
-  }
-
-  .arcana-test-case-question {
-    font-size: 0.875rem;
-    color: #111827;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    min-width: 0;
-  }
-
-  .arcana-test-case-badge {
-    display: inline-block;
-    padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.02em;
-  }
-
-  .arcana-test-case-badge--generated {
-    background: #ede9fe;
-    color: #6d28d9;
-  }
-
-  .arcana-test-case-badge--synthetic {
-    background: #ede9fe;
-    color: #6d28d9;
-  }
-
-  .arcana-test-case-badge--manual {
-    background: #dbeafe;
-    color: #1d4ed8;
-  }
-
-  .arcana-test-case-chunks {
-    font-size: 0.75rem;
-    color: #6b7280;
-    white-space: nowrap;
-    font-variant-numeric: tabular-nums;
-  }
-
-  .arcana-test-case-time {
-    font-size: 0.75rem;
-    color: #9ca3af;
-    white-space: nowrap;
-    cursor: help;
-  }
-
-  .arcana-test-case-detail {
-    padding: 1rem 1rem 1.25rem 2rem;
-    background: #fafafa;
-  }
-
-  .arcana-test-case-detail-section {
-    margin-top: 0.75rem;
-  }
-
-  .arcana-test-case-detail-section:first-child {
-    margin-top: 0;
-  }
-
-  .arcana-test-case-detail-section h5 {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: #6d28d9;
-    margin: 0 0 0.375rem;
-  }
-
-  .arcana-test-case-detail-section p {
-    margin: 0;
-    font-size: 0.875rem;
-    color: #374151;
-    line-height: 1.5;
-  }
-
-  .arcana-test-case-chunk-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-  }
-
-  .arcana-test-case-chunk-list li {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 0.625rem;
-    align-items: baseline;
-    padding: 0.375rem 0.5rem;
-    background: white;
-    border-radius: 0.25rem;
-    border: 1px solid #f3f4f6;
-  }
-
-  .arcana-test-case-chunk-id {
-    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
-    font-size: 0.75rem;
-    color: #7c3aed;
-    padding: 0.0625rem 0.25rem;
-    background: #faf5ff;
-    border-radius: 0.1875rem;
-  }
-
-  .arcana-test-case-chunk-text {
-    font-size: 0.8125rem;
-    color: #4b5563;
-    line-height: 1.5;
-  }
-
-  .arcana-test-case-empty {
-    font-size: 0.875rem;
-    color: #9ca3af;
-    font-style: italic;
-  }
-
-  .arcana-actions-cell {
-    text-align: center;
-    white-space: nowrap;
-  }
-
-  .arcana-icon-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.375rem;
-    background: transparent;
-    color: #9ca3af;
-    border: none;
-    border-radius: 0.25rem;
-    cursor: pointer;
-  }
-
-  .arcana-icon-btn:hover {
-    color: #7c3aed;
-    background: #f3f4f6;
-  }
-
-  .arcana-delete-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.375rem;
-    background: transparent;
-    color: #9ca3af;
-    border: none;
-    border-radius: 0.25rem;
-    cursor: pointer;
-  }
-
-  .arcana-delete-btn:hover {
-    color: #dc2626;
-    background: #fef2f2;
-  }
-
-  .arcana-run-card {
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    margin-bottom: 1rem;
-    overflow: hidden;
-  }
-
-  .arcana-run-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.75rem 1rem;
-    background: #f3f4f6;
-    border-bottom: 1px solid #e5e7eb;
-  }
-
-  .arcana-run-header-left {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .arcana-run-status {
-    padding: 0.25rem 0.75rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 500;
-  }
-
-  .arcana-run-status.completed {
-    background: #d1fae5;
-    color: #065f46;
-  }
-
-  .arcana-run-status.running {
-    background: #fef3c7;
-    color: #92400e;
-  }
-
-  .arcana-run-status.failed {
-    background: #fee2e2;
-    color: #991b1b;
-  }
-
-  .arcana-run-body {
-    padding: 1rem;
-  }
-
-  .arcana-run-config {
-    font-size: 0.75rem;
-    color: #6b7280;
-    margin-bottom: 0.75rem;
-  }
-
-  /* Upload styles */
-  .arcana-dropzone {
-    position: relative;
-    border: 2px dashed #d1d5db;
-    border-radius: 0.5rem;
-    padding: 2rem;
-    text-align: center;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    margin-bottom: 1rem;
-  }
-
-  .arcana-dropzone:hover {
-    border-color: #7c3aed;
-    background: #f5f3ff;
-  }
-
-  .arcana-dropzone p {
-    margin: 0 0 0.5rem 0;
-    color: #374151;
-  }
-
-  .arcana-upload-hint {
-    font-size: 0.75rem;
-    color: #6b7280;
-  }
-
-  .arcana-file-input {
-    position: absolute;
-    inset: 0;
-    opacity: 0;
-    cursor: pointer;
-  }
-
-  .arcana-upload-entry {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.5rem;
-    background: #f9fafb;
-    border-radius: 0.375rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .arcana-upload-entry progress {
-    flex: 1;
-    height: 0.5rem;
-  }
-
-  .arcana-upload-entry button {
-    background: transparent;
-    border: none;
-    color: #dc2626;
-    cursor: pointer;
-    font-size: 1.25rem;
-  }
-
-  .arcana-upload-error {
-    color: #dc2626;
-    font-size: 0.75rem;
-  }
-
-  .arcana-upload-btn {
-    background: #7c3aed;
-    color: white;
-    padding: 0.625rem 1.25rem;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-  }
-
-  .arcana-upload-btn:hover {
-    background: #6d28d9;
-  }
-
-  .arcana-divider {
-    text-align: center;
-    color: #6b7280;
-    font-size: 0.875rem;
-    margin: 1.5rem 0;
-    position: relative;
-  }
-
-  .arcana-divider::before,
-  .arcana-divider::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    width: 40%;
-    height: 1px;
-    background: #e5e7eb;
-  }
-
-  .arcana-divider::before {
-    left: 0;
-  }
-
-  .arcana-divider::after {
-    right: 0;
-  }
-
-  /* Search Results Styles */
-  .arcana-search-results {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-
-  .arcana-search-result {
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    overflow: hidden;
-    background: white;
-  }
-
-  .arcana-result-header {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
-    background: #f9fafb;
-    border-bottom: 1px solid #e5e7eb;
-  }
-
-  .arcana-result-score {
-    min-width: 60px;
-  }
-
-  .arcana-result-score .score-value {
-    font-weight: 600;
-    color: #7c3aed;
-    font-size: 0.875rem;
-  }
-
-  .arcana-result-meta {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex: 1;
-  }
-
-  .arcana-result-meta code {
-    font-size: 0.7rem;
-  }
-
-  .arcana-chunk-badge {
-    background: #ede9fe;
-    color: #6d28d9;
-    padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 500;
-  }
-
-  .arcana-result-actions {
-    display: flex;
-    gap: 0.5rem;
-  }
-
-  .arcana-result-btn {
-    padding: 0.375rem 0.75rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    background: white;
-    font-size: 0.75rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-result-btn:hover {
-    border-color: #7c3aed;
-    color: #7c3aed;
-  }
-
-  .arcana-result-btn-primary {
-    background: #7c3aed;
-    border-color: #7c3aed;
-    color: white;
-  }
-
-  .arcana-result-btn-primary:hover {
-    background: #6d28d9;
-    border-color: #6d28d9;
-    color: white;
-  }
-
-  .arcana-result-text {
-    padding: 1rem;
-    font-size: 0.875rem;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    color: #374151;
-    max-height: 100px;
-    overflow: hidden;
-    position: relative;
-  }
-
-  .arcana-result-text.expanded {
-    max-height: none;
-    overflow: visible;
-  }
-
-  /* ChunkResultsComponent: grouped chunks with expandable details. */
-  .arcana-chunk-results {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-
-  .arcana-chunk-doc {
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    overflow: hidden;
-  }
-
-  .arcana-chunk-doc--has-source {
-    border-color: #a7f3d0;
-    box-shadow: 0 0 0 1px #a7f3d0 inset;
-  }
-
-  .arcana-chunk-doc-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.625rem 0.875rem;
-    background: #f9fafb;
-    border-bottom: 1px solid #e5e7eb;
-  }
-
-  .arcana-chunk-doc--has-source .arcana-chunk-doc-header {
-    background: #ecfdf5;
-    border-bottom-color: #a7f3d0;
-  }
-
-  .arcana-chunk-doc-title {
-    margin: 0;
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #111827;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    flex: 1;
-    min-width: 0;
-  }
-
-  .arcana-chunk-doc-link {
-    color: inherit;
-    text-decoration: none;
-    transition: color 0.15s ease;
-  }
-
-  .arcana-chunk-doc-link:hover {
-    color: #6d28d9;
-    text-decoration: underline;
-  }
-
-  .arcana-chunk-doc-meta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: 0.75rem;
-    color: #6b7280;
-    flex-shrink: 0;
-  }
-
-  .arcana-chunk-source-dot {
-    display: inline-block;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    background: #10b981;
-  }
-
-  .arcana-chunk-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .arcana-chunk-item {
-    border-top: 1px solid #f3f4f6;
-  }
-
-  .arcana-chunk-item:first-child {
-    border-top: none;
-  }
-
-  .arcana-chunk-item--source {
-    background: #f0fdf4;
-  }
-
-  .arcana-chunk-details {
-    width: 100%;
-  }
-
-  .arcana-chunk-summary {
-    display: flex;
-    align-items: center;
-    gap: 0.625rem;
-    padding: 0.5rem 0.875rem;
-    cursor: pointer;
-    list-style: none;
-    font-size: 0.8125rem;
-    line-height: 1.4;
-    user-select: none;
-  }
-
-  .arcana-chunk-summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .arcana-chunk-summary::before {
-    content: '▸';
-    color: #9ca3af;
-    font-size: 0.6875rem;
-    flex-shrink: 0;
-    transition: transform 0.15s ease;
-    display: inline-block;
-  }
-
-  .arcana-chunk-details[open] > .arcana-chunk-summary::before {
-    transform: rotate(90deg);
-  }
-
-  .arcana-chunk-summary:hover {
-    background: #f9fafb;
-  }
-
-  .arcana-chunk-item--source .arcana-chunk-summary:hover {
-    background: #dcfce7;
-  }
-
-  .arcana-chunk-score {
-    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    color: #6d28d9;
-    flex-shrink: 0;
-  }
-
-  .arcana-chunk-index {
-    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
-    font-size: 0.6875rem;
-    color: #9ca3af;
-    flex-shrink: 0;
-  }
-
-  .arcana-chunk-supports {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    color: #047857;
-    background: #d1fae5;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    flex-shrink: 0;
-  }
-
-  .arcana-chunk-via {
-    font-size: 0.6875rem;
-    color: #7c3aed;
-    background: #ede9fe;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    flex-shrink: 0;
-    max-width: 12rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .arcana-chunk-preview {
-    flex: 1;
-    min-width: 0;
-    color: #4b5563;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .arcana-chunk-full {
-    padding: 0.75rem 1rem 1rem 2.25rem;
-    font-size: 0.8125rem;
-    line-height: 1.55;
-    color: #1f2937;
-    white-space: pre-line;
-    border-top: 1px dashed #e5e7eb;
-  }
-
-  /* Collection checkboxes - shared between Search and Ask tabs */
-  .arcana-ask-collections {
-    margin: 1rem 0;
-  }
-
-  .arcana-ask-collections > label {
-    display: block;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: #374151;
-    margin-bottom: 0.5rem;
-  }
-
-  .arcana-llm-select-toggle {
-    margin-bottom: 0.75rem;
-    padding: 0.75rem;
-    background: #f5f3ff;
-    border: 1px solid #ddd6fe;
-    border-radius: 0.5rem;
-  }
-  .arcana-llm-select-toggle .arcana-checkbox-label {
-    margin: 0;
-  }
-
-  .arcana-collection-checkboxes {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  .arcana-collection-check {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.375rem 0.75rem;
-    background: white;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    font-size: 0.8125rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-collection-check:hover {
-    border-color: #7c3aed;
-    background: #faf5ff;
-  }
-
-  .arcana-collection-check:has(input:checked) {
-    border-color: #7c3aed;
-    background: #ede9fe;
-    color: #5b21b6;
-  }
-
-  .arcana-collection-check input {
-    accent-color: #7c3aed;
-  }
-
-  .arcana-collection-hint {
-    display: block;
-    margin-top: 0.375rem;
-    font-size: 0.75rem;
-    color: #6b7280;
-  }
-
-  /* Tab description */
-  .arcana-tab-description {
-    color: #6b7280;
-    margin-bottom: 1rem;
-    font-size: 0.875rem;
-  }
-
-  /* Ask tab styles */
-  .arcana-ask-mode-nav {
-    display: inline-flex;
-    background: #f3f4f6;
-    border-radius: 0.5rem;
-    padding: 0.25rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .arcana-mode-btn {
-    padding: 0.5rem 1rem;
-    border: none;
-    background: transparent;
-    color: #6b7280;
-    font-size: 0.875rem;
-    font-weight: 500;
-    border-radius: 0.375rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-mode-btn:hover {
-    color: #374151;
-  }
-
-  .arcana-mode-btn.active {
-    background: white;
-    color: #7c3aed;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  }
-
-  .arcana-mode-description {
-    color: #9ca3af;
-    font-size: 0.8125rem;
-    margin-bottom: 1rem;
-    font-style: italic;
-  }
-
-  .arcana-ask-form {
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 1rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-ask-input textarea {
-    width: 100%;
-    padding: 0.75rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    resize: vertical;
-    box-sizing: border-box;
-  }
-
-  .arcana-ask-input textarea:focus {
-    outline: none;
-    border-color: #7c3aed;
-    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
-  }
-
-  .arcana-ask-options {
-    margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid #e5e7eb;
-  }
-
-  .arcana-ask-options h4 {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #374151;
-    margin: 0 0 0.75rem 0;
-  }
-
-  .arcana-pipeline {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .arcana-pipeline > li {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .arcana-pipeline > li:not(:last-child)::after {
-    content: '';
-    display: block;
-    width: 2px;
-    height: 1.25rem;
-    background: #c4b5fd;
-  }
-
-  .arcana-pipeline > li:has(> .arcana-pipeline-step:not(:has(input:checked)):not(.fixed)):not(:last-child)::after {
-    background: none;
-    border-left: 2px dashed #d1d5db;
-  }
-
-  .arcana-pipeline-step {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 240px;
-    padding: 0.625rem 1rem;
-    background: #fafafa;
-    border: 2px dashed #d1d5db;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    text-align: center;
-  }
-
-  .arcana-pipeline-step:has(input:checked) {
-    background: #ede9fe;
-    border: 2px solid #7c3aed;
-  }
-
-  .arcana-pipeline-step:has(input:checked) .arcana-step-label {
-    color: #6d28d9;
-  }
-
-  .arcana-pipeline-step:not(.fixed):hover {
-    border-color: #a78bfa;
-  }
-
-  .arcana-pipeline-step.fixed {
-    background: #f0fdf4;
-    border: 2px solid #86efac;
-    cursor: default;
-  }
-
-  .arcana-pipeline-step.fixed .arcana-step-label {
-    color: #15803d;
-  }
-
-  .arcana-pipeline-step input[type="checkbox"],
-  .arcana-pipeline-step input[type="radio"] {
-    position: absolute;
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-
-  .arcana-step-label {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #374151;
-  }
-
-  .arcana-pipeline-step small {
-    font-size: 0.75rem;
-    color: #6b7280;
-    margin-top: 0.125rem;
-  }
-
-  .arcana-pipeline-fork {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .arcana-pipeline-fork .arcana-pipeline-step {
-    width: 160px;
-  }
-
-  .arcana-fork-or {
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: #9ca3af;
-    text-transform: uppercase;
-  }
-
-  .arcana-pipeline-step:has(input:disabled) {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  /* Phase grouping: wraps the flat pipeline into three labeled sections
-     (Query preparation, Retrieval, Answer) with a thin divider line
-     between them. Each phase keeps its own vertical flow; the dividers
-     make the three stages visible without losing the single-column shape. */
-  .arcana-pipeline-phases {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 1rem;
-  }
-
-  .arcana-pipeline-phase {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 1rem 0.75rem 1.25rem;
-    background: #faf5ff;
-    border: 1px solid #ede9fe;
-    border-radius: 0.625rem;
-  }
-
-  .arcana-pipeline-phase-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    max-width: 280px;
-    margin: 0 auto 0.75rem;
-  }
-
-  .arcana-pipeline-phase-header h5 {
-    margin: 0;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: #7c3aed;
-  }
-
-  .arcana-pipeline-phase-toggle {
-    font-size: 0.6875rem;
-    font-weight: 400;
-    color: #9ca3af;
-    letter-spacing: 0;
-    text-transform: none;
-  }
-
-  /* Substep: a conditional loop on the previous step (Multi-hop reasoning
-     loops search, Self-correction loops answer). The ↻ glyph on the label
-     signals the loop relationship. Keeps the same width + center axis as
-     the primary steps so the vertical connector stays straight. */
-  .arcana-loop-glyph {
-    display: inline-block;
-    margin-right: 0.25rem;
-    color: #a78bfa;
-    font-weight: 700;
-  }
-
-  .arcana-pipeline-step:has(input:checked) .arcana-loop-glyph {
-    color: #7c3aed;
-  }
-
-  /* Ask page sub-tabs: segmented pill control. Distinct from the
-     top-level .arcana-tab nav (which uses underlines) so the two
-     navigation levels don't visually compete. */
-  .arcana-ask-sub-tab-nav {
-    display: inline-flex;
-    align-items: center;
-    background: #f3f4f6;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 0.25rem;
-    gap: 0.125rem;
-    margin: 1rem 0 0.75rem;
-  }
-
-  .arcana-ask-sub-tab {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 36px;
-    padding: 0.5rem 1.25rem;
-    border: none;
-    background: transparent;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: #6b7280;
-    cursor: pointer;
-    border-radius: 0.375rem;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-ask-sub-tab:hover:not(.active) {
-    color: #4b5563;
-    background: rgba(255, 255, 255, 0.6);
-  }
-
-  .arcana-ask-sub-tab.active {
-    background: #ffffff;
-    color: #6d28d9;
-    font-weight: 600;
-    box-shadow:
-      0 1px 2px rgba(15, 23, 42, 0.06),
-      0 1px 3px rgba(15, 23, 42, 0.04);
-  }
-
-  .arcana-sub-tab-description {
-    color: #6b7280;
-    font-size: 0.875rem;
-    margin: 0 0 1.25rem 0;
-    line-height: 1.5;
-  }
-
-  /* Loop settings: card grid that mirrors the .arcana-pipeline-step
-     visual language so the Loop sub-tab feels like part of the same
-     surface as the Pipeline sub-tab. */
-  .arcana-loop-settings {
-    margin-top: 0.75rem;
-  }
-
-  .arcana-loop-settings h4 {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    color: #6b7280;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    margin: 0 0 0.5rem 0;
-  }
-
-  /* Two-row layout: info cards (4-col) row, then number+toggle (2-col)
-     row. Both rows live inside the same grid so column widths align.
-     Info cards are horizontally compact; number inputs and the toggle
-     get their own tighter row beneath them. */
-  .arcana-loop-settings-grid {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0.5rem;
-  }
-
-  .arcana-loop-setting {
-    display: flex;
-    flex-direction: column;
-    padding: 0.625rem 0.75rem;
-    background: #fafafa;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.375rem;
-    gap: 0.125rem;
-    transition: border-color 0.15s ease;
-    min-width: 0;
-  }
-
-  .arcana-loop-setting:hover {
-    border-color: #d1d5db;
-  }
-
-  .arcana-loop-setting label {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #374151;
-  }
-
-  .arcana-loop-setting > small {
-    font-size: 0.6875rem;
-    color: #6b7280;
-    line-height: 1.35;
-  }
-
-  .arcana-loop-setting code {
-    font-size: 0.625rem;
-    background: #ede9fe;
-    color: #6d28d9;
-    padding: 0.0625rem 0.3125rem;
-    border-radius: 0.1875rem;
-  }
-
-  .arcana-loop-setting--info {
-    background: #f5f3ff;
-    border-color: #ddd6fe;
-  }
-
-  .arcana-loop-setting--info:hover {
-    border-color: #c4b5fd;
-  }
-
-  .arcana-loop-setting-value {
-    margin-top: 0.25rem;
-    font-size: 0.6875rem;
-    color: #6d28d9;
-    font-family:
-      ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* Inline temperature row inside an LLM info card. The temperature is
-     visually attached to the LLM it controls so users can see at a
-     glance which model each setting affects. */
-  .arcana-loop-setting-temp {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    margin-top: 0.5rem;
-    padding-top: 0.5rem;
-    border-top: 1px dashed #ddd6fe;
-  }
-
-  .arcana-loop-setting-temp label {
-    font-size: 0.625rem;
-    font-weight: 600;
-    color: #9ca3af;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin: 0;
-  }
-
-  .arcana-loop-setting-temp input[type="number"] {
-    width: 2.75rem;
-    margin: 0;
-    padding: 0.125rem 0.3125rem;
-    border: 1px solid #ddd6fe;
-    border-radius: 0.25rem;
-    font-size: 0.6875rem;
-    background: white;
-    color: #6d28d9;
-    box-sizing: border-box;
-    /* Hide the spin buttons in WebKit since the field is too narrow
-       for them to be useful and they consume horizontal space. */
-    appearance: textfield;
-    -moz-appearance: textfield;
-  }
-
-  .arcana-loop-setting-temp input[type="number"]::-webkit-inner-spin-button,
-  .arcana-loop-setting-temp input[type="number"]::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-
-  .arcana-loop-setting-temp input[type="number"]:focus {
-    outline: none;
-    border-color: #7c3aed;
-    box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.15);
-  }
-
-  .arcana-loop-setting-temp input[type="number"]:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  /* Number-input cards (max_iterations, chunk_cap) sit in two
-     compact columns beneath the four LLM info cards. The remaining
-     two columns of the row are visually balanced by the full-width
-     toggle below. */
-  .arcana-loop-setting--number {
-    grid-column: span 1;
-  }
-
-  .arcana-loop-setting input[type="number"] {
-    margin-top: 0.25rem;
-    width: 100%;
-    padding: 0.375rem 0.625rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.3125rem;
-    font-size: 0.8125rem;
-    background: white;
-    color: #111827;
-    box-sizing: border-box;
-    transition:
-      border-color 0.15s ease,
-      box-shadow 0.15s ease;
-  }
-
-  .arcana-loop-setting input[type="number"]:focus {
-    outline: none;
-    border-color: #7c3aed;
-    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
-  }
-
-  .arcana-loop-setting input[type="number"]:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .arcana-loop-setting--toggle {
-    grid-column: 1 / -1;
-    flex-direction: row;
-    align-items: center;
-    gap: 0.625rem;
-    padding: 0.5rem 0.75rem;
-    cursor: pointer;
-  }
-
-  .arcana-loop-setting--toggle:has(input:checked) {
-    background: #ede9fe;
-    border-color: #7c3aed;
-  }
-
-  .arcana-loop-setting--toggle:has(input:checked) .arcana-loop-toggle-label {
-    color: #6d28d9;
-  }
-
-  .arcana-loop-setting--toggle input[type="checkbox"] {
-    margin: 0;
-    width: 15px;
-    height: 15px;
-    accent-color: #7c3aed;
-    cursor: pointer;
-    flex-shrink: 0;
-  }
-
-  .arcana-loop-toggle-content {
-    display: flex;
-    flex-direction: row;
-    align-items: baseline;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    min-width: 0;
-  }
-
-  .arcana-loop-toggle-label {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #374151;
-  }
-
-  .arcana-loop-toggle-content small {
-    font-size: 0.6875rem;
-    color: #6b7280;
-    line-height: 1.3;
-  }
-
-  /* Loop trace: shared visual language for both the live (during run)
-     and the static (post run) tool history. The live variant adds a
-     pulsing header and a slide-in animation on each new entry. */
-  .arcana-loop-trace,
-  .arcana-loop-live-trace {
-    margin-top: 1rem;
-    background: #fafafa;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 1rem 1.25rem;
-  }
-
-  .arcana-loop-live-trace {
-    background: linear-gradient(180deg, #faf5ff 0%, #fafafa 100%);
-    border-color: #ddd6fe;
-  }
-
-  .arcana-loop-trace h4 {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #6b7280;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    margin: 0 0 0.875rem 0;
-    display: flex;
-    align-items: center;
-    gap: 0.625rem;
-  }
-
-  .arcana-loop-meta {
-    font-size: 0.6875rem;
-    font-weight: 500;
-    color: #9ca3af;
-    text-transform: none;
-    letter-spacing: 0;
-  }
-
-  .arcana-loop-meta code {
-    font-size: 0.6875rem;
-    background: #ede9fe;
-    color: #6d28d9;
-    padding: 0.0625rem 0.375rem;
-    border-radius: 0.25rem;
-  }
-
-  .arcana-loop-live-header {
-    display: flex;
-    align-items: center;
-    gap: 0.625rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #6d28d9;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    margin-bottom: 0.875rem;
-  }
-
-  .arcana-loop-live-pulse {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: #7c3aed;
-    box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.6);
-    animation: arcana-loop-pulse 1.6s ease-out infinite;
-  }
-
-  @keyframes arcana-loop-pulse {
-    0% {
-      box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.6);
+    .arcana-tabs {
+      display: flex;
+      gap: 0.5rem;
+      border-bottom: 2px solid #e5e7eb;
+      margin-bottom: 1.5rem;
     }
-    70% {
-      box-shadow: 0 0 0 8px rgba(124, 58, 237, 0);
+
+    .arcana-tab {
+      padding: 0.75rem 1.5rem;
+      border: none;
+      background: transparent;
+      font-size: 1rem;
+      font-weight: 500;
+      color: #6b7280;
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+      transition: all 0.15s ease;
+      text-decoration: none;
     }
-    100% {
-      box-shadow: 0 0 0 0 rgba(124, 58, 237, 0);
+
+    .arcana-tab:hover {
+      color: #7c3aed;
     }
-  }
 
-  .arcana-loop-live-title {
-    flex: 1;
-  }
+    .arcana-tab.active {
+      color: #7c3aed;
+      border-bottom-color: #7c3aed;
+    }
 
-  .arcana-loop-live-count {
-    font-size: 0.6875rem;
-    font-weight: 500;
-    color: #9ca3af;
-    text-transform: none;
-    letter-spacing: 0;
-  }
+    .arcana-dashboard h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: #111827;
+      margin: 0 0 1rem 0;
+    }
 
-  .arcana-loop-live-empty {
-    font-size: 0.8125rem;
-    color: #9ca3af;
-    font-style: italic;
-    padding: 0.5rem 0 0.25rem;
-  }
+    .arcana-ingest-form,
+    .arcana-search-form {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 1rem;
+      margin-bottom: 1.5rem;
+    }
 
-  .arcana-loop-iterations {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    position: relative;
-  }
+    .arcana-ingest-form textarea,
+    .arcana-search-form input[type="text"] {
+      width: 100%;
+      padding: 0.75rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      box-sizing: border-box;
+    }
 
-  /* Vertical timeline rail running down the left side of the iteration
-     list. Anchored to the iter-num badge so the rail aligns with the
-     center of each badge. */
-  .arcana-loop-iterations::before {
-    content: '';
-    position: absolute;
-    left: 0.875rem;
-    top: 0.75rem;
-    bottom: 0.75rem;
-    width: 2px;
-    background: #e5e7eb;
-    border-radius: 1px;
-  }
+    .arcana-ingest-form textarea:focus,
+    .arcana-search-form input:focus,
+    .arcana-search-form select:focus {
+      outline: none;
+      border-color: #7c3aed;
+      box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+    }
 
-  .arcana-loop-iterations--live::before {
-    background: linear-gradient(180deg, #c4b5fd 0%, #ddd6fe 100%);
-  }
+    .arcana-search-options {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.75rem;
+    }
 
-  .arcana-loop-iteration {
-    position: relative;
-    padding: 0.375rem 0 0.375rem 2.25rem;
-    min-height: 2.5rem;
-    display: flex;
-    align-items: center;
-    animation: arcana-loop-fade-in 0.35s ease-out both;
-  }
+    .arcana-search-options label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: #6b7280;
+    }
 
-  @keyframes arcana-loop-fade-in {
-    from {
+    .arcana-search-options select,
+    .arcana-search-options input[type="number"] {
+      padding: 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      min-width: 100px;
+    }
+
+    .arcana-ingest-form button,
+    .arcana-search-form button {
+      background: #7c3aed;
+      color: white;
+      padding: 0.625rem 1.25rem;
+      border: none;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.15s ease;
+    }
+
+    .arcana-ingest-form button:hover,
+    .arcana-search-form button:hover {
+      background: #6d28d9;
+    }
+
+    .arcana-ingest-options {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .arcana-ingest-options label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: #6b7280;
+    }
+
+    .arcana-ingest-options select {
+      padding: 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      min-width: 120px;
+    }
+
+    .arcana-ingest-options select:focus {
+      outline: none;
+      border-color: #7c3aed;
+      box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+    }
+
+    .arcana-empty {
+      color: #6b7280;
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+      background: #f9fafb;
+      border-radius: 0.5rem;
+    }
+
+    .arcana-documents-table,
+    .arcana-results-table,
+    .arcana-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+    }
+
+    .arcana-documents-table th,
+    .arcana-results-table th,
+    .arcana-table th {
+      text-align: left;
+      padding: 0.75rem;
+      background: #f3f4f6;
+      border-bottom: 2px solid #e5e7eb;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .arcana-documents-table td,
+    .arcana-results-table td,
+    .arcana-table td {
+      padding: 0.75rem;
+      border-bottom: 1px solid #e5e7eb;
+      vertical-align: middle;
+    }
+
+    .arcana-documents-table td:nth-child(1) {
+      max-width: 120px;
+      word-break: break-all;
+    }
+
+    .arcana-documents-table td:nth-child(2) {
+      max-width: 300px;
+    }
+
+    .arcana-documents-table td:nth-child(5),
+    .arcana-documents-table td:nth-child(6),
+    .arcana-documents-table td:nth-child(7) {
+      white-space: nowrap;
+    }
+
+    .arcana-documents-table tr:hover,
+    .arcana-results-table tr:hover,
+    .arcana-table tr:hover {
+      background: #f9fafb;
+    }
+
+    .arcana-documents-table code,
+    .arcana-results-table code,
+    .arcana-table code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+      font-size: 0.75rem;
+      background: #ede9fe;
+      color: #6d28d9;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+    }
+
+    .arcana-metadata {
+      font-size: 0.75rem;
+      color: #6b7280;
+      max-width: 200px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .arcana-stats {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+      padding: 1rem;
+      background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
+      border-radius: 0.5rem;
+      color: white;
+      align-items: center;
+    }
+
+    .arcana-brand {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.025em;
+      padding-right: 1.5rem;
+      border-right: 1px solid rgba(255, 255, 255, 0.3);
+      margin-right: 0.5rem;
+      display: flex;
+      align-items: center;
+      align-self: center;
+    }
+
+    .arcana-stat {
+      text-align: center;
+    }
+
+    .arcana-stat-value {
+      font-size: 1.5rem;
+      font-weight: 700;
+      font-variant-numeric: tabular-nums;
+      letter-spacing: -0.01em;
+    }
+
+    .arcana-stat-label {
+      font-size: 0.75rem;
+      opacity: 0.9;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .arcana-stat-divider {
+      width: 1px;
+      height: 2rem;
+      background: rgba(255, 255, 255, 0.3);
+      margin: 0 0.5rem;
+    }
+
+    .arcana-pagination {
+      display: flex;
+      gap: 0.375rem;
+      justify-content: center;
+      align-items: center;
+      flex-wrap: wrap;
+      margin-top: 1rem;
+      padding-top: 1rem;
+      border-top: 1px solid #e5e7eb;
+    }
+
+    .arcana-page-btn {
+      padding: 0.5rem 0.75rem;
+      min-width: 2.5rem;
+      border: 1px solid #d1d5db;
+      background: white;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      font-variant-numeric: tabular-nums;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-page-btn:hover:not(:disabled) {
+      border-color: #7c3aed;
+      color: #7c3aed;
+    }
+
+    .arcana-page-btn.active {
+      background: #7c3aed;
+      border-color: #7c3aed;
+      color: white;
+    }
+
+    .arcana-page-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .arcana-page-ellipsis {
+      padding: 0.5rem 0.25rem;
+      color: #9ca3af;
+      font-size: 0.875rem;
+      user-select: none;
+    }
+
+    .arcana-view-btn {
+      background: transparent;
+      color: #7c3aed;
+      border: 1px solid #7c3aed;
+    }
+
+    .arcana-view-btn:hover {
+      background: #7c3aed;
+      color: white;
+    }
+
+    .arcana-filter-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      padding: 0.75rem 1rem;
+      background: #f3f4f6;
+      border-radius: 0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .arcana-filter-label {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #6b7280;
+      margin-right: 0.5rem;
+    }
+
+    .arcana-filter-btn {
+      padding: 0.375rem 0.75rem;
+      font-size: 0.875rem;
+      border: 1px solid #d1d5db;
+      border-radius: 9999px;
+      background: white;
+      color: #374151;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-filter-btn:hover {
+      border-color: #7c3aed;
+      color: #7c3aed;
+    }
+
+    .arcana-filter-btn.active {
+      background: #7c3aed;
+      border-color: #7c3aed;
+      color: white;
+    }
+
+    .arcana-filter-clear {
+      background: #fef2f2;
+      border-color: #fecaca;
+      color: #dc2626;
+    }
+
+    .arcana-filter-clear:hover {
+      background: #fee2e2;
+      border-color: #dc2626;
+    }
+
+    .arcana-doc-detail {
+      /* No background - inherits from page */
+    }
+
+    .arcana-doc-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 1.5rem;
+    }
+
+    .arcana-doc-header h2 {
+      margin: 0;
+    }
+
+    .arcana-close-btn {
+      background: transparent;
+      color: #6b7280;
+      border: 1px solid #d1d5db;
+      padding: 0.5rem 1rem;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      text-decoration: none;
+    }
+
+    .arcana-close-btn:hover {
+      border-color: #7c3aed;
+      color: #7c3aed;
+    }
+
+    .arcana-doc-info {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .arcana-doc-field label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: #6b7280;
+      margin-bottom: 0.25rem;
+    }
+
+    .arcana-doc-section {
+      margin-bottom: 1.5rem;
+    }
+
+    .arcana-doc-section h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: #374151;
+      margin: 0 0 0.75rem 0;
+    }
+
+    .arcana-doc-content {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      margin: 0;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    /* Info page grid layout */
+    .arcana-info-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .arcana-info-section {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 1rem;
+    }
+
+    .arcana-info-section h3 {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #7c3aed;
+      margin: 0 0 0.75rem 0;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #f3e8ff;
+    }
+
+    .arcana-info-section .arcana-doc-info {
+      margin-bottom: 0;
+      background: transparent;
+      border: none;
+      padding: 0;
+    }
+
+    .arcana-info-full {
+      grid-column: 1 / -1;
+    }
+
+    .arcana-not-configured {
+      color: #9ca3af;
+    }
+
+    .arcana-status-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+
+    .arcana-status-badge.enabled {
+      background: #d1fae5;
+      color: #065f46;
+    }
+
+    .arcana-status-badge.disabled {
+      background: #f3f4f6;
+      color: #6b7280;
+    }
+
+    /* Maintenance page styles */
+    .arcana-maintenance-section {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 1.25rem;
+      margin-bottom: 2rem;
+    }
+
+    .arcana-maintenance-section h3 {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #7c3aed;
+      margin: 0 0 0.75rem 0;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #f3e8ff;
+    }
+
+    .arcana-maintenance-section .arcana-doc-info {
+      margin-bottom: 0;
+      background: transparent;
+      border: none;
+      padding: 0;
+    }
+
+    .arcana-orphan-section {
+      background: #fef3c7;
+      border-color: #f59e0b;
+    }
+    .arcana-orphan-section h3 {
+      color: #b45309;
+      border-bottom-color: #fcd34d;
+    }
+    .arcana-orphan-count {
+      font-weight: 600;
+      color: #b45309;
+    }
+
+    .arcana-chunks-list {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .arcana-chunk {
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      overflow: hidden;
+    }
+
+    .arcana-chunk-header {
+      display: flex;
+      justify-content: space-between;
+      padding: 0.5rem 1rem;
+      background: #f3f4f6;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+
+    .arcana-chunk-index {
+      color: #7c3aed;
+    }
+
+    .arcana-chunk-tokens {
+      color: #6b7280;
+    }
+
+    .arcana-chunk-text {
+      padding: 1rem;
+      margin: 0;
+      font-size: 0.875rem;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      background: #f9fafb;
+    }
+
+    .arcana-btn {
+      background: transparent;
+      color: #374151;
+      border: 1px solid #d1d5db;
+      padding: 0.375rem 0.75rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-btn:hover {
+      border-color: #7c3aed;
+      color: #7c3aed;
+    }
+
+    .arcana-btn-primary {
+      background: #7c3aed;
+      color: white;
+      border-color: #7c3aed;
+    }
+
+    .arcana-btn-primary:hover {
+      background: #6d28d9;
+      border-color: #6d28d9;
+      color: white;
+    }
+
+    .arcana-btn-danger {
+      background: transparent;
+      color: #dc2626;
+      border-color: #dc2626;
+    }
+
+    .arcana-btn-danger:hover {
+      background: #dc2626;
+      color: white;
+    }
+
+    .arcana-form-row {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
+    .arcana-input {
+      padding: 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+    }
+
+    .arcana-input:focus {
+      outline: none;
+      border-color: #7c3aed;
+      box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+    }
+
+    .arcana-confirm-delete {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
+    .arcana-confirm-delete span {
+      font-size: 0.75rem;
+      color: #dc2626;
+      font-weight: 500;
+    }
+
+    /* Evaluation styles */
+    .arcana-eval-nav {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .arcana-eval-nav-btn {
+      position: relative;
+      padding: 0.625rem 0;
+      border: none;
+      background: transparent;
+      font-size: 0.9375rem;
+      font-weight: 500;
+      color: #6b7280;
+      cursor: pointer;
+      transition: color 0.15s ease;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+    }
+
+    .arcana-eval-nav-btn:hover {
+      color: #7c3aed;
+    }
+
+    .arcana-eval-nav-btn.active {
+      color: #7c3aed;
+      border-bottom-color: #7c3aed;
+      font-weight: 600;
+    }
+
+    .arcana-eval-message {
+      padding: 0.75rem 1rem;
+      border-radius: 0.375rem;
+      margin-bottom: 1rem;
+      font-size: 0.875rem;
+    }
+
+    .arcana-eval-message.success {
+      background: #d1fae5;
+      color: #065f46;
+      border: 1px solid #a7f3d0;
+    }
+
+    .arcana-eval-message.error {
+      background: #fee2e2;
+      color: #991b1b;
+      border: 1px solid #fecaca;
+    }
+
+    /* Evaluation run form: vertical stack of sections, radio cards for
+       retriever, options row for mode + evaluate_answers toggle, a
+       prominent Run Evaluation button bottom-right. Replaces the old
+       flex-end one-liner that smushed inputs of different heights next
+       to each other. */
+    .arcana-eval-run-intro {
+      margin: 0 0 1.25rem;
+      color: #4b5563;
+      font-size: 0.9375rem;
+    }
+
+    .arcana-eval-run-intro strong {
+      color: #111827;
+      font-weight: 600;
+    }
+
+    .arcana-eval-run-form {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .arcana-eval-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .arcana-eval-field-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #374151;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin: 0;
+    }
+
+    .arcana-eval-hint {
+      font-size: 0.75rem;
+      color: #6b7280;
+      line-height: 1.4;
+    }
+
+    .arcana-eval-option-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75rem;
+    }
+
+    .arcana-eval-option-card {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+      padding: 1rem 1rem 1rem 1rem;
+      background: #fafafa;
+      border: 2px solid #e5e7eb;
+      border-radius: 0.5rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-eval-option-card input[type="radio"] {
+      position: absolute;
       opacity: 0;
-      transform: translateY(-4px);
+      pointer-events: none;
     }
-    to {
-      opacity: 1;
-      transform: translateY(0);
+
+    .arcana-eval-option-card:hover {
+      border-color: #c4b5fd;
+      background: #faf5ff;
     }
-  }
 
-  .arcana-loop-iter-header {
-    display: flex;
-    align-items: center;
-    gap: 0.625rem;
-    flex-wrap: wrap;
-    min-height: 1.75rem;
-  }
-
-  .arcana-loop-iter-num {
-    position: absolute;
-    left: 0;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 1.75rem;
-    height: 1.75rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: white;
-    border: 2px solid #e5e7eb;
-    border-radius: 50%;
-    font-size: 0.6875rem;
-    font-weight: 700;
-    color: #6b7280;
-    z-index: 1;
-  }
-
-  .arcana-loop-iterations--live .arcana-loop-iter-num {
-    border-color: #c4b5fd;
-    color: #6d28d9;
-  }
-
-  /* Per-tool color coding so search vs answer vs give_up is scannable */
-  .arcana-tool-search .arcana-loop-iter-num {
-    border-color: #93c5fd;
-    color: #1d4ed8;
-    background: #eff6ff;
-  }
-
-  .arcana-tool-answer .arcana-loop-iter-num {
-    border-color: #86efac;
-    color: #15803d;
-    background: #f0fdf4;
-  }
-
-  .arcana-tool-give_up .arcana-loop-iter-num {
-    border-color: #fca5a5;
-    color: #b91c1c;
-    background: #fef2f2;
-  }
-
-  .arcana-tool-synthesis .arcana-loop-iter-num {
-    border-color: #fcd34d;
-    color: #b45309;
-    background: #fffbeb;
-  }
-
-  .arcana-loop-tool {
-    font-size: 0.8125rem;
-    font-weight: 600;
-    font-family:
-      ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-    padding: 0.125rem 0.5rem;
-    border-radius: 0.25rem;
-    background: #f3f4f6;
-    color: #374151;
-  }
-
-  .arcana-tool-search .arcana-loop-tool {
-    background: #dbeafe;
-    color: #1d4ed8;
-  }
-
-  .arcana-tool-answer .arcana-loop-tool {
-    background: #dcfce7;
-    color: #15803d;
-  }
-
-  .arcana-tool-give_up .arcana-loop-tool {
-    background: #fee2e2;
-    color: #b91c1c;
-  }
-
-  .arcana-tool-synthesis .arcana-loop-tool {
-    background: #fef3c7;
-    color: #b45309;
-  }
-
-  /* Pipeline step trace: same visual language as the loop trace, but
-     each entry is a "step" with a running/done state instead of a
-     completed tool call. The number badge contains a tiny spinner
-     while running, then becomes a step number when done. */
-  .arcana-pipeline-iterations::before {
-    background: linear-gradient(180deg, #c4b5fd 0%, #ddd6fe 100%);
-  }
-
-  .arcana-pipeline-step-trace--running .arcana-loop-iter-num {
-    background: #f5f3ff;
-    border-color: #c4b5fd;
-    color: #6d28d9;
-  }
-
-  .arcana-pipeline-step-trace--running .arcana-loop-tool {
-    background: #ede9fe;
-    color: #6d28d9;
-  }
-
-  .arcana-pipeline-step-trace--done .arcana-loop-iter-num {
-    background: #f0fdf4;
-    border-color: #86efac;
-    color: #15803d;
-  }
-
-  .arcana-pipeline-step-trace--done .arcana-loop-tool {
-    background: #dcfce7;
-    color: #15803d;
-  }
-
-  .arcana-pipeline-step-spinner {
-    width: 0.75rem;
-    height: 0.75rem;
-    border-radius: 50%;
-    border: 2px solid rgba(124, 58, 237, 0.25);
-    border-top-color: #7c3aed;
-    animation: arcana-pipeline-spin 0.8s linear infinite;
-  }
-
-  @keyframes arcana-pipeline-spin {
-    to {
-      transform: rotate(360deg);
+    .arcana-eval-option-card:has(input:checked) {
+      border-color: #7c3aed;
+      background: #ede9fe;
     }
-  }
-
-  .arcana-loop-args {
-    font-size: 0.8125rem;
-    color: #4b5563;
-    font-family:
-      ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .arcana-loop-chunk-count {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    color: #6d28d9;
-    background: #ede9fe;
-    padding: 0.125rem 0.5rem;
-    border-radius: 999px;
-    flex-shrink: 0;
-  }
-
-  .arcana-checkbox-label {
-    display: flex;
-    flex-direction: column;
-    padding: 0.75rem;
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.375rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-checkbox-label:hover {
-    border-color: #7c3aed;
-  }
-
-  .arcana-checkbox-label input[type="checkbox"] {
-    position: absolute;
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-
-  .arcana-checkbox-label span {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: #374151;
-  }
-
-  .arcana-checkbox-label small {
-    font-size: 0.75rem;
-    color: #6b7280;
-    margin-top: 0.25rem;
-  }
-
-  .arcana-checkbox-label:has(input:checked) {
-    background: #ede9fe;
-    border-color: #7c3aed;
-  }
-
-  .arcana-checkbox-label:has(input:checked) span {
-    color: #6d28d9;
-  }
-
-  .arcana-checkbox-label:has(input:disabled) {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .arcana-ask-actions {
-    display: flex;
-    gap: 0.5rem;
-    margin-top: 1rem;
-  }
-
-  .arcana-ask-actions button {
-    background: #7c3aed;
-    color: white;
-    padding: 0.625rem 1.25rem;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background-color 0.15s ease;
-  }
-
-  .arcana-ask-actions button:hover {
-    background: #6d28d9;
-  }
-
-  .arcana-ask-actions button:disabled {
-    background: #9ca3af;
-    cursor: not-allowed;
-  }
-
-  .arcana-ask-actions button[type="button"] {
-    background: transparent;
-    color: #6b7280;
-    border: 1px solid #d1d5db;
-  }
-
-  .arcana-ask-actions button[type="button"]:hover {
-    border-color: #7c3aed;
-    color: #7c3aed;
-    background: transparent;
-  }
-
-  .arcana-ask-loading {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 1.5rem;
-    background: #f9fafb;
-    border-radius: 0.5rem;
-    color: #6b7280;
-  }
-
-  .arcana-spinner {
-    width: 1.25rem;
-    height: 1.25rem;
-    border: 2px solid #e5e7eb;
-    border-top-color: #7c3aed;
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-  }
-
-  @keyframes spin {
-    to { transform: rotate(360deg); }
-  }
-
-  .arcana-ask-results {
-    margin-top: 1.5rem;
-  }
-
-  .arcana-ask-answer {
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    overflow: hidden;
-    margin-bottom: 1rem;
-  }
-
-  .arcana-ask-answer h3 {
-    margin: 0;
-    padding: 0.75rem 1rem;
-    background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
-    color: white;
-    font-size: 0.875rem;
-    font-weight: 600;
-  }
-
-  .arcana-answer-content {
-    padding: 1rem 1.25rem;
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: #1f2937;
-  }
-
-  /* Markdown elements inside a rendered answer. Earmark produces
-     standard HTML, so we style a minimal set: paragraphs, lists,
-     inline emphasis, inline code, and a few headers. */
-  .arcana-answer-content > :first-child {
-    margin-top: 0;
-  }
-
-  .arcana-answer-content > :last-child {
-    margin-bottom: 0;
-  }
-
-  .arcana-answer-content p {
-    margin: 0 0 0.75rem 0;
-  }
-
-  .arcana-answer-content ul,
-  .arcana-answer-content ol {
-    margin: 0 0 0.75rem 0;
-    padding-left: 1.5rem;
-  }
-
-  .arcana-answer-content li {
-    margin-bottom: 0.25rem;
-  }
-
-  .arcana-answer-content li > ul,
-  .arcana-answer-content li > ol {
-    margin-top: 0.25rem;
-    margin-bottom: 0.25rem;
-  }
-
-  .arcana-answer-content strong {
-    font-weight: 600;
-    color: #111827;
-  }
-
-  .arcana-answer-content em {
-    font-style: italic;
-  }
-
-  .arcana-answer-content code {
-    background: #f3f4f6;
-    color: #7c3aed;
-    padding: 0.0625rem 0.375rem;
-    border-radius: 0.25rem;
-    font-size: 0.8125rem;
-    font-family:
-      ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-  }
-
-  .arcana-answer-content pre {
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.375rem;
-    padding: 0.75rem;
-    overflow-x: auto;
-    margin: 0 0 0.75rem 0;
-  }
-
-  .arcana-answer-content pre code {
-    background: transparent;
-    color: inherit;
-    padding: 0;
-  }
-
-  .arcana-answer-content h1,
-  .arcana-answer-content h2,
-  .arcana-answer-content h3,
-  .arcana-answer-content h4,
-  .arcana-answer-content h5,
-  .arcana-answer-content h6 {
-    font-weight: 700;
-    color: #1f2937;
-    margin: 1.5rem 0 0.5rem 0;
-    line-height: 1.3;
-  }
-
-  /* First heading shouldn't push down — there's already padding above. */
-  .arcana-answer-content > :first-child:is(h1, h2, h3, h4, h5, h6) {
-    margin-top: 0;
-  }
-
-  .arcana-answer-content h1 {
-    font-size: 1.25rem;
-    color: #111827;
-    padding-bottom: 0.375rem;
-    border-bottom: 2px solid #ede9fe;
-  }
-
-  /* h2 is the most common section heading the LLM emits. Distinctive
-     but not loud: a left accent bar + a slightly bigger size + a touch
-     of color. */
-  .arcana-answer-content h2 {
-    font-size: 1.0625rem;
-    color: #6d28d9;
-    padding-left: 0.75rem;
-    border-left: 3px solid #7c3aed;
-  }
-
-  .arcana-answer-content h3 {
-    font-size: 0.9375rem;
-    color: #4b5563;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    font-weight: 600;
-  }
-
-  .arcana-answer-content h4,
-  .arcana-answer-content h5,
-  .arcana-answer-content h6 {
-    font-size: 0.875rem;
-    color: #4b5563;
-    font-weight: 600;
-  }
-
-  .arcana-answer-content blockquote {
-    border-left: 3px solid #c4b5fd;
-    padding-left: 0.875rem;
-    color: #4b5563;
-    margin: 0 0 0.75rem 0;
-  }
-
-  .arcana-answer-content a {
-    color: #7c3aed;
-    text-decoration: underline;
-  }
-
-  .arcana-answer-content a:hover {
-    color: #6d28d9;
-  }
-
-  .arcana-ask-section {
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 1rem;
-    margin-bottom: 1rem;
-  }
-
-  .arcana-ask-section h4 {
-    margin: 0 0 0.75rem 0;
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #374151;
-  }
-
-  .arcana-query-list {
-    margin: 0;
-    padding-left: 1.5rem;
-    font-size: 0.875rem;
-    color: #374151;
-  }
-
-  .arcana-query-list li {
-    margin-bottom: 0.25rem;
-  }
-
-  /* Pipeline internals: one block below the answer that shows what each
-     pipeline step produced (rewritten query, gate decision, sub-questions,
-     etc). Renders as a <dl> with each step's label + value on one line. */
-  .arcana-pipeline-internals-list {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 0.5rem 1rem;
-    margin: 0;
-    font-size: 0.875rem;
-  }
-
-  .arcana-pipeline-internals-list dt {
-    font-weight: 600;
-    color: #6d28d9;
-    white-space: nowrap;
-  }
-
-  .arcana-pipeline-internals-list dd {
-    margin: 0;
-    color: #374151;
-    min-width: 0;
-  }
-
-  .arcana-pipeline-internals-quote {
-    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
-    font-size: 0.8125rem;
-    color: #4b5563;
-    background: #f9fafb;
-    padding: 0.125rem 0.5rem;
-    border-radius: 0.25rem;
-    display: inline-block;
-  }
-
-  .arcana-pipeline-internals-badge {
-    display: inline-block;
-    padding: 0.125rem 0.5rem;
-    border-radius: 0.25rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-  }
-
-  .arcana-pipeline-internals-badge.skip {
-    background: #fef3c7;
-    color: #b45309;
-  }
-
-  .arcana-pipeline-internals-badge.retrieve {
-    background: #dbeafe;
-    color: #1d4ed8;
-  }
-
-  .arcana-pipeline-internals-badge.neutral {
-    background: #f3f4f6;
-    color: #6b7280;
-  }
-
-  .arcana-pipeline-internals-reasoning {
-    display: block;
-    margin-top: 0.25rem;
-    font-size: 0.8125rem;
-    color: #6b7280;
-    font-style: italic;
-  }
-
-  .arcana-pipeline-internals-feedback {
-    font-size: 0.8125rem;
-    color: #6b7280;
-    font-style: italic;
-    margin-bottom: 0.25rem;
-  }
-
-  .arcana-collection-badges {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-  }
-
-  .arcana-collection-badge {
-    background: #ede9fe;
-    color: #6d28d9;
-    padding: 0.25rem 0.75rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 500;
-  }
-
-  /* Grounding Styles */
-
-  .arcana-grounding-score {
-    font-weight: 500;
-    font-size: 0.75rem;
-    padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
-    margin-left: 0.5rem;
-  }
-
-  .arcana-grounding-score.good { background: #d1fae5; color: #065f46; }
-  .arcana-grounding-score.warn { background: #fef3c7; color: #92400e; }
-  .arcana-grounding-score.bad { background: #fee2e2; color: #991b1b; }
-
-  .arcana-grounding-spans h5 {
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: #6b7280;
-    margin: 0.75rem 0 0.5rem 0;
-  }
-
-  .arcana-span {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.375rem 0.5rem;
-    border-radius: 0.375rem;
-    margin-bottom: 0.25rem;
-    font-size: 0.8rem;
-  }
-
-  .arcana-span.hallucinated {
-    background: #fef2f2;
-    border-left: 3px solid #ef4444;
-  }
-
-  .arcana-span.faithful {
-    background: #f0fdf4;
-    border-left: 3px solid #22c55e;
-  }
-
-  .arcana-span-text {
-    font-family: ui-monospace, monospace;
-    font-size: 0.8rem;
-  }
-
-  .arcana-span-score {
-    font-size: 0.7rem;
-    color: #9ca3af;
-  }
-
-  .arcana-span-sources {
-    display: flex;
-    gap: 0.25rem;
-    flex-wrap: wrap;
-    width: 100%;
-  }
-
-  .arcana-source-badge {
-    font-size: 0.65rem;
-    background: #f3f4f6;
-    color: #6b7280;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-  }
-
-  .arcana-source-badge.clickable {
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    list-style: none;
-  }
-
-  .arcana-source-badge.clickable:hover {
-    background: #e5e7eb;
-  }
-
-  .arcana-source-badge.clickable::-webkit-details-marker {
-    display: none;
-  }
-
-  .arcana-source-label {
-    font-weight: 600;
-    color: #4b5563;
-  }
-
-  .arcana-source-overlap {
-    color: #9ca3af;
-  }
-
-  .arcana-source-detail {
-    display: inline;
-  }
-
-  .arcana-source-preview {
-    font-size: 0.7rem;
-    color: #4b5563;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.25rem;
-    padding: 0.5rem;
-    margin-top: 0.375rem;
-    margin-bottom: 0.25rem;
-    line-height: 1.5;
-    width: 100%;
-  }
-
-  /* Answer highlighting */
-  .arcana-hl-hallucinated {
-    background: #fecaca;
-    border-bottom: 2px solid #ef4444;
-    border-radius: 2px;
-    padding: 0 1px;
-  }
-
-  .arcana-hl-faithful {
-    background: #bbf7d0;
-    border-bottom: 2px solid #22c55e;
-    border-radius: 2px;
-    padding: 0 1px;
-  }
-
-  /* Graph Tab Styles */
-  .arcana-graph-subtabs {
-    display: flex;
-    gap: 0.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .arcana-subtab-btn {
-    padding: 0.5rem 1rem;
-    border: 1px solid #d1d5db;
-    background: white;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .arcana-subtab-btn:hover {
-    border-color: #7c3aed;
-    color: #7c3aed;
-  }
-
-  .arcana-subtab-btn.active {
-    background: #7c3aed;
-    border-color: #7c3aed;
-    color: white;
-  }
-
-  .arcana-graph-table {
-    margin-top: 1rem;
-  }
-
-  /* Entity type badges */
-  .arcana-entity-type-badge {
-    display: inline-block;
-    padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: lowercase;
-  }
-
-  .arcana-entity-type-badge.person {
-    background: #dbeafe;
-    color: #1e40af;
-  }
-
-  .arcana-entity-type-badge.organization {
-    background: #dcfce7;
-    color: #166534;
-  }
-
-  .arcana-entity-type-badge.technology {
-    background: #fce7f3;
-    color: #9d174d;
-  }
-
-  .arcana-entity-type-badge.concept {
-    background: #fef3c7;
-    color: #92400e;
-  }
-
-  .arcana-entity-type-badge.location {
-    background: #e0e7ff;
-    color: #3730a3;
-  }
-
-  .arcana-entity-type-badge.event {
-    background: #f3e8ff;
-    color: #6b21a8;
-  }
-
-  /* Relationship strength meter */
-  .arcana-strength-meter {
-    display: inline-flex;
-    gap: 2px;
-    align-items: center;
-  }
-
-  .arcana-strength-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #e5e7eb;
-  }
-
-  .arcana-strength-dot.filled {
-    background: #7c3aed;
-  }
-
-  /* Community status indicators */
-  .arcana-status-ready {
-    color: #16a34a;
-  }
-
-  .arcana-status-pending {
-    color: #d97706;
-  }
-
-  .arcana-status-empty {
-    color: #9ca3af;
-  }
-
-  .arcana-no-summary {
-    color: #9ca3af;
-    font-style: italic;
-  }
-
-  /* Graph empty state */
-  .arcana-empty-state {
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.5rem;
-    padding: 2rem;
-    text-align: center;
-  }
-
-  .arcana-empty-state h3 {
-    margin: 0 0 1rem 0;
-    color: #374151;
-  }
-
-  .arcana-empty-state p {
-    color: #6b7280;
-    margin: 0.5rem 0;
-  }
-
-  .arcana-empty-state pre {
-    background: #1f2937;
-    color: #e5e7eb;
-    padding: 0.75rem 1rem;
-    border-radius: 0.375rem;
-    display: inline-block;
-    margin: 1rem 0;
-    font-size: 0.875rem;
-  }
-
-  .arcana-empty-state code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
-  }
-
-  /* Entity detail panel */
-  .arcana-entity-row {
-    cursor: pointer;
-    transition: background-color 0.15s;
-  }
-
-  .arcana-entity-row.selected {
-    background: #ede9fe;
-  }
-
-  .arcana-entity-detail {
-    margin-top: 1.5rem;
-    padding: 1.5rem;
-    background: #faf5ff;
-    border: 1px solid #e9d5ff;
-    border-radius: 0.5rem;
-  }
-
-  .arcana-entity-detail-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .arcana-entity-detail-header h3 {
-    margin: 0;
-    font-size: 1.125rem;
-    color: #1f2937;
-  }
-
-  .arcana-entity-detail-close {
-    margin-left: auto;
-    background: transparent;
-    border: none;
-    font-size: 1.5rem;
-    color: #6b7280;
-    cursor: pointer;
-    padding: 0;
-    line-height: 1;
-  }
-
-  .arcana-entity-detail-close:hover {
-    color: #374151;
-  }
-
-  .arcana-entity-description {
-    color: #4b5563;
-    margin: 0 0 1rem 0;
-  }
-
-  .arcana-entity-relationships h4,
-  .arcana-entity-mentions h4 {
-    margin: 0 0 0.5rem 0;
-    font-size: 0.875rem;
-    color: #6b7280;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  .arcana-rel-cards {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .arcana-rel-card {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-  }
-
-  .arcana-rel-type {
-    font-family: monospace;
-    background: #ede9fe;
-    color: #5b21b6;
-    padding: 0.125rem 0.5rem;
-    border-radius: 0.25rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-  }
-
-  .arcana-rel-arrow {
-    color: #9ca3af;
-    font-weight: bold;
-  }
-
-  .arcana-rel-target,
-  .arcana-rel-source {
-    font-weight: 500;
-    color: #1f2937;
-  }
-
-  .arcana-rel-self {
-    color: #6b7280;
-    font-style: italic;
-    font-size: 0.75rem;
-  }
-
-  .arcana-mention-preview {
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.375rem;
-    padding: 0.75rem;
-    margin-bottom: 0.5rem;
-  }
-
-  .arcana-mention-preview p {
-    margin: 0 0 0.5rem 0;
-    font-size: 0.875rem;
-    color: #374151;
-  }
-
-  .arcana-view-in-docs {
-    font-size: 0.75rem;
-    color: #7c3aed;
-    text-decoration: none;
-  }
-
-  .arcana-view-in-docs:hover {
-    text-decoration: underline;
-  }
-
-  /* Relationship detail panel */
-  .arcana-relationship-row {
-    cursor: pointer;
-    transition: background-color 0.15s;
-  }
-
-  .arcana-relationship-row.selected {
-    background: #ede9fe;
-  }
-
-  .arcana-relationship-detail {
-    margin-top: 1.5rem;
-    padding: 1.5rem;
-    background: #faf5ff;
-    border: 1px solid #e9d5ff;
-    border-radius: 0.5rem;
-  }
-
-  .arcana-relationship-detail-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 1rem;
-  }
-
-  .arcana-relationship-visual {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 1rem;
-  }
-
-  .arcana-relationship-source,
-  .arcana-relationship-target {
-    font-weight: 600;
-    color: #1f2937;
-  }
-
-  .arcana-relationship-arrow {
-    color: #9ca3af;
-  }
-
-  .arcana-relationship-type {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
-    font-size: 0.875rem;
-    background: #ede9fe;
-    color: #6d28d9;
-    padding: 0.25rem 0.5rem;
-    border-radius: 0.25rem;
-  }
-
-  .arcana-relationship-detail-close {
-    background: transparent;
-    border: none;
-    font-size: 1.5rem;
-    color: #6b7280;
-    cursor: pointer;
-    padding: 0;
-    line-height: 1;
-  }
-
-  .arcana-relationship-detail-close:hover {
-    color: #374151;
-  }
-
-  .arcana-relationship-strength {
-    margin-bottom: 0.75rem;
-    color: #4b5563;
-  }
-
-  .arcana-relationship-description {
-    color: #4b5563;
-    margin: 0;
-  }
-
-  .arcana-empty-hint {
-    font-size: 0.8125rem;
-  }
-
-  /* Community detail panel */
-  .arcana-community-row {
-    cursor: pointer;
-    transition: background-color 0.15s;
-  }
-
-  .arcana-community-row.selected {
-    background: #ede9fe;
-  }
-
-  .arcana-community-detail {
-    margin-top: 1.5rem;
-    padding: 1.5rem;
-    background: #faf5ff;
-    border: 1px solid #e9d5ff;
-    border-radius: 0.5rem;
-  }
-
-  .arcana-community-detail-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .arcana-community-detail-header h3 {
-    margin: 0;
-    font-size: 1.125rem;
-    color: #1f2937;
-  }
-
-  .arcana-community-level-badge {
-    display: inline-block;
-    padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 500;
-    background: #ddd6fe;
-    color: #5b21b6;
-  }
-
-  .arcana-community-detail-close {
-    margin-left: auto;
-    background: transparent;
-    border: none;
-    font-size: 1.5rem;
-    color: #6b7280;
-    cursor: pointer;
-    padding: 0;
-    line-height: 1;
-  }
-
-  .arcana-community-detail-close:hover {
-    color: #374151;
-  }
-
-  .arcana-community-summary,
-  .arcana-community-entities,
-  .arcana-community-relationships {
-    margin-bottom: 1rem;
-  }
-
-  .arcana-community-summary h4,
-  .arcana-community-entities h4,
-  .arcana-community-relationships h4 {
-    margin: 0 0 0.5rem 0;
-    font-size: 0.875rem;
-    color: #6b7280;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  .arcana-community-summary p {
-    margin: 0;
-    color: #374151;
-    line-height: 1.5;
-  }
-
-  .arcana-community-entities ul,
-  .arcana-community-relationships ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  .arcana-community-entities li,
-  .arcana-community-relationships li {
-    padding: 0.5rem 0;
-    border-bottom: 1px solid #e5e7eb;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .arcana-community-entities li:last-child,
-  .arcana-community-relationships li:last-child {
-    border-bottom: none;
-  }
-
-  .arcana-community-no-summary {
-    color: #9ca3af;
-    font-style: italic;
-  }
-
-  /* Collection selector */
-  .arcana-collection-selector {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-  }
-
-  .arcana-collection-selector label {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: #374151;
-  }
-
-  .arcana-collection-selector select {
-    padding: 0.5rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    min-width: 200px;
-  }
-
-  .arcana-collection-selector select:focus {
-    outline: none;
-    border-color: #7c3aed;
-    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
-  }
-
-  /* Entity/Relationship/Community views */
-  .arcana-entities-view,
-  .arcana-relationships-view,
-  .arcana-communities-view {
-    margin-top: 1rem;
-  }
-
-  /* Deep Search toggle (simple mode, below textarea) */
-  .arcana-deep-search-toggle {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    margin-top: 0.5rem;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.375rem;
-    cursor: pointer;
-    font-size: 0.8125rem;
-  }
-
-  .arcana-deep-search-toggle:hover {
-    background: #f3f4f6;
-  }
-
-  .arcana-deep-search-toggle input[type="checkbox"] {
-    accent-color: #7c3aed;
-  }
-
-  .arcana-deep-search-toggle span {
-    font-weight: 500;
-    color: #374151;
-  }
-
-  .arcana-deep-search-toggle small {
-    color: #6b7280;
-    font-size: 0.75rem;
-  }
-
-  /* Graph Context section */
-  .arcana-graph-context {
-    margin: 1.5rem 0;
-    padding: 1rem;
-    background: linear-gradient(to right, #faf5ff, #f3e8ff);
-    border: 1px solid #e9d5ff;
-    border-radius: 0.5rem;
-  }
-
-  .arcana-graph-context-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.5rem;
-  }
-
-  .arcana-graph-context-header h4 {
-    margin: 0;
-    color: #7c3aed;
-    font-size: 1rem;
-  }
-
-  .arcana-toggle-btn {
-    background: transparent;
-    border: 1px solid #d8b4fe;
-    border-radius: 0.25rem;
-    padding: 0.25rem 0.5rem;
-    cursor: pointer;
-    color: #7c3aed;
-    font-size: 0.75rem;
-  }
-
-  .arcana-toggle-btn:hover {
-    background: #f3e8ff;
-  }
-
-  .arcana-no-matches {
-    color: #9ca3af;
-    font-style: italic;
-    margin: 0.5rem 0;
-  }
-
-  .arcana-matched-entities,
-  .arcana-matched-relationships {
-    margin-top: 0.75rem;
-  }
-
-  .arcana-matched-entities h5,
-  .arcana-matched-relationships h5 {
-    margin: 0 0 0.5rem 0;
-    font-size: 0.875rem;
-    color: #6b21a8;
-  }
-
-  .arcana-matched-entities ul,
-  .arcana-matched-relationships ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  .arcana-matched-entities li,
-  .arcana-matched-relationships li {
-    padding: 0.375rem 0;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    border-bottom: 1px solid #f3e8ff;
-  }
-
-  .arcana-matched-entities li:last-child,
-  .arcana-matched-relationships li:last-child {
-    border-bottom: none;
-  }
-
-  .arcana-entity-name {
-    font-weight: 500;
-    color: #1f2937;
-  }
-
-  .arcana-entity-type {
-    font-size: 0.75rem;
-    padding: 0.125rem 0.5rem;
-    background: #e9d5ff;
-    color: #7c3aed;
-    border-radius: 9999px;
-  }
-
-  .arcana-view-in-graph {
-    margin-left: auto;
-    font-size: 0.75rem;
-    color: #7c3aed;
-    text-decoration: none;
-  }
-
-  .arcana-view-in-graph:hover {
-    text-decoration: underline;
-  }
-
-  .arcana-rel-source,
-  .arcana-rel-target {
-    color: #1f2937;
-  }
-
-  .arcana-rel-type {
-    font-size: 0.75rem;
-    color: #7c3aed;
-    font-family: monospace;
-  }
-
-  /* Graph attribution in chunks */
-  .arcana-graph-attribution {
-    display: block;
-    font-size: 0.75rem;
-    color: #7c3aed;
-    margin-top: 0.25rem;
-    font-style: italic;
-  }
-  """
-  @css_hash :crypto.hash(:md5, @css) |> Base.encode16(case: :lower) |> binary_part(0, 8)
-
-  @doc """
-  Returns the current hash for the given asset type.
-  """
-  def current_hash(:js), do: @js_hash
-  def current_hash(:css), do: @css_hash
-
-  @impl Plug
-  def init(asset), do: asset
-
-  @impl Plug
-  def call(conn, asset) do
-    {content, content_type} =
-      case asset do
-        :js -> {@js, "text/javascript"}
-        :css -> {@css, "text/css"}
-      end
-
-    conn
-    |> Plug.Conn.put_resp_header("content-type", content_type)
-    |> Plug.Conn.put_resp_header("cache-control", "public, max-age=31536000, immutable")
-    |> Plug.Conn.delete_resp_header("x-frame-options")
-    |> Plug.Conn.put_private(:plug_skip_csrf_protection, true)
-    |> Plug.Conn.send_resp(200, content)
+
+    .arcana-eval-option-card:has(input:checked) .arcana-eval-option-title {
+      color: #6d28d9;
+    }
+
+    .arcana-eval-option-title {
+      font-size: 0.9375rem;
+      font-weight: 600;
+      color: #111827;
+    }
+
+    .arcana-eval-option-desc {
+      font-size: 0.8125rem;
+      color: #6b7280;
+      line-height: 1.4;
+    }
+
+    .arcana-eval-option-desc code {
+      font-size: 0.75rem;
+      padding: 0.0625rem 0.25rem;
+      background: #f3f4f6;
+      border-radius: 0.1875rem;
+      color: #374151;
+    }
+
+    .arcana-eval-options-row {
+      display: grid;
+      grid-template-columns: minmax(0, 240px) minmax(0, 1fr);
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    .arcana-eval-select {
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      background: white;
+      color: #111827;
+    }
+
+    .arcana-eval-toggle {
+      position: relative;
+      display: flex;
+      align-items: flex-start;
+      gap: 0.625rem;
+      padding: 0.75rem 1rem;
+      background: #fafafa;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-eval-toggle input[type="checkbox"] {
+      position: absolute;
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .arcana-eval-toggle-indicator {
+      flex-shrink: 0;
+      width: 1rem;
+      height: 1rem;
+      margin-top: 0.125rem;
+      border: 2px solid #9ca3af;
+      border-radius: 0.25rem;
+      background: white;
+      transition: all 0.15s ease;
+      position: relative;
+    }
+
+    .arcana-eval-toggle:has(input:checked) {
+      border-color: #7c3aed;
+      background: #ede9fe;
+    }
+
+    .arcana-eval-toggle:has(input:checked) .arcana-eval-toggle-indicator {
+      border-color: #7c3aed;
+      background: #7c3aed;
+    }
+
+    .arcana-eval-toggle:has(input:checked) .arcana-eval-toggle-indicator::after {
+      content: "";
+      position: absolute;
+      left: 3px;
+      top: 0px;
+      width: 4px;
+      height: 8px;
+      border: solid white;
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
+    }
+
+    .arcana-eval-toggle-content {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .arcana-eval-toggle-title {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #111827;
+    }
+
+    .arcana-eval-actions {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      border-top: 1px solid #f3f4f6;
+      padding-top: 1.25rem;
+      margin-top: 0.25rem;
+    }
+
+    .arcana-eval-progress {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+      min-width: 0;
+    }
+
+    .arcana-eval-progress-label {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.8125rem;
+      color: #4b5563;
+    }
+
+    .arcana-eval-progress-elapsed {
+      color: #6b7280;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .arcana-eval-progress-bar {
+      height: 6px;
+      background: #ede9fe;
+      border-radius: 3px;
+      overflow: hidden;
+    }
+
+    .arcana-eval-progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #8b5cf6, #7c3aed);
+      border-radius: 3px;
+      transition: width 0.3s ease;
+    }
+
+    .arcana-eval-progress-current {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.8125rem;
+      color: #6d28d9;
+      margin-top: 0.125rem;
+    }
+
+    .arcana-eval-progress-current-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+
+    .arcana-eval-progress-spinner {
+      display: inline-block;
+      width: 0.75rem;
+      height: 0.75rem;
+      border: 2px solid #ede9fe;
+      border-top-color: #7c3aed;
+      border-radius: 50%;
+      flex-shrink: 0;
+      animation: arcana-eval-spin 0.8s linear infinite;
+    }
+
+    @keyframes arcana-eval-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .arcana-eval-run-btn {
+      background: #7c3aed;
+      color: white;
+      padding: 0.625rem 1.5rem;
+      border: none;
+      border-radius: 0.5rem;
+      font-size: 0.9375rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background-color 0.15s ease;
+    }
+
+    .arcana-eval-run-btn:hover:not(:disabled) {
+      background: #6d28d9;
+    }
+
+    .arcana-eval-run-btn:disabled {
+      background: #9ca3af;
+      cursor: not-allowed;
+      opacity: 0.7;
+    }
+
+    @media (max-width: 640px) {
+      .arcana-eval-option-grid,
+      .arcana-eval-options-row {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .arcana-metrics-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .arcana-metric-card {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 1rem;
+      text-align: center;
+    }
+
+    .arcana-metric-value {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #7c3aed;
+    }
+
+    .arcana-metric-label {
+      font-size: 0.75rem;
+      color: #6b7280;
+      margin-top: 0.25rem;
+    }
+
+    /* Empty state for the test cases view when no test cases exist. */
+    .arcana-eval-empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 3rem 1rem;
+      background: #fafafa;
+      border: 1px dashed #d1d5db;
+      border-radius: 0.75rem;
+      text-align: center;
+      color: #6b7280;
+    }
+
+    .arcana-eval-empty-state h4 {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .arcana-eval-empty-state p {
+      margin: 0;
+      font-size: 0.875rem;
+    }
+
+    .arcana-eval-empty-state code {
+      background: #f3f4f6;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.8125rem;
+    }
+
+    .arcana-eval-empty-icon {
+      font-size: 2.5rem;
+      color: #d1d5db;
+      line-height: 1;
+    }
+
+    /* Test case list: compact rows that expand on click to show the
+       reference answer (when present) and the relevant chunks. */
+    .arcana-test-case-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+      margin-top: 1.5rem;
+    }
+
+    .arcana-test-case {
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      overflow: hidden;
+      transition: border-color 0.15s ease;
+    }
+
+    .arcana-test-case.expanded {
+      border-color: #c4b5fd;
+    }
+
+    .arcana-test-case-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.625rem 0.875rem;
+    }
+
+    .arcana-test-case-row-main {
+      display: grid;
+      grid-template-columns: auto 1fr auto auto auto;
+      align-items: center;
+      gap: 0.75rem;
+      flex: 1;
+      min-width: 0;
+      cursor: pointer;
+      padding: 0.125rem 0;
+      border-radius: 0.25rem;
+      transition: background-color 0.15s ease;
+    }
+
+    .arcana-test-case-row-main:hover {
+      background: #fafafa;
+    }
+
+    .arcana-test-case.expanded .arcana-test-case-row {
+      background: #faf5ff;
+      border-bottom: 1px solid #ede9fe;
+    }
+
+    .arcana-test-case-chevron {
+      color: #9ca3af;
+      font-size: 0.75rem;
+      width: 0.75rem;
+      text-align: center;
+    }
+
+    .arcana-test-case-question {
+      font-size: 0.875rem;
+      color: #111827;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+
+    .arcana-test-case-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    .arcana-test-case-badge--generated {
+      background: #ede9fe;
+      color: #6d28d9;
+    }
+
+    .arcana-test-case-badge--synthetic {
+      background: #ede9fe;
+      color: #6d28d9;
+    }
+
+    .arcana-test-case-badge--manual {
+      background: #dbeafe;
+      color: #1d4ed8;
+    }
+
+    .arcana-test-case-chunks {
+      font-size: 0.75rem;
+      color: #6b7280;
+      white-space: nowrap;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .arcana-test-case-time {
+      font-size: 0.75rem;
+      color: #9ca3af;
+      white-space: nowrap;
+      cursor: help;
+    }
+
+    .arcana-test-case-detail {
+      padding: 1rem 1rem 1.25rem 2rem;
+      background: #fafafa;
+    }
+
+    .arcana-test-case-detail-section {
+      margin-top: 0.75rem;
+    }
+
+    .arcana-test-case-detail-section:first-child {
+      margin-top: 0;
+    }
+
+    .arcana-test-case-detail-section h5 {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6d28d9;
+      margin: 0 0 0.375rem;
+    }
+
+    .arcana-test-case-detail-section p {
+      margin: 0;
+      font-size: 0.875rem;
+      color: #374151;
+      line-height: 1.5;
+    }
+
+    .arcana-test-case-chunk-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+    }
+
+    .arcana-test-case-chunk-list li {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.625rem;
+      align-items: baseline;
+      padding: 0.375rem 0.5rem;
+      background: white;
+      border-radius: 0.25rem;
+      border: 1px solid #f3f4f6;
+    }
+
+    .arcana-test-case-chunk-id {
+      font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+      font-size: 0.75rem;
+      color: #7c3aed;
+      padding: 0.0625rem 0.25rem;
+      background: #faf5ff;
+      border-radius: 0.1875rem;
+    }
+
+    .arcana-test-case-chunk-text {
+      font-size: 0.8125rem;
+      color: #4b5563;
+      line-height: 1.5;
+    }
+
+    .arcana-test-case-empty {
+      font-size: 0.875rem;
+      color: #9ca3af;
+      font-style: italic;
+    }
+
+    .arcana-actions-cell {
+      text-align: center;
+      white-space: nowrap;
+    }
+
+    .arcana-icon-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.375rem;
+      background: transparent;
+      color: #9ca3af;
+      border: none;
+      border-radius: 0.25rem;
+      cursor: pointer;
+    }
+
+    .arcana-icon-btn:hover {
+      color: #7c3aed;
+      background: #f3f4f6;
+    }
+
+    .arcana-delete-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.375rem;
+      background: transparent;
+      color: #9ca3af;
+      border: none;
+      border-radius: 0.25rem;
+      cursor: pointer;
+    }
+
+    .arcana-delete-btn:hover {
+      color: #dc2626;
+      background: #fef2f2;
+    }
+
+    .arcana-run-card {
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      margin-bottom: 1rem;
+      overflow: hidden;
+    }
+
+    .arcana-run-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.75rem 1rem;
+      background: #f3f4f6;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .arcana-run-header-left {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .arcana-run-status {
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+
+    .arcana-run-status.completed {
+      background: #d1fae5;
+      color: #065f46;
+    }
+
+    .arcana-run-status.running {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .arcana-run-status.failed {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    .arcana-run-body {
+      padding: 1rem;
+    }
+
+    .arcana-run-config {
+      font-size: 0.75rem;
+      color: #6b7280;
+      margin-bottom: 0.75rem;
+    }
+
+    /* Upload styles */
+    .arcana-dropzone {
+      position: relative;
+      border: 2px dashed #d1d5db;
+      border-radius: 0.5rem;
+      padding: 2rem;
+      text-align: center;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      margin-bottom: 1rem;
+    }
+
+    .arcana-dropzone:hover {
+      border-color: #7c3aed;
+      background: #f5f3ff;
+    }
+
+    .arcana-dropzone p {
+      margin: 0 0 0.5rem 0;
+      color: #374151;
+    }
+
+    .arcana-upload-hint {
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+
+    .arcana-file-input {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+    }
+
+    .arcana-upload-entry {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.5rem;
+      background: #f9fafb;
+      border-radius: 0.375rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .arcana-upload-entry progress {
+      flex: 1;
+      height: 0.5rem;
+    }
+
+    .arcana-upload-entry button {
+      background: transparent;
+      border: none;
+      color: #dc2626;
+      cursor: pointer;
+      font-size: 1.25rem;
+    }
+
+    .arcana-upload-error {
+      color: #dc2626;
+      font-size: 0.75rem;
+    }
+
+    .arcana-upload-btn {
+      background: #7c3aed;
+      color: white;
+      padding: 0.625rem 1.25rem;
+      border: none;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+    }
+
+    .arcana-upload-btn:hover {
+      background: #6d28d9;
+    }
+
+    .arcana-divider {
+      text-align: center;
+      color: #6b7280;
+      font-size: 0.875rem;
+      margin: 1.5rem 0;
+      position: relative;
+    }
+
+    .arcana-divider::before,
+    .arcana-divider::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      width: 40%;
+      height: 1px;
+      background: #e5e7eb;
+    }
+
+    .arcana-divider::before {
+      left: 0;
+    }
+
+    .arcana-divider::after {
+      right: 0;
+    }
+
+    /* Search Results Styles */
+    .arcana-search-results {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .arcana-search-result {
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      overflow: hidden;
+      background: white;
+    }
+
+    .arcana-result-header {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.75rem 1rem;
+      background: #f9fafb;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .arcana-result-score {
+      min-width: 60px;
+    }
+
+    .arcana-result-score .score-value {
+      font-weight: 600;
+      color: #7c3aed;
+      font-size: 0.875rem;
+    }
+
+    .arcana-result-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex: 1;
+    }
+
+    .arcana-result-meta code {
+      font-size: 0.7rem;
+    }
+
+    .arcana-chunk-badge {
+      background: #ede9fe;
+      color: #6d28d9;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+
+    .arcana-result-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .arcana-result-btn {
+      padding: 0.375rem 0.75rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      background: white;
+      font-size: 0.75rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-result-btn:hover {
+      border-color: #7c3aed;
+      color: #7c3aed;
+    }
+
+    .arcana-result-btn-primary {
+      background: #7c3aed;
+      border-color: #7c3aed;
+      color: white;
+    }
+
+    .arcana-result-btn-primary:hover {
+      background: #6d28d9;
+      border-color: #6d28d9;
+      color: white;
+    }
+
+    .arcana-result-text {
+      padding: 1rem;
+      font-size: 0.875rem;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      color: #374151;
+      max-height: 100px;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .arcana-result-text.expanded {
+      max-height: none;
+      overflow: visible;
+    }
+
+    /* ChunkResultsComponent: grouped chunks with expandable details. */
+    .arcana-chunk-results {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .arcana-chunk-doc {
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      overflow: hidden;
+    }
+
+    .arcana-chunk-doc--has-source {
+      border-color: #a7f3d0;
+      box-shadow: 0 0 0 1px #a7f3d0 inset;
+    }
+
+    .arcana-chunk-doc-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.625rem 0.875rem;
+      background: #f9fafb;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .arcana-chunk-doc--has-source .arcana-chunk-doc-header {
+      background: #ecfdf5;
+      border-bottom-color: #a7f3d0;
+    }
+
+    .arcana-chunk-doc-title {
+      margin: 0;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #111827;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .arcana-chunk-doc-link {
+      color: inherit;
+      text-decoration: none;
+      transition: color 0.15s ease;
+    }
+
+    .arcana-chunk-doc-link:hover {
+      color: #6d28d9;
+      text-decoration: underline;
+    }
+
+    .arcana-chunk-doc-meta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.75rem;
+      color: #6b7280;
+      flex-shrink: 0;
+    }
+
+    .arcana-chunk-source-dot {
+      display: inline-block;
+      width: 0.5rem;
+      height: 0.5rem;
+      border-radius: 50%;
+      background: #10b981;
+    }
+
+    .arcana-chunk-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .arcana-chunk-item {
+      border-top: 1px solid #f3f4f6;
+    }
+
+    .arcana-chunk-item:first-child {
+      border-top: none;
+    }
+
+    .arcana-chunk-item--source {
+      background: #f0fdf4;
+    }
+
+    .arcana-chunk-details {
+      width: 100%;
+    }
+
+    .arcana-chunk-summary {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      padding: 0.5rem 0.875rem;
+      cursor: pointer;
+      list-style: none;
+      font-size: 0.8125rem;
+      line-height: 1.4;
+      user-select: none;
+    }
+
+    .arcana-chunk-summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .arcana-chunk-summary::before {
+      content: '▸';
+      color: #9ca3af;
+      font-size: 0.6875rem;
+      flex-shrink: 0;
+      transition: transform 0.15s ease;
+      display: inline-block;
+    }
+
+    .arcana-chunk-details[open] > .arcana-chunk-summary::before {
+      transform: rotate(90deg);
+    }
+
+    .arcana-chunk-summary:hover {
+      background: #f9fafb;
+    }
+
+    .arcana-chunk-item--source .arcana-chunk-summary:hover {
+      background: #dcfce7;
+    }
+
+    .arcana-chunk-score {
+      font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: #6d28d9;
+      flex-shrink: 0;
+    }
+
+    .arcana-chunk-index {
+      font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+      font-size: 0.6875rem;
+      color: #9ca3af;
+      flex-shrink: 0;
+    }
+
+    .arcana-chunk-supports {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: #047857;
+      background: #d1fae5;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      flex-shrink: 0;
+    }
+
+    .arcana-chunk-via {
+      font-size: 0.6875rem;
+      color: #7c3aed;
+      background: #ede9fe;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      flex-shrink: 0;
+      max-width: 12rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .arcana-chunk-preview {
+      flex: 1;
+      min-width: 0;
+      color: #4b5563;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .arcana-chunk-full {
+      padding: 0.75rem 1rem 1rem 2.25rem;
+      font-size: 0.8125rem;
+      line-height: 1.55;
+      color: #1f2937;
+      white-space: pre-line;
+      border-top: 1px dashed #e5e7eb;
+    }
+
+    /* Collection checkboxes - shared between Search and Ask tabs */
+    .arcana-ask-collections {
+      margin: 1rem 0;
+    }
+
+    .arcana-ask-collections > label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #374151;
+      margin-bottom: 0.5rem;
+    }
+
+    .arcana-llm-select-toggle {
+      margin-bottom: 0.75rem;
+      padding: 0.75rem;
+      background: #f5f3ff;
+      border: 1px solid #ddd6fe;
+      border-radius: 0.5rem;
+    }
+    .arcana-llm-select-toggle .arcana-checkbox-label {
+      margin: 0;
+    }
+
+    .arcana-collection-checkboxes {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .arcana-collection-check {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.375rem 0.75rem;
+      background: white;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.8125rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-collection-check:hover {
+      border-color: #7c3aed;
+      background: #faf5ff;
+    }
+
+    .arcana-collection-check:has(input:checked) {
+      border-color: #7c3aed;
+      background: #ede9fe;
+      color: #5b21b6;
+    }
+
+    .arcana-collection-check input {
+      accent-color: #7c3aed;
+    }
+
+    .arcana-collection-hint {
+      display: block;
+      margin-top: 0.375rem;
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+
+    /* Tab description */
+    .arcana-tab-description {
+      color: #6b7280;
+      margin-bottom: 1rem;
+      font-size: 0.875rem;
+    }
+
+    /* Ask tab styles */
+    .arcana-ask-mode-nav {
+      display: inline-flex;
+      background: #f3f4f6;
+      border-radius: 0.5rem;
+      padding: 0.25rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .arcana-mode-btn {
+      padding: 0.5rem 1rem;
+      border: none;
+      background: transparent;
+      color: #6b7280;
+      font-size: 0.875rem;
+      font-weight: 500;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-mode-btn:hover {
+      color: #374151;
+    }
+
+    .arcana-mode-btn.active {
+      background: white;
+      color: #7c3aed;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+
+    .arcana-mode-description {
+      color: #9ca3af;
+      font-size: 0.8125rem;
+      margin-bottom: 1rem;
+      font-style: italic;
+    }
+
+    .arcana-ask-form {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .arcana-ask-input textarea {
+      width: 100%;
+      padding: 0.75rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      resize: vertical;
+      box-sizing: border-box;
+    }
+
+    .arcana-ask-input textarea:focus {
+      outline: none;
+      border-color: #7c3aed;
+      box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+    }
+
+    .arcana-ask-options {
+      margin-top: 1rem;
+      padding-top: 1rem;
+      border-top: 1px solid #e5e7eb;
+    }
+
+    .arcana-ask-options h4 {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #374151;
+      margin: 0 0 0.75rem 0;
+    }
+
+    .arcana-pipeline {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .arcana-pipeline > li {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .arcana-pipeline > li:not(:last-child)::after {
+      content: '';
+      display: block;
+      width: 2px;
+      height: 1.25rem;
+      background: #c4b5fd;
+    }
+
+    .arcana-pipeline > li:has(> .arcana-pipeline-step:not(:has(input:checked)):not(.fixed)):not(:last-child)::after {
+      background: none;
+      border-left: 2px dashed #d1d5db;
+    }
+
+    .arcana-pipeline-step {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 240px;
+      padding: 0.625rem 1rem;
+      background: #fafafa;
+      border: 2px dashed #d1d5db;
+      border-radius: 0.5rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      text-align: center;
+    }
+
+    .arcana-pipeline-step:has(input:checked) {
+      background: #ede9fe;
+      border: 2px solid #7c3aed;
+    }
+
+    .arcana-pipeline-step:has(input:checked) .arcana-step-label {
+      color: #6d28d9;
+    }
+
+    .arcana-pipeline-step:not(.fixed):hover {
+      border-color: #a78bfa;
+    }
+
+    .arcana-pipeline-step.fixed {
+      background: #f0fdf4;
+      border: 2px solid #86efac;
+      cursor: default;
+    }
+
+    .arcana-pipeline-step.fixed .arcana-step-label {
+      color: #15803d;
+    }
+
+    .arcana-pipeline-step input[type="checkbox"],
+    .arcana-pipeline-step input[type="radio"] {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .arcana-step-label {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .arcana-pipeline-step small {
+      font-size: 0.75rem;
+      color: #6b7280;
+      margin-top: 0.125rem;
+    }
+
+    .arcana-pipeline-fork {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .arcana-pipeline-fork .arcana-pipeline-step {
+      width: 160px;
+    }
+
+    .arcana-fork-or {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: #9ca3af;
+      text-transform: uppercase;
+    }
+
+    .arcana-pipeline-step:has(input:disabled) {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    /* Phase grouping: wraps the flat pipeline into three labeled sections
+       (Query preparation, Retrieval, Answer) with a thin divider line
+       between them. Each phase keeps its own vertical flow; the dividers
+       make the three stages visible without losing the single-column shape. */
+    .arcana-pipeline-phases {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 1rem;
+    }
+
+    .arcana-pipeline-phase {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 1rem 0.75rem 1.25rem;
+      background: #faf5ff;
+      border: 1px solid #ede9fe;
+      border-radius: 0.625rem;
+    }
+
+    .arcana-pipeline-phase-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+      max-width: 280px;
+      margin: 0 auto 0.75rem;
+    }
+
+    .arcana-pipeline-phase-header h5 {
+      margin: 0;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #7c3aed;
+    }
+
+    .arcana-pipeline-phase-toggle {
+      font-size: 0.6875rem;
+      font-weight: 400;
+      color: #9ca3af;
+      letter-spacing: 0;
+      text-transform: none;
+    }
+
+    /* Substep: a conditional loop on the previous step (Multi-hop reasoning
+       loops search, Self-correction loops answer). The ↻ glyph on the label
+       signals the loop relationship. Keeps the same width + center axis as
+       the primary steps so the vertical connector stays straight. */
+    .arcana-loop-glyph {
+      display: inline-block;
+      margin-right: 0.25rem;
+      color: #a78bfa;
+      font-weight: 700;
+    }
+
+    .arcana-pipeline-step:has(input:checked) .arcana-loop-glyph {
+      color: #7c3aed;
+    }
+
+    /* Ask page sub-tabs: segmented pill control. Distinct from the
+       top-level .arcana-tab nav (which uses underlines) so the two
+       navigation levels don't visually compete. */
+    .arcana-ask-sub-tab-nav {
+      display: inline-flex;
+      align-items: center;
+      background: #f3f4f6;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 0.25rem;
+      gap: 0.125rem;
+      margin: 1rem 0 0.75rem;
+    }
+
+    .arcana-ask-sub-tab {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 36px;
+      padding: 0.5rem 1.25rem;
+      border: none;
+      background: transparent;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #6b7280;
+      cursor: pointer;
+      border-radius: 0.375rem;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-ask-sub-tab:hover:not(.active) {
+      color: #4b5563;
+      background: rgba(255, 255, 255, 0.6);
+    }
+
+    .arcana-ask-sub-tab.active {
+      background: #ffffff;
+      color: #6d28d9;
+      font-weight: 600;
+      box-shadow:
+        0 1px 2px rgba(15, 23, 42, 0.06),
+        0 1px 3px rgba(15, 23, 42, 0.04);
+    }
+
+    .arcana-sub-tab-description {
+      color: #6b7280;
+      font-size: 0.875rem;
+      margin: 0 0 1.25rem 0;
+      line-height: 1.5;
+    }
+
+    /* Loop settings: card grid that mirrors the .arcana-pipeline-step
+       visual language so the Loop sub-tab feels like part of the same
+       surface as the Pipeline sub-tab. */
+    .arcana-loop-settings {
+      margin-top: 0.75rem;
+    }
+
+    .arcana-loop-settings h4 {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin: 0 0 0.5rem 0;
+    }
+
+    /* Two-row layout: info cards (4-col) row, then number+toggle (2-col)
+       row. Both rows live inside the same grid so column widths align.
+       Info cards are horizontally compact; number inputs and the toggle
+       get their own tighter row beneath them. */
+    .arcana-loop-settings-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 0.5rem;
+    }
+
+    .arcana-loop-setting {
+      display: flex;
+      flex-direction: column;
+      padding: 0.625rem 0.75rem;
+      background: #fafafa;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      gap: 0.125rem;
+      transition: border-color 0.15s ease;
+      min-width: 0;
+    }
+
+    .arcana-loop-setting:hover {
+      border-color: #d1d5db;
+    }
+
+    .arcana-loop-setting label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .arcana-loop-setting > small {
+      font-size: 0.6875rem;
+      color: #6b7280;
+      line-height: 1.35;
+    }
+
+    .arcana-loop-setting code {
+      font-size: 0.625rem;
+      background: #ede9fe;
+      color: #6d28d9;
+      padding: 0.0625rem 0.3125rem;
+      border-radius: 0.1875rem;
+    }
+
+    .arcana-loop-setting--info {
+      background: #f5f3ff;
+      border-color: #ddd6fe;
+    }
+
+    .arcana-loop-setting--info:hover {
+      border-color: #c4b5fd;
+    }
+
+    .arcana-loop-setting-value {
+      margin-top: 0.25rem;
+      font-size: 0.6875rem;
+      color: #6d28d9;
+      font-family:
+        ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* Inline temperature row inside an LLM info card. The temperature is
+       visually attached to the LLM it controls so users can see at a
+       glance which model each setting affects. */
+    .arcana-loop-setting-temp {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      margin-top: 0.5rem;
+      padding-top: 0.5rem;
+      border-top: 1px dashed #ddd6fe;
+    }
+
+    .arcana-loop-setting-temp label {
+      font-size: 0.625rem;
+      font-weight: 600;
+      color: #9ca3af;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin: 0;
+    }
+
+    .arcana-loop-setting-temp input[type="number"] {
+      width: 2.75rem;
+      margin: 0;
+      padding: 0.125rem 0.3125rem;
+      border: 1px solid #ddd6fe;
+      border-radius: 0.25rem;
+      font-size: 0.6875rem;
+      background: white;
+      color: #6d28d9;
+      box-sizing: border-box;
+      /* Hide the spin buttons in WebKit since the field is too narrow
+         for them to be useful and they consume horizontal space. */
+      appearance: textfield;
+      -moz-appearance: textfield;
+    }
+
+    .arcana-loop-setting-temp input[type="number"]::-webkit-inner-spin-button,
+    .arcana-loop-setting-temp input[type="number"]::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    .arcana-loop-setting-temp input[type="number"]:focus {
+      outline: none;
+      border-color: #7c3aed;
+      box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.15);
+    }
+
+    .arcana-loop-setting-temp input[type="number"]:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    /* Number-input cards (max_iterations, chunk_cap) sit in two
+       compact columns beneath the four LLM info cards. The remaining
+       two columns of the row are visually balanced by the full-width
+       toggle below. */
+    .arcana-loop-setting--number {
+      grid-column: span 1;
+    }
+
+    .arcana-loop-setting input[type="number"] {
+      margin-top: 0.25rem;
+      width: 100%;
+      padding: 0.375rem 0.625rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.3125rem;
+      font-size: 0.8125rem;
+      background: white;
+      color: #111827;
+      box-sizing: border-box;
+      transition:
+        border-color 0.15s ease,
+        box-shadow 0.15s ease;
+    }
+
+    .arcana-loop-setting input[type="number"]:focus {
+      outline: none;
+      border-color: #7c3aed;
+      box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+    }
+
+    .arcana-loop-setting input[type="number"]:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    .arcana-loop-setting--toggle {
+      grid-column: 1 / -1;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.625rem;
+      padding: 0.5rem 0.75rem;
+      cursor: pointer;
+    }
+
+    .arcana-loop-setting--toggle:has(input:checked) {
+      background: #ede9fe;
+      border-color: #7c3aed;
+    }
+
+    .arcana-loop-setting--toggle:has(input:checked) .arcana-loop-toggle-label {
+      color: #6d28d9;
+    }
+
+    .arcana-loop-setting--toggle input[type="checkbox"] {
+      margin: 0;
+      width: 15px;
+      height: 15px;
+      accent-color: #7c3aed;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    .arcana-loop-toggle-content {
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      min-width: 0;
+    }
+
+    .arcana-loop-toggle-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .arcana-loop-toggle-content small {
+      font-size: 0.6875rem;
+      color: #6b7280;
+      line-height: 1.3;
+    }
+
+    /* Loop trace: shared visual language for both the live (during run)
+       and the static (post run) tool history. The live variant adds a
+       pulsing header and a slide-in animation on each new entry. */
+    .arcana-loop-trace,
+    .arcana-loop-live-trace {
+      margin-top: 1rem;
+      background: #fafafa;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 1rem 1.25rem;
+    }
+
+    .arcana-loop-live-trace {
+      background: linear-gradient(180deg, #faf5ff 0%, #fafafa 100%);
+      border-color: #ddd6fe;
+    }
+
+    .arcana-loop-trace h4 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin: 0 0 0.875rem 0;
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+    }
+
+    .arcana-loop-meta {
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: #9ca3af;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+
+    .arcana-loop-meta code {
+      font-size: 0.6875rem;
+      background: #ede9fe;
+      color: #6d28d9;
+      padding: 0.0625rem 0.375rem;
+      border-radius: 0.25rem;
+    }
+
+    .arcana-loop-live-header {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #6d28d9;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 0.875rem;
+    }
+
+    .arcana-loop-live-pulse {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #7c3aed;
+      box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.6);
+      animation: arcana-loop-pulse 1.6s ease-out infinite;
+    }
+
+    @keyframes arcana-loop-pulse {
+      0% {
+        box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.6);
+      }
+      70% {
+        box-shadow: 0 0 0 8px rgba(124, 58, 237, 0);
+      }
+      100% {
+        box-shadow: 0 0 0 0 rgba(124, 58, 237, 0);
+      }
+    }
+
+    .arcana-loop-live-title {
+      flex: 1;
+    }
+
+    .arcana-loop-live-count {
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: #9ca3af;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+
+    .arcana-loop-live-empty {
+      font-size: 0.8125rem;
+      color: #9ca3af;
+      font-style: italic;
+      padding: 0.5rem 0 0.25rem;
+    }
+
+    .arcana-loop-iterations {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      position: relative;
+    }
+
+    /* Vertical timeline rail running down the left side of the iteration
+       list. Anchored to the iter-num badge so the rail aligns with the
+       center of each badge. */
+    .arcana-loop-iterations::before {
+      content: '';
+      position: absolute;
+      left: 0.875rem;
+      top: 0.75rem;
+      bottom: 0.75rem;
+      width: 2px;
+      background: #e5e7eb;
+      border-radius: 1px;
+    }
+
+    .arcana-loop-iterations--live::before {
+      background: linear-gradient(180deg, #c4b5fd 0%, #ddd6fe 100%);
+    }
+
+    .arcana-loop-iteration {
+      position: relative;
+      padding: 0.375rem 0 0.375rem 2.25rem;
+      min-height: 2.5rem;
+      display: flex;
+      align-items: center;
+      animation: arcana-loop-fade-in 0.35s ease-out both;
+    }
+
+    @keyframes arcana-loop-fade-in {
+      from {
+        opacity: 0;
+        transform: translateY(-4px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .arcana-loop-iter-header {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      flex-wrap: wrap;
+      min-height: 1.75rem;
+    }
+
+    .arcana-loop-iter-num {
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 1.75rem;
+      height: 1.75rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: white;
+      border: 2px solid #e5e7eb;
+      border-radius: 50%;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      color: #6b7280;
+      z-index: 1;
+    }
+
+    .arcana-loop-iterations--live .arcana-loop-iter-num {
+      border-color: #c4b5fd;
+      color: #6d28d9;
+    }
+
+    /* Per-tool color coding so search vs answer vs give_up is scannable */
+    .arcana-tool-search .arcana-loop-iter-num {
+      border-color: #93c5fd;
+      color: #1d4ed8;
+      background: #eff6ff;
+    }
+
+    .arcana-tool-answer .arcana-loop-iter-num {
+      border-color: #86efac;
+      color: #15803d;
+      background: #f0fdf4;
+    }
+
+    .arcana-tool-give_up .arcana-loop-iter-num {
+      border-color: #fca5a5;
+      color: #b91c1c;
+      background: #fef2f2;
+    }
+
+    .arcana-tool-synthesis .arcana-loop-iter-num {
+      border-color: #fcd34d;
+      color: #b45309;
+      background: #fffbeb;
+    }
+
+    .arcana-loop-tool {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      font-family:
+        ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      padding: 0.125rem 0.5rem;
+      border-radius: 0.25rem;
+      background: #f3f4f6;
+      color: #374151;
+    }
+
+    .arcana-tool-search .arcana-loop-tool {
+      background: #dbeafe;
+      color: #1d4ed8;
+    }
+
+    .arcana-tool-answer .arcana-loop-tool {
+      background: #dcfce7;
+      color: #15803d;
+    }
+
+    .arcana-tool-give_up .arcana-loop-tool {
+      background: #fee2e2;
+      color: #b91c1c;
+    }
+
+    .arcana-tool-synthesis .arcana-loop-tool {
+      background: #fef3c7;
+      color: #b45309;
+    }
+
+    /* Pipeline step trace: same visual language as the loop trace, but
+       each entry is a "step" with a running/done state instead of a
+       completed tool call. The number badge contains a tiny spinner
+       while running, then becomes a step number when done. */
+    .arcana-pipeline-iterations::before {
+      background: linear-gradient(180deg, #c4b5fd 0%, #ddd6fe 100%);
+    }
+
+    .arcana-pipeline-step-trace--running .arcana-loop-iter-num {
+      background: #f5f3ff;
+      border-color: #c4b5fd;
+      color: #6d28d9;
+    }
+
+    .arcana-pipeline-step-trace--running .arcana-loop-tool {
+      background: #ede9fe;
+      color: #6d28d9;
+    }
+
+    .arcana-pipeline-step-trace--done .arcana-loop-iter-num {
+      background: #f0fdf4;
+      border-color: #86efac;
+      color: #15803d;
+    }
+
+    .arcana-pipeline-step-trace--done .arcana-loop-tool {
+      background: #dcfce7;
+      color: #15803d;
+    }
+
+    .arcana-pipeline-step-spinner {
+      width: 0.75rem;
+      height: 0.75rem;
+      border-radius: 50%;
+      border: 2px solid rgba(124, 58, 237, 0.25);
+      border-top-color: #7c3aed;
+      animation: arcana-pipeline-spin 0.8s linear infinite;
+    }
+
+    @keyframes arcana-pipeline-spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    .arcana-loop-args {
+      font-size: 0.8125rem;
+      color: #4b5563;
+      font-family:
+        ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .arcana-loop-chunk-count {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: #6d28d9;
+      background: #ede9fe;
+      padding: 0.125rem 0.5rem;
+      border-radius: 999px;
+      flex-shrink: 0;
+    }
+
+    .arcana-checkbox-label {
+      display: flex;
+      flex-direction: column;
+      padding: 0.75rem;
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-checkbox-label:hover {
+      border-color: #7c3aed;
+    }
+
+    .arcana-checkbox-label input[type="checkbox"] {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .arcana-checkbox-label span {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #374151;
+    }
+
+    .arcana-checkbox-label small {
+      font-size: 0.75rem;
+      color: #6b7280;
+      margin-top: 0.25rem;
+    }
+
+    .arcana-checkbox-label:has(input:checked) {
+      background: #ede9fe;
+      border-color: #7c3aed;
+    }
+
+    .arcana-checkbox-label:has(input:checked) span {
+      color: #6d28d9;
+    }
+
+    .arcana-checkbox-label:has(input:disabled) {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .arcana-ask-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .arcana-ask-actions button {
+      background: #7c3aed;
+      color: white;
+      padding: 0.625rem 1.25rem;
+      border: none;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.15s ease;
+    }
+
+    .arcana-ask-actions button:hover {
+      background: #6d28d9;
+    }
+
+    .arcana-ask-actions button:disabled {
+      background: #9ca3af;
+      cursor: not-allowed;
+    }
+
+    .arcana-ask-actions button[type="button"] {
+      background: transparent;
+      color: #6b7280;
+      border: 1px solid #d1d5db;
+    }
+
+    .arcana-ask-actions button[type="button"]:hover {
+      border-color: #7c3aed;
+      color: #7c3aed;
+      background: transparent;
+    }
+
+    .arcana-ask-loading {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 1.5rem;
+      background: #f9fafb;
+      border-radius: 0.5rem;
+      color: #6b7280;
+    }
+
+    .arcana-spinner {
+      width: 1.25rem;
+      height: 1.25rem;
+      border: 2px solid #e5e7eb;
+      border-top-color: #7c3aed;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .arcana-ask-results {
+      margin-top: 1.5rem;
+    }
+
+    .arcana-ask-answer {
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      overflow: hidden;
+      margin-bottom: 1rem;
+    }
+
+    .arcana-ask-answer h3 {
+      margin: 0;
+      padding: 0.75rem 1rem;
+      background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
+      color: white;
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
+
+    .arcana-answer-content {
+      padding: 1rem 1.25rem;
+      font-size: 0.875rem;
+      line-height: 1.6;
+      color: #1f2937;
+    }
+
+    /* Markdown elements inside a rendered answer. Earmark produces
+       standard HTML, so we style a minimal set: paragraphs, lists,
+       inline emphasis, inline code, and a few headers. */
+    .arcana-answer-content > :first-child {
+      margin-top: 0;
+    }
+
+    .arcana-answer-content > :last-child {
+      margin-bottom: 0;
+    }
+
+    .arcana-answer-content p {
+      margin: 0 0 0.75rem 0;
+    }
+
+    .arcana-answer-content ul,
+    .arcana-answer-content ol {
+      margin: 0 0 0.75rem 0;
+      padding-left: 1.5rem;
+    }
+
+    .arcana-answer-content li {
+      margin-bottom: 0.25rem;
+    }
+
+    .arcana-answer-content li > ul,
+    .arcana-answer-content li > ol {
+      margin-top: 0.25rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .arcana-answer-content strong {
+      font-weight: 600;
+      color: #111827;
+    }
+
+    .arcana-answer-content em {
+      font-style: italic;
+    }
+
+    .arcana-answer-content code {
+      background: #f3f4f6;
+      color: #7c3aed;
+      padding: 0.0625rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.8125rem;
+      font-family:
+        ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    }
+
+    .arcana-answer-content pre {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      padding: 0.75rem;
+      overflow-x: auto;
+      margin: 0 0 0.75rem 0;
+    }
+
+    .arcana-answer-content pre code {
+      background: transparent;
+      color: inherit;
+      padding: 0;
+    }
+
+    .arcana-answer-content h1,
+    .arcana-answer-content h2,
+    .arcana-answer-content h3,
+    .arcana-answer-content h4,
+    .arcana-answer-content h5,
+    .arcana-answer-content h6 {
+      font-weight: 700;
+      color: #1f2937;
+      margin: 1.5rem 0 0.5rem 0;
+      line-height: 1.3;
+    }
+
+    /* First heading shouldn't push down — there's already padding above. */
+    .arcana-answer-content > :first-child:is(h1, h2, h3, h4, h5, h6) {
+      margin-top: 0;
+    }
+
+    .arcana-answer-content h1 {
+      font-size: 1.25rem;
+      color: #111827;
+      padding-bottom: 0.375rem;
+      border-bottom: 2px solid #ede9fe;
+    }
+
+    /* h2 is the most common section heading the LLM emits. Distinctive
+       but not loud: a left accent bar + a slightly bigger size + a touch
+       of color. */
+    .arcana-answer-content h2 {
+      font-size: 1.0625rem;
+      color: #6d28d9;
+      padding-left: 0.75rem;
+      border-left: 3px solid #7c3aed;
+    }
+
+    .arcana-answer-content h3 {
+      font-size: 0.9375rem;
+      color: #4b5563;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      font-weight: 600;
+    }
+
+    .arcana-answer-content h4,
+    .arcana-answer-content h5,
+    .arcana-answer-content h6 {
+      font-size: 0.875rem;
+      color: #4b5563;
+      font-weight: 600;
+    }
+
+    .arcana-answer-content blockquote {
+      border-left: 3px solid #c4b5fd;
+      padding-left: 0.875rem;
+      color: #4b5563;
+      margin: 0 0 0.75rem 0;
+    }
+
+    .arcana-answer-content a {
+      color: #7c3aed;
+      text-decoration: underline;
+    }
+
+    .arcana-answer-content a:hover {
+      color: #6d28d9;
+    }
+
+    .arcana-ask-section {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .arcana-ask-section h4 {
+      margin: 0 0 0.75rem 0;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .arcana-query-list {
+      margin: 0;
+      padding-left: 1.5rem;
+      font-size: 0.875rem;
+      color: #374151;
+    }
+
+    .arcana-query-list li {
+      margin-bottom: 0.25rem;
+    }
+
+    /* Pipeline internals: one block below the answer that shows what each
+       pipeline step produced (rewritten query, gate decision, sub-questions,
+       etc). Renders as a <dl> with each step's label + value on one line. */
+    .arcana-pipeline-internals-list {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 0.5rem 1rem;
+      margin: 0;
+      font-size: 0.875rem;
+    }
+
+    .arcana-pipeline-internals-list dt {
+      font-weight: 600;
+      color: #6d28d9;
+      white-space: nowrap;
+    }
+
+    .arcana-pipeline-internals-list dd {
+      margin: 0;
+      color: #374151;
+      min-width: 0;
+    }
+
+    .arcana-pipeline-internals-quote {
+      font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+      font-size: 0.8125rem;
+      color: #4b5563;
+      background: #f9fafb;
+      padding: 0.125rem 0.5rem;
+      border-radius: 0.25rem;
+      display: inline-block;
+    }
+
+    .arcana-pipeline-internals-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .arcana-pipeline-internals-badge.skip {
+      background: #fef3c7;
+      color: #b45309;
+    }
+
+    .arcana-pipeline-internals-badge.retrieve {
+      background: #dbeafe;
+      color: #1d4ed8;
+    }
+
+    .arcana-pipeline-internals-badge.neutral {
+      background: #f3f4f6;
+      color: #6b7280;
+    }
+
+    .arcana-pipeline-internals-reasoning {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.8125rem;
+      color: #6b7280;
+      font-style: italic;
+    }
+
+    .arcana-pipeline-internals-feedback {
+      font-size: 0.8125rem;
+      color: #6b7280;
+      font-style: italic;
+      margin-bottom: 0.25rem;
+    }
+
+    .arcana-collection-badges {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .arcana-collection-badge {
+      background: #ede9fe;
+      color: #6d28d9;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+
+    /* Grounding Styles */
+
+    .arcana-grounding-score {
+      font-weight: 500;
+      font-size: 0.75rem;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      margin-left: 0.5rem;
+    }
+
+    .arcana-grounding-score.good { background: #d1fae5; color: #065f46; }
+    .arcana-grounding-score.warn { background: #fef3c7; color: #92400e; }
+    .arcana-grounding-score.bad { background: #fee2e2; color: #991b1b; }
+
+    .arcana-grounding-spans h5 {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #6b7280;
+      margin: 0.75rem 0 0.5rem 0;
+    }
+
+    .arcana-span {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.5rem;
+      border-radius: 0.375rem;
+      margin-bottom: 0.25rem;
+      font-size: 0.8rem;
+    }
+
+    .arcana-span.hallucinated {
+      background: #fef2f2;
+      border-left: 3px solid #ef4444;
+    }
+
+    .arcana-span.faithful {
+      background: #f0fdf4;
+      border-left: 3px solid #22c55e;
+    }
+
+    .arcana-span-text {
+      font-family: ui-monospace, monospace;
+      font-size: 0.8rem;
+    }
+
+    .arcana-span-score {
+      font-size: 0.7rem;
+      color: #9ca3af;
+    }
+
+    .arcana-span-sources {
+      display: flex;
+      gap: 0.25rem;
+      flex-wrap: wrap;
+      width: 100%;
+    }
+
+    .arcana-source-badge {
+      font-size: 0.65rem;
+      background: #f3f4f6;
+      color: #6b7280;
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+    }
+
+    .arcana-source-badge.clickable {
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      list-style: none;
+    }
+
+    .arcana-source-badge.clickable:hover {
+      background: #e5e7eb;
+    }
+
+    .arcana-source-badge.clickable::-webkit-details-marker {
+      display: none;
+    }
+
+    .arcana-source-label {
+      font-weight: 600;
+      color: #4b5563;
+    }
+
+    .arcana-source-overlap {
+      color: #9ca3af;
+    }
+
+    .arcana-source-detail {
+      display: inline;
+    }
+
+    .arcana-source-preview {
+      font-size: 0.7rem;
+      color: #4b5563;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.25rem;
+      padding: 0.5rem;
+      margin-top: 0.375rem;
+      margin-bottom: 0.25rem;
+      line-height: 1.5;
+      width: 100%;
+    }
+
+    /* Answer highlighting */
+    .arcana-hl-hallucinated {
+      background: #fecaca;
+      border-bottom: 2px solid #ef4444;
+      border-radius: 2px;
+      padding: 0 1px;
+    }
+
+    .arcana-hl-faithful {
+      background: #bbf7d0;
+      border-bottom: 2px solid #22c55e;
+      border-radius: 2px;
+      padding: 0 1px;
+    }
+
+    /* Graph Tab Styles */
+    .arcana-graph-subtabs {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .arcana-subtab-btn {
+      padding: 0.5rem 1rem;
+      border: 1px solid #d1d5db;
+      background: white;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .arcana-subtab-btn:hover {
+      border-color: #7c3aed;
+      color: #7c3aed;
+    }
+
+    .arcana-subtab-btn.active {
+      background: #7c3aed;
+      border-color: #7c3aed;
+      color: white;
+    }
+
+    .arcana-graph-table {
+      margin-top: 1rem;
+    }
+
+    /* Entity type badges */
+    .arcana-entity-type-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: lowercase;
+    }
+
+    .arcana-entity-type-badge.person {
+      background: #dbeafe;
+      color: #1e40af;
+    }
+
+    .arcana-entity-type-badge.organization {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .arcana-entity-type-badge.technology {
+      background: #fce7f3;
+      color: #9d174d;
+    }
+
+    .arcana-entity-type-badge.concept {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .arcana-entity-type-badge.location {
+      background: #e0e7ff;
+      color: #3730a3;
+    }
+
+    .arcana-entity-type-badge.event {
+      background: #f3e8ff;
+      color: #6b21a8;
+    }
+
+    /* Relationship strength meter */
+    .arcana-strength-meter {
+      display: inline-flex;
+      gap: 2px;
+      align-items: center;
+    }
+
+    .arcana-strength-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #e5e7eb;
+    }
+
+    .arcana-strength-dot.filled {
+      background: #7c3aed;
+    }
+
+    /* Community status indicators */
+    .arcana-status-ready {
+      color: #16a34a;
+    }
+
+    .arcana-status-pending {
+      color: #d97706;
+    }
+
+    .arcana-status-empty {
+      color: #9ca3af;
+    }
+
+    .arcana-no-summary {
+      color: #9ca3af;
+      font-style: italic;
+    }
+
+    /* Graph empty state */
+    .arcana-empty-state {
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.5rem;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    .arcana-empty-state h3 {
+      margin: 0 0 1rem 0;
+      color: #374151;
+    }
+
+    .arcana-empty-state p {
+      color: #6b7280;
+      margin: 0.5rem 0;
+    }
+
+    .arcana-empty-state pre {
+      background: #1f2937;
+      color: #e5e7eb;
+      padding: 0.75rem 1rem;
+      border-radius: 0.375rem;
+      display: inline-block;
+      margin: 1rem 0;
+      font-size: 0.875rem;
+    }
+
+    .arcana-empty-state code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    }
+
+    /* Entity detail panel */
+    .arcana-entity-row {
+      cursor: pointer;
+      transition: background-color 0.15s;
+    }
+
+    .arcana-entity-row.selected {
+      background: #ede9fe;
+    }
+
+    .arcana-entity-detail {
+      margin-top: 1.5rem;
+      padding: 1.5rem;
+      background: #faf5ff;
+      border: 1px solid #e9d5ff;
+      border-radius: 0.5rem;
+    }
+
+    .arcana-entity-detail-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .arcana-entity-detail-header h3 {
+      margin: 0;
+      font-size: 1.125rem;
+      color: #1f2937;
+    }
+
+    .arcana-entity-detail-close {
+      margin-left: auto;
+      background: transparent;
+      border: none;
+      font-size: 1.5rem;
+      color: #6b7280;
+      cursor: pointer;
+      padding: 0;
+      line-height: 1;
+    }
+
+    .arcana-entity-detail-close:hover {
+      color: #374151;
+    }
+
+    .arcana-entity-description {
+      color: #4b5563;
+      margin: 0 0 1rem 0;
+    }
+
+    .arcana-entity-relationships h4,
+    .arcana-entity-mentions h4 {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.875rem;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .arcana-rel-cards {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .arcana-rel-card {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+    }
+
+    .arcana-rel-type {
+      font-family: monospace;
+      background: #ede9fe;
+      color: #5b21b6;
+      padding: 0.125rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+
+    .arcana-rel-arrow {
+      color: #9ca3af;
+      font-weight: bold;
+    }
+
+    .arcana-rel-target,
+    .arcana-rel-source {
+      font-weight: 500;
+      color: #1f2937;
+    }
+
+    .arcana-rel-self {
+      color: #6b7280;
+      font-style: italic;
+      font-size: 0.75rem;
+    }
+
+    .arcana-mention-preview {
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      padding: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .arcana-mention-preview p {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.875rem;
+      color: #374151;
+    }
+
+    .arcana-view-in-docs {
+      font-size: 0.75rem;
+      color: #7c3aed;
+      text-decoration: none;
+    }
+
+    .arcana-view-in-docs:hover {
+      text-decoration: underline;
+    }
+
+    /* Relationship detail panel */
+    .arcana-relationship-row {
+      cursor: pointer;
+      transition: background-color 0.15s;
+    }
+
+    .arcana-relationship-row.selected {
+      background: #ede9fe;
+    }
+
+    .arcana-relationship-detail {
+      margin-top: 1.5rem;
+      padding: 1.5rem;
+      background: #faf5ff;
+      border: 1px solid #e9d5ff;
+      border-radius: 0.5rem;
+    }
+
+    .arcana-relationship-detail-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1rem;
+    }
+
+    .arcana-relationship-visual {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 1rem;
+    }
+
+    .arcana-relationship-source,
+    .arcana-relationship-target {
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    .arcana-relationship-arrow {
+      color: #9ca3af;
+    }
+
+    .arcana-relationship-type {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+      font-size: 0.875rem;
+      background: #ede9fe;
+      color: #6d28d9;
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+    }
+
+    .arcana-relationship-detail-close {
+      background: transparent;
+      border: none;
+      font-size: 1.5rem;
+      color: #6b7280;
+      cursor: pointer;
+      padding: 0;
+      line-height: 1;
+    }
+
+    .arcana-relationship-detail-close:hover {
+      color: #374151;
+    }
+
+    .arcana-relationship-strength {
+      margin-bottom: 0.75rem;
+      color: #4b5563;
+    }
+
+    .arcana-relationship-description {
+      color: #4b5563;
+      margin: 0;
+    }
+
+    .arcana-empty-hint {
+      font-size: 0.8125rem;
+    }
+
+    /* Community detail panel */
+    .arcana-community-row {
+      cursor: pointer;
+      transition: background-color 0.15s;
+    }
+
+    .arcana-community-row.selected {
+      background: #ede9fe;
+    }
+
+    .arcana-community-detail {
+      margin-top: 1.5rem;
+      padding: 1.5rem;
+      background: #faf5ff;
+      border: 1px solid #e9d5ff;
+      border-radius: 0.5rem;
+    }
+
+    .arcana-community-detail-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .arcana-community-detail-header h3 {
+      margin: 0;
+      font-size: 1.125rem;
+      color: #1f2937;
+    }
+
+    .arcana-community-level-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+      background: #ddd6fe;
+      color: #5b21b6;
+    }
+
+    .arcana-community-detail-close {
+      margin-left: auto;
+      background: transparent;
+      border: none;
+      font-size: 1.5rem;
+      color: #6b7280;
+      cursor: pointer;
+      padding: 0;
+      line-height: 1;
+    }
+
+    .arcana-community-detail-close:hover {
+      color: #374151;
+    }
+
+    .arcana-community-summary,
+    .arcana-community-entities,
+    .arcana-community-relationships {
+      margin-bottom: 1rem;
+    }
+
+    .arcana-community-summary h4,
+    .arcana-community-entities h4,
+    .arcana-community-relationships h4 {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.875rem;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .arcana-community-summary p {
+      margin: 0;
+      color: #374151;
+      line-height: 1.5;
+    }
+
+    .arcana-community-entities ul,
+    .arcana-community-relationships ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .arcana-community-entities li,
+    .arcana-community-relationships li {
+      padding: 0.5rem 0;
+      border-bottom: 1px solid #e5e7eb;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .arcana-community-entities li:last-child,
+    .arcana-community-relationships li:last-child {
+      border-bottom: none;
+    }
+
+    .arcana-community-no-summary {
+      color: #9ca3af;
+      font-style: italic;
+    }
+
+    /* Collection selector */
+    .arcana-collection-selector {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .arcana-collection-selector label {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #374151;
+    }
+
+    .arcana-collection-selector select {
+      padding: 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      min-width: 200px;
+    }
+
+    .arcana-collection-selector select:focus {
+      outline: none;
+      border-color: #7c3aed;
+      box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
+    }
+
+    /* Entity/Relationship/Community views */
+    .arcana-entities-view,
+    .arcana-relationships-view,
+    .arcana-communities-view {
+      margin-top: 1rem;
+    }
+
+    /* Deep Search toggle (simple mode, below textarea) */
+    .arcana-deep-search-toggle {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      margin-top: 0.5rem;
+      background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      font-size: 0.8125rem;
+    }
+
+    .arcana-deep-search-toggle:hover {
+      background: #f3f4f6;
+    }
+
+    .arcana-deep-search-toggle input[type="checkbox"] {
+      accent-color: #7c3aed;
+    }
+
+    .arcana-deep-search-toggle span {
+      font-weight: 500;
+      color: #374151;
+    }
+
+    .arcana-deep-search-toggle small {
+      color: #6b7280;
+      font-size: 0.75rem;
+    }
+
+    /* Graph Context section */
+    .arcana-graph-context {
+      margin: 1.5rem 0;
+      padding: 1rem;
+      background: linear-gradient(to right, #faf5ff, #f3e8ff);
+      border: 1px solid #e9d5ff;
+      border-radius: 0.5rem;
+    }
+
+    .arcana-graph-context-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.5rem;
+    }
+
+    .arcana-graph-context-header h4 {
+      margin: 0;
+      color: #7c3aed;
+      font-size: 1rem;
+    }
+
+    .arcana-toggle-btn {
+      background: transparent;
+      border: 1px solid #d8b4fe;
+      border-radius: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      cursor: pointer;
+      color: #7c3aed;
+      font-size: 0.75rem;
+    }
+
+    .arcana-toggle-btn:hover {
+      background: #f3e8ff;
+    }
+
+    .arcana-no-matches {
+      color: #9ca3af;
+      font-style: italic;
+      margin: 0.5rem 0;
+    }
+
+    .arcana-matched-entities,
+    .arcana-matched-relationships {
+      margin-top: 0.75rem;
+    }
+
+    .arcana-matched-entities h5,
+    .arcana-matched-relationships h5 {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.875rem;
+      color: #6b21a8;
+    }
+
+    .arcana-matched-entities ul,
+    .arcana-matched-relationships ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .arcana-matched-entities li,
+    .arcana-matched-relationships li {
+      padding: 0.375rem 0;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border-bottom: 1px solid #f3e8ff;
+    }
+
+    .arcana-matched-entities li:last-child,
+    .arcana-matched-relationships li:last-child {
+      border-bottom: none;
+    }
+
+    .arcana-entity-name {
+      font-weight: 500;
+      color: #1f2937;
+    }
+
+    .arcana-entity-type {
+      font-size: 0.75rem;
+      padding: 0.125rem 0.5rem;
+      background: #e9d5ff;
+      color: #7c3aed;
+      border-radius: 9999px;
+    }
+
+    .arcana-view-in-graph {
+      margin-left: auto;
+      font-size: 0.75rem;
+      color: #7c3aed;
+      text-decoration: none;
+    }
+
+    .arcana-view-in-graph:hover {
+      text-decoration: underline;
+    }
+
+    .arcana-rel-source,
+    .arcana-rel-target {
+      color: #1f2937;
+    }
+
+    .arcana-rel-type {
+      font-size: 0.75rem;
+      color: #7c3aed;
+      font-family: monospace;
+    }
+
+    /* Graph attribution in chunks */
+    .arcana-graph-attribution {
+      display: block;
+      font-size: 0.75rem;
+      color: #7c3aed;
+      margin-top: 0.25rem;
+      font-style: italic;
+    }
+    """
+    @css_hash :crypto.hash(:md5, @css) |> Base.encode16(case: :lower) |> binary_part(0, 8)
+
+    @doc """
+    Returns the current hash for the given asset type.
+    """
+    def current_hash(:js), do: @js_hash
+    def current_hash(:css), do: @css_hash
+
+    @impl Plug
+    def init(asset), do: asset
+
+    @impl Plug
+    def call(conn, asset) do
+      {content, content_type} =
+        case asset do
+          :js -> {@js, "text/javascript"}
+          :css -> {@css, "text/css"}
+        end
+
+      conn
+      |> Plug.Conn.put_resp_header("content-type", content_type)
+      |> Plug.Conn.put_resp_header("cache-control", "public, max-age=31536000, immutable")
+      |> Plug.Conn.delete_resp_header("x-frame-options")
+      |> Plug.Conn.put_private(:plug_skip_csrf_protection, true)
+      |> Plug.Conn.send_resp(200, content)
+    end
   end
 end

--- a/lib/arcana_web/assets.ex
+++ b/lib/arcana_web/assets.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.Assets do

--- a/lib/arcana_web/dashboard_live.ex
+++ b/lib/arcana_web/dashboard_live.ex
@@ -1,29 +1,34 @@
-defmodule ArcanaWeb.DashboardLive do
-  @moduledoc """
-  Redirects to the Documents page.
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  This module previously contained the monolithic dashboard with tab switching.
-  It has been replaced by separate LiveView pages for each tab:
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.DashboardLive do
+    @moduledoc """
+    Redirects to the Documents page.
 
-  - `/documents` - ArcanaWeb.DocumentsLive
-  - `/collections` - ArcanaWeb.CollectionsLive
-  - `/search` - ArcanaWeb.SearchLive
-  - `/ask` - ArcanaWeb.AskLive
-  - `/evaluation` - ArcanaWeb.EvaluationLive
-  - `/maintenance` - ArcanaWeb.MaintenanceLive
-  - `/info` - ArcanaWeb.InfoLive
-  """
-  use Phoenix.LiveView
+    This module previously contained the monolithic dashboard with tab switching.
+    It has been replaced by separate LiveView pages for each tab:
 
-  @impl true
-  def mount(_params, _session, socket) do
-    {:ok, socket, layout: false}
-  end
-
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <script>window.location.href = window.location.pathname + "/documents";</script>
+    - `/documents` - ArcanaWeb.DocumentsLive
+    - `/collections` - ArcanaWeb.CollectionsLive
+    - `/search` - ArcanaWeb.SearchLive
+    - `/ask` - ArcanaWeb.AskLive
+    - `/evaluation` - ArcanaWeb.EvaluationLive
+    - `/maintenance` - ArcanaWeb.MaintenanceLive
+    - `/info` - ArcanaWeb.InfoLive
     """
+    use Phoenix.LiveView
+
+    @impl true
+    def mount(_params, _session, socket) do
+      {:ok, socket, layout: false}
+    end
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <script>window.location.href = window.location.pathname + "/documents";</script>
+      """
+    end
   end
 end

--- a/lib/arcana_web/dashboard_live.ex
+++ b/lib/arcana_web/dashboard_live.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.DashboardLive do

--- a/lib/arcana_web/error_view.ex
+++ b/lib/arcana_web/error_view.ex
@@ -1,7 +1,12 @@
-defmodule ArcanaWeb.ErrorView do
-  @moduledoc false
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  def render(template, _assigns) do
-    Phoenix.Controller.status_message_from_template(template)
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.ErrorView do
+    @moduledoc false
+
+    def render(template, _assigns) do
+      Phoenix.Controller.status_message_from_template(template)
+    end
   end
 end

--- a/lib/arcana_web/error_view.ex
+++ b/lib/arcana_web/error_view.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.ErrorView do

--- a/lib/arcana_web/layouts.ex
+++ b/lib/arcana_web/layouts.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.Layouts do

--- a/lib/arcana_web/layouts.ex
+++ b/lib/arcana_web/layouts.ex
@@ -1,44 +1,49 @@
-defmodule ArcanaWeb.Layouts do
-  @moduledoc false
-  use Phoenix.Component
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  @doc """
-  Root layout for the Arcana dashboard.
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.Layouts do
+    @moduledoc false
+    use Phoenix.Component
 
-  Renders a complete HTML document with isolated styles and bundled
-  Phoenix LiveView JavaScript, making the dashboard self-contained.
-  """
-  def root(assigns) do
-    ~H"""
-    <!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="csrf-token" content={Phoenix.Controller.get_csrf_token()} />
-        <title>Arcana Dashboard</title>
-        <style>
-          /* Reset and isolate from host app styles */
-          html, body {
-            margin: 0;
-            padding: 0;
-            background: #f8fafc;
-            min-height: 100vh;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-          }
-        </style>
-      </head>
-      <body>
-        {@inner_content}
-        <script defer src="/assets/js/app.js"></script>
-      </body>
-    </html>
+    @doc """
+    Root layout for the Arcana dashboard.
+
+    Renders a complete HTML document with isolated styles and bundled
+    Phoenix LiveView JavaScript, making the dashboard self-contained.
     """
-  end
+    def root(assigns) do
+      ~H"""
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <meta name="csrf-token" content={Phoenix.Controller.get_csrf_token()} />
+          <title>Arcana Dashboard</title>
+          <style>
+            /* Reset and isolate from host app styles */
+            html, body {
+              margin: 0;
+              padding: 0;
+              background: #f8fafc;
+              min-height: 100vh;
+              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            }
+          </style>
+        </head>
+        <body>
+          {@inner_content}
+          <script defer src="/assets/js/app.js"></script>
+        </body>
+      </html>
+      """
+    end
 
-  def app(assigns) do
-    ~H"""
-    {@inner_content}
-    """
+    def app(assigns) do
+      ~H"""
+      {@inner_content}
+      """
+    end
   end
 end

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.AskLive do

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -1,1200 +1,1229 @@
-defmodule ArcanaWeb.AskLive do
-  @moduledoc """
-  LiveView for asking questions about documents in Arcana.
-  """
-  use Phoenix.LiveView
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  import Ecto.Query
-  import ArcanaWeb.DashboardComponents
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.AskLive do
+    @moduledoc """
+    LiveView for asking questions about documents in Arcana.
+    """
+    use Phoenix.LiveView
 
-  alias Arcana.Document
-  alias Arcana.Graph.Entity
-  alias ArcanaWeb.ChunkResultsComponent
+    import Ecto.Query
+    import ArcanaWeb.DashboardComponents
 
-  # Form param names for the Pipeline tab's optional steps. Tracked in
-  # socket assigns so the all/none toggle can update them server-side
-  # rather than reaching into the DOM with inline JS.
-  @pipeline_step_keys ~w(use_gate use_rewrite use_expand use_decompose use_reason self_correct use_rerank use_ground)
+    alias Arcana.Document
+    alias Arcana.Graph.Entity
+    alias ArcanaWeb.ChunkResultsComponent
 
-  # Groups the pipeline steps into the three phases of the Singh taxonomy's
-  # Modular RAG: query preparation, retrieval, and answer. Used by the
-  # per-phase "all / none" toggles on the Pipeline UI.
-  @pipeline_step_groups %{
-    "query" => ~w(use_gate use_rewrite use_expand use_decompose),
-    "retrieval" => ~w(use_reason use_rerank),
-    "answer" => ~w(self_correct use_ground)
-  }
+    # Form param names for the Pipeline tab's optional steps. Tracked in
+    # socket assigns so the all/none toggle can update them server-side
+    # rather than reaching into the DOM with inline JS.
+    @pipeline_step_keys ~w(use_gate use_rewrite use_expand use_decompose use_reason self_correct use_rerank use_ground)
 
-  @impl true
-  def mount(_params, session, socket) do
-    repo = get_repo_from_session(session)
+    # Groups the pipeline steps into the three phases of the Singh taxonomy's
+    # Modular RAG: query preparation, retrieval, and answer. Used by the
+    # per-phase "all / none" toggles on the Pipeline UI.
+    @pipeline_step_groups %{
+      "query" => ~w(use_gate use_rewrite use_expand use_decompose),
+      "retrieval" => ~w(use_reason use_rerank),
+      "answer" => ~w(self_correct use_ground)
+    }
 
-    {:ok,
-     socket
-     |> assign(repo: repo)
-     |> assign(
-       ask_sub_tab: :advanced,
-       ask_question: "",
-       ask_running: false,
-       ask_context: nil,
-       ask_error: nil,
-       stats: nil,
-       collections: [],
-       graph_search: true,
-       selected_collections: [],
-       graph_context_expanded: true,
-       llm_select: false,
-       pipeline_step: nil,
-       pipeline_steps: Map.new(@pipeline_step_keys, &{&1, false}),
-       loop_live_history: [],
-       loop_phase: :idle,
-       trace_history: []
-     )}
-  end
+    @impl true
+    def mount(_params, session, socket) do
+      repo = get_repo_from_session(session)
 
-  @impl true
-  def handle_params(params, _uri, socket) do
-    sub_tab = parse_sub_tab(params["sub_tab"])
-    sub_tab_changed? = sub_tab != socket.assigns.ask_sub_tab
-    # LLM collection select only makes sense on the Pipeline sub-tab
-    llm_select = if sub_tab == :pipeline, do: socket.assigns.llm_select, else: false
-
-    socket =
-      socket
-      |> assign(ask_sub_tab: sub_tab, llm_select: llm_select)
-      |> maybe_reset_ask_state(sub_tab_changed?)
-      |> maybe_load_data()
-
-    {:noreply, socket}
-  end
-
-  # Stats and collections only need to load once per LiveView session.
-  # Sub-tab switches re-enter handle_params/3 via push_patch but don't
-  # need to re-query the DB.
-  defp maybe_load_data(%{assigns: %{stats: nil}} = socket), do: load_data(socket)
-  defp maybe_load_data(socket), do: socket
-
-  # Switching sub-tabs swaps in a different retrieval strategy, so any
-  # previously rendered context, error, or pipeline progress label belongs
-  # to the old strategy and would be confusing to leave visible.
-  defp maybe_reset_ask_state(socket, false), do: socket
-
-  defp maybe_reset_ask_state(socket, true) do
-    assign(socket,
-      ask_context: nil,
-      ask_error: nil,
-      pipeline_step: nil,
-      loop_live_history: [],
-      loop_phase: :idle,
-      trace_history: []
-    )
-  end
-
-  defp parse_sub_tab("advanced"), do: :advanced
-  defp parse_sub_tab("pipeline"), do: :pipeline
-  defp parse_sub_tab("loop"), do: :loop
-  # Any other value (including nil for /arcana/ask with no segment, or an
-  # unknown sub-tab name) falls back to the default landing.
-  defp parse_sub_tab(_), do: :advanced
-
-  defp load_data(socket) do
-    repo = socket.assigns.repo
-
-    socket
-    |> assign(stats: load_stats(repo))
-    |> assign(collections: load_collections_with_graph_status(repo))
-  end
-
-  defp load_collections_with_graph_status(repo) do
-    collections = load_collections(repo)
-
-    # Get entity counts per collection
-    entity_counts =
-      repo.all(
-        from(e in Entity,
-          group_by: e.collection_id,
-          select: {e.collection_id, count(e.id)}
-        )
-      )
-      |> Map.new()
-
-    Enum.map(collections, fn c ->
-      entity_count = Map.get(entity_counts, c.id, 0)
-      Map.put(c, :graph_enabled, entity_count > 0)
-    end)
-  end
-
-  defp selected_graph_enabled?(collections, selected) do
-    case selected do
-      [] -> false
-      names -> Enum.any?(collections, &(&1.name in names and &1[:graph_enabled]))
+      {:ok,
+       socket
+       |> assign(repo: repo)
+       |> assign(
+         ask_sub_tab: :advanced,
+         ask_question: "",
+         ask_running: false,
+         ask_context: nil,
+         ask_error: nil,
+         stats: nil,
+         collections: [],
+         graph_search: true,
+         selected_collections: [],
+         graph_context_expanded: true,
+         llm_select: false,
+         pipeline_step: nil,
+         pipeline_steps: Map.new(@pipeline_step_keys, &{&1, false}),
+         loop_live_history: [],
+         loop_phase: :idle,
+         trace_history: []
+       )}
     end
-  end
 
-  @impl true
-  def handle_event("ask_submit", params, socket) do
-    question = params["question"] || ""
+    @impl true
+    def handle_params(params, _uri, socket) do
+      sub_tab = parse_sub_tab(params["sub_tab"])
+      sub_tab_changed? = sub_tab != socket.assigns.ask_sub_tab
+      # LLM collection select only makes sense on the Pipeline sub-tab
+      llm_select = if sub_tab == :pipeline, do: socket.assigns.llm_select, else: false
 
-    case {Arcana.Config.get_env(:llm), question} do
-      {nil, _} ->
-        {:noreply,
-         assign(socket,
-           ask_error: "No LLM configured. Set :arcana, :llm in your config.",
-           ask_running: false
-         )}
+      socket =
+        socket
+        |> assign(ask_sub_tab: sub_tab, llm_select: llm_select)
+        |> maybe_reset_ask_state(sub_tab_changed?)
+        |> maybe_load_data()
 
-      {_, ""} ->
-        {:noreply, assign(socket, ask_error: "Please enter a question")}
+      {:noreply, socket}
+    end
 
-      {llm, question} ->
-        socket =
-          assign(socket,
-            ask_running: true,
-            ask_error: nil,
-            ask_question: question,
-            ask_context: nil,
-            loop_live_history: [],
-            loop_phase: :idle,
-            trace_history: []
+    # Stats and collections only need to load once per LiveView session.
+    # Sub-tab switches re-enter handle_params/3 via push_patch but don't
+    # need to re-query the DB.
+    defp maybe_load_data(%{assigns: %{stats: nil}} = socket), do: load_data(socket)
+    defp maybe_load_data(socket), do: socket
+
+    # Switching sub-tabs swaps in a different retrieval strategy, so any
+    # previously rendered context, error, or pipeline progress label belongs
+    # to the old strategy and would be confusing to leave visible.
+    defp maybe_reset_ask_state(socket, false), do: socket
+
+    defp maybe_reset_ask_state(socket, true) do
+      assign(socket,
+        ask_context: nil,
+        ask_error: nil,
+        pipeline_step: nil,
+        loop_live_history: [],
+        loop_phase: :idle,
+        trace_history: []
+      )
+    end
+
+    defp parse_sub_tab("advanced"), do: :advanced
+    defp parse_sub_tab("pipeline"), do: :pipeline
+    defp parse_sub_tab("loop"), do: :loop
+    # Any other value (including nil for /arcana/ask with no segment, or an
+    # unknown sub-tab name) falls back to the default landing.
+    defp parse_sub_tab(_), do: :advanced
+
+    defp load_data(socket) do
+      repo = socket.assigns.repo
+
+      socket
+      |> assign(stats: load_stats(repo))
+      |> assign(collections: load_collections_with_graph_status(repo))
+    end
+
+    defp load_collections_with_graph_status(repo) do
+      collections = load_collections(repo)
+
+      # Get entity counts per collection
+      entity_counts =
+        repo.all(
+          from(e in Entity,
+            group_by: e.collection_id,
+            select: {e.collection_id, count(e.id)}
+          )
+        )
+        |> Map.new()
+
+      Enum.map(collections, fn c ->
+        entity_count = Map.get(entity_counts, c.id, 0)
+        Map.put(c, :graph_enabled, entity_count > 0)
+      end)
+    end
+
+    defp selected_graph_enabled?(collections, selected) do
+      case selected do
+        [] -> false
+        names -> Enum.any?(collections, &(&1.name in names and &1[:graph_enabled]))
+      end
+    end
+
+    @impl true
+    def handle_event("ask_submit", params, socket) do
+      question = params["question"] || ""
+
+      case {Arcana.Config.get_env(:llm), question} do
+        {nil, _} ->
+          {:noreply,
+           assign(socket,
+             ask_error: "No LLM configured. Set :arcana, :llm in your config.",
+             ask_running: false
+           )}
+
+        {_, ""} ->
+          {:noreply, assign(socket, ask_error: "Please enter a question")}
+
+        {llm, question} ->
+          socket =
+            assign(socket,
+              ask_running: true,
+              ask_error: nil,
+              ask_question: question,
+              ask_context: nil,
+              loop_live_history: [],
+              loop_phase: :idle,
+              trace_history: []
+            )
+
+          start_ask_task(socket, params, llm, question)
+          {:noreply, socket}
+      end
+    end
+
+    def handle_event("ask_clear", _params, socket) do
+      {:noreply,
+       assign(socket,
+         ask_context: nil,
+         ask_error: nil,
+         ask_question: "",
+         loop_live_history: [],
+         loop_phase: :idle,
+         trace_history: []
+       )}
+    end
+
+    def handle_event("ask_switch_sub_tab", %{"sub_tab" => sub_tab}, socket) do
+      # push_patch to the corresponding URL so the sub-tab selection is
+      # shareable and survives page reloads. handle_params/3 will pick
+      # up the new :sub_tab param and update the assigns.
+      {:noreply, push_patch(socket, to: "#{socket.assigns.prefix}/ask/#{sub_tab}")}
+    end
+
+    def handle_event("form_changed", params, socket) do
+      selected = params["collections"] || []
+      pipeline_steps = Map.new(@pipeline_step_keys, &{&1, params[&1] == "true"})
+      # Carry the textarea content forward on every form-change so a
+      # checkbox click (collections, pipeline steps) doesn't blow away
+      # what the user typed in the question box.
+      question = params["question"] || socket.assigns.ask_question
+
+      {:noreply,
+       assign(socket,
+         selected_collections: selected,
+         pipeline_steps: pipeline_steps,
+         ask_question: question
+       )}
+    end
+
+    def handle_event("toggle_graph_context", _params, socket) do
+      {:noreply, assign(socket, graph_context_expanded: !socket.assigns.graph_context_expanded)}
+    end
+
+    def handle_event("toggle_llm_select", _params, socket) do
+      {:noreply, assign(socket, llm_select: !socket.assigns.llm_select)}
+    end
+
+    def handle_event("set_pipeline_steps", %{"mode" => mode} = params, socket) do
+      enabled? = mode == "all"
+
+      keys =
+        case Map.get(params, "group") do
+          nil -> @pipeline_step_keys
+          group -> Map.get(@pipeline_step_groups, group, [])
+        end
+
+      steps =
+        Enum.reduce(keys, socket.assigns.pipeline_steps, fn key, acc ->
+          Map.put(acc, key, enabled?)
+        end)
+
+      {:noreply, assign(socket, pipeline_steps: steps)}
+    end
+
+    defp ask_loading_label(:advanced, _step, _phase), do: "Generating answer..."
+
+    defp ask_loading_label(:loop, _step, :grounding),
+      do: "Grounding answer against retrieved chunks..."
+
+    defp ask_loading_label(:loop, _step, _phase), do: "Running agent loop..."
+    defp ask_loading_label(:pipeline, step, _phase), do: step || "Running pipeline..."
+
+    # Renders an answer as markdown via MDEx. MDEx is an optional dep
+    # (see mix.exs) because the dashboard itself is optional. When it's
+    # missing, fall back to a minimal plain-text-to-html that preserves
+    # paragraph + line breaks (double newlines → <p>, single newlines →
+    # <br>) instead of collapsing the whole answer into one wall of text.
+    #
+    # MDEx's `:sanitize` enables ammonia-based HTML sanitization so any
+    # raw HTML the LLM emits gets scrubbed (the LLM is untrusted input).
+    # The fallback path also escapes HTML so it's safe to render.
+    defp render_markdown_answer(text) when is_binary(text) do
+      trimmed = String.trim(text)
+
+      if Code.ensure_loaded?(MDEx) do
+        Phoenix.HTML.raw(MDEx.to_html!(trimmed, sanitize: []))
+      else
+        plain_text_to_html(trimmed)
+      end
+    end
+
+    defp render_markdown_answer(_), do: ""
+
+    defp plain_text_to_html(text) do
+      paragraphs =
+        text
+        |> String.split(~r/\n{2,}/)
+        |> Enum.map_join("", fn paragraph ->
+          body =
+            paragraph
+            |> String.split("\n")
+            |> Enum.map_join("<br>", fn line ->
+              line
+              |> Phoenix.HTML.html_escape()
+              |> Phoenix.HTML.safe_to_string()
+            end)
+
+          "<p>#{body}</p>"
+        end)
+
+      Phoenix.HTML.raw(paragraphs)
+    end
+
+    # Resolves which LLM each role uses, mirroring the lookup chain inside
+    # Arcana.Loop.run/2:
+    #   controller_llm = config :arcana, :loop, :controller_llm || :arcana, :llm
+    #   answer_llm     = config :arcana, :loop, :answer_llm (nil → uses controller text)
+    #   fallback       = answer_llm || controller_llm
+    defp loop_llm_roles do
+      loop_opts = Arcana.Config.get_env(:loop, [])
+      base_llm = Arcana.Config.get_env(:llm)
+
+      controller = Keyword.get(loop_opts, :controller_llm) || base_llm
+      answer = Keyword.get(loop_opts, :answer_llm)
+
+      %{
+        controller: format_llm_spec(controller),
+        answer: format_llm_spec(answer),
+        fallback: format_llm_spec(answer || controller)
+      }
+    end
+
+    defp format_llm_spec(nil), do: nil
+    defp format_llm_spec(fun) when is_function(fun), do: "<function/1>"
+    defp format_llm_spec({model, _opts}) when is_binary(model), do: model
+    defp format_llm_spec({model, _opts}) when is_atom(model), do: Atom.to_string(model)
+    defp format_llm_spec(model) when is_binary(model), do: model
+    defp format_llm_spec(model) when is_atom(model), do: Atom.to_string(model)
+    defp format_llm_spec(other), do: inspect(other, limit: 1)
+
+    defp start_ask_task(socket, params, llm, question) do
+      repo = socket.assigns.repo
+      sub_tab = params["sub_tab"] || "advanced"
+      selected_collections = params["collections"] || []
+      parent = self()
+
+      ArcanaWeb.TaskSupervisor.start_child(fn ->
+        handler_id = "pipeline-progress-#{inspect(parent)}"
+        trace_handler_id = "trace-progress-#{inspect(parent)}"
+        loop_handler_id = "loop-progress-#{inspect(parent)}"
+
+        graph_enabled = params["graph_search"] == "true"
+
+        pipeline_steps = [
+          :gate,
+          :rewrite,
+          :expand,
+          :decompose,
+          :select,
+          :search,
+          :reason,
+          :self_correct,
+          :rerank,
+          :answer,
+          :ground
+        ]
+
+        # Pipeline progress label events (the old "Running X..." text that
+        # updates the spinner label).
+        label_events =
+          Enum.map(pipeline_steps, &[:arcana, :pipeline, &1, :start]) ++
+            [[:arcana, :graph, :search, :start]]
+
+        :telemetry.attach_many(
+          handler_id,
+          label_events,
+          fn
+            [:arcana, :graph, :search, :start], _measurements, _metadata, _config ->
+              send(parent, {:pipeline_progress, "Searching with graph connections..."})
+
+            [:arcana, :pipeline, step, :start], _measurements, _metadata, _config ->
+              label =
+                if step == :search and graph_enabled,
+                  do: "Searching with graph connections...",
+                  else: pipeline_step_label(step)
+
+              if label, do: send(parent, {:pipeline_progress, label})
+          end,
+          nil
+        )
+
+        # Trace events for the live step-by-step panel. Every sub-tab
+        # subscribes, the handler normalizes the event path to a
+        # `{:trace_step_start, atom}` / `{:trace_step_stop, atom, ms, meta}`
+        # tuple. Pipeline and Advanced both flow through this pathway.
+        trace_events =
+          Enum.flat_map(pipeline_steps, fn step ->
+            [
+              [:arcana, :pipeline, step, :start],
+              [:arcana, :pipeline, step, :stop]
+            ]
+          end) ++
+            [
+              [:arcana, :search, :start],
+              [:arcana, :search, :stop],
+              [:arcana, :graph, :search, :start],
+              [:arcana, :graph, :search, :stop],
+              [:arcana, :llm, :complete, :start],
+              [:arcana, :llm, :complete, :stop]
+            ]
+
+        :telemetry.attach_many(
+          trace_handler_id,
+          trace_events,
+          fn event, measurements, metadata, _config ->
+            case {event, measurements} do
+              {[:arcana, :pipeline, step, :start], _} ->
+                send(parent, {:trace_step_start, step})
+
+              {[:arcana, :pipeline, step, :stop], %{duration: d}} ->
+                send(parent, {:trace_step_stop, step, native_to_ms(d), metadata})
+
+              {[:arcana, :search, :start], _} ->
+                send(parent, {:trace_step_start, :search})
+
+              {[:arcana, :search, :stop], %{duration: d}} ->
+                send(parent, {:trace_step_stop, :search, native_to_ms(d), metadata})
+
+              {[:arcana, :graph, :search, :start], _} ->
+                send(parent, {:trace_step_start, :graph_search})
+
+              {[:arcana, :graph, :search, :stop], %{duration: d}} ->
+                send(parent, {:trace_step_stop, :graph_search, native_to_ms(d), metadata})
+
+              {[:arcana, :llm, :complete, :start], _} ->
+                send(parent, {:trace_step_start, :llm_complete})
+
+              {[:arcana, :llm, :complete, :stop], %{duration: d}} ->
+                send(parent, {:trace_step_stop, :llm_complete, native_to_ms(d), metadata})
+
+              _ ->
+                :ok
+            end
+          end,
+          nil
+        )
+
+        # Per-tool-call telemetry for the Loop sub-tab. Each event carries
+        # the same shape as a tool_history entry, so the LV can render
+        # the live trace incrementally as the loop unfolds.
+        :telemetry.attach_many(
+          loop_handler_id,
+          [
+            [:arcana, :loop, :tool_call],
+            [:arcana, :loop, :ground, :start],
+            [:arcana, :loop, :ground, :stop]
+          ],
+          fn
+            [:arcana, :loop, :tool_call], _measurements, metadata, _config ->
+              send(parent, {:loop_progress, metadata})
+
+            [:arcana, :loop, :ground, :start], _measurements, _metadata, _config ->
+              send(parent, {:loop_phase, :grounding})
+
+            [:arcana, :loop, :ground, :stop], _measurements, _metadata, _config ->
+              send(parent, {:loop_phase, :idle})
+          end,
+          nil
+        )
+
+        result =
+          run_ask(
+            sub_tab,
+            question,
+            repo,
+            llm,
+            socket.assigns.collections,
+            params,
+            selected_collections
           )
 
-        start_ask_task(socket, params, llm, question)
-        {:noreply, socket}
-    end
-  end
-
-  def handle_event("ask_clear", _params, socket) do
-    {:noreply,
-     assign(socket,
-       ask_context: nil,
-       ask_error: nil,
-       ask_question: "",
-       loop_live_history: [],
-       loop_phase: :idle,
-       trace_history: []
-     )}
-  end
-
-  def handle_event("ask_switch_sub_tab", %{"sub_tab" => sub_tab}, socket) do
-    # push_patch to the corresponding URL so the sub-tab selection is
-    # shareable and survives page reloads. handle_params/3 will pick
-    # up the new :sub_tab param and update the assigns.
-    {:noreply, push_patch(socket, to: "#{socket.assigns.prefix}/ask/#{sub_tab}")}
-  end
-
-  def handle_event("form_changed", params, socket) do
-    selected = params["collections"] || []
-    pipeline_steps = Map.new(@pipeline_step_keys, &{&1, params[&1] == "true"})
-    # Carry the textarea content forward on every form-change so a
-    # checkbox click (collections, pipeline steps) doesn't blow away
-    # what the user typed in the question box.
-    question = params["question"] || socket.assigns.ask_question
-
-    {:noreply,
-     assign(socket,
-       selected_collections: selected,
-       pipeline_steps: pipeline_steps,
-       ask_question: question
-     )}
-  end
-
-  def handle_event("toggle_graph_context", _params, socket) do
-    {:noreply, assign(socket, graph_context_expanded: !socket.assigns.graph_context_expanded)}
-  end
-
-  def handle_event("toggle_llm_select", _params, socket) do
-    {:noreply, assign(socket, llm_select: !socket.assigns.llm_select)}
-  end
-
-  def handle_event("set_pipeline_steps", %{"mode" => mode} = params, socket) do
-    enabled? = mode == "all"
-
-    keys =
-      case Map.get(params, "group") do
-        nil -> @pipeline_step_keys
-        group -> Map.get(@pipeline_step_groups, group, [])
-      end
-
-    steps =
-      Enum.reduce(keys, socket.assigns.pipeline_steps, fn key, acc ->
-        Map.put(acc, key, enabled?)
+        :telemetry.detach(handler_id)
+        :telemetry.detach(trace_handler_id)
+        :telemetry.detach(loop_handler_id)
+        send(parent, {:ask_complete, result})
       end)
-
-    {:noreply, assign(socket, pipeline_steps: steps)}
-  end
-
-  defp ask_loading_label(:advanced, _step, _phase), do: "Generating answer..."
-
-  defp ask_loading_label(:loop, _step, :grounding),
-    do: "Grounding answer against retrieved chunks..."
-
-  defp ask_loading_label(:loop, _step, _phase), do: "Running agent loop..."
-  defp ask_loading_label(:pipeline, step, _phase), do: step || "Running pipeline..."
-
-  # Renders an answer as markdown via MDEx. MDEx is an optional dep
-  # (see mix.exs) because the dashboard itself is optional. When it's
-  # missing, fall back to a minimal plain-text-to-html that preserves
-  # paragraph + line breaks (double newlines → <p>, single newlines →
-  # <br>) instead of collapsing the whole answer into one wall of text.
-  #
-  # MDEx's `:sanitize` enables ammonia-based HTML sanitization so any
-  # raw HTML the LLM emits gets scrubbed (the LLM is untrusted input).
-  # The fallback path also escapes HTML so it's safe to render.
-  defp render_markdown_answer(text) when is_binary(text) do
-    trimmed = String.trim(text)
-
-    if Code.ensure_loaded?(MDEx) do
-      Phoenix.HTML.raw(MDEx.to_html!(trimmed, sanitize: []))
-    else
-      plain_text_to_html(trimmed)
     end
-  end
 
-  defp render_markdown_answer(_), do: ""
+    defp native_to_ms(duration) do
+      System.convert_time_unit(duration, :native, :millisecond)
+    end
 
-  defp plain_text_to_html(text) do
-    paragraphs =
-      text
-      |> String.split(~r/\n{2,}/)
-      |> Enum.map_join("", fn paragraph ->
-        body =
-          paragraph
-          |> String.split("\n")
-          |> Enum.map_join("<br>", fn line ->
-            line
-            |> Phoenix.HTML.html_escape()
-            |> Phoenix.HTML.safe_to_string()
-          end)
+    defp run_ask("advanced", question, repo, llm, _all_collections, params, selected_collections) do
+      run_advanced_ask(question, repo, llm, selected_collections, params)
+    end
 
-        "<p>#{body}</p>"
-      end)
+    defp run_ask("loop", question, repo, llm, _all_collections, params, selected_collections) do
+      run_loop_ask(question, repo, llm, selected_collections, params)
+    end
 
-    Phoenix.HTML.raw(paragraphs)
-  end
-
-  # Resolves which LLM each role uses, mirroring the lookup chain inside
-  # Arcana.Loop.run/2:
-  #   controller_llm = config :arcana, :loop, :controller_llm || :arcana, :llm
-  #   answer_llm     = config :arcana, :loop, :answer_llm (nil → uses controller text)
-  #   fallback       = answer_llm || controller_llm
-  defp loop_llm_roles do
-    loop_opts = Arcana.Config.get_env(:loop, [])
-    base_llm = Arcana.Config.get_env(:llm)
-
-    controller = Keyword.get(loop_opts, :controller_llm) || base_llm
-    answer = Keyword.get(loop_opts, :answer_llm)
-
-    %{
-      controller: format_llm_spec(controller),
-      answer: format_llm_spec(answer),
-      fallback: format_llm_spec(answer || controller)
-    }
-  end
-
-  defp format_llm_spec(nil), do: nil
-  defp format_llm_spec(fun) when is_function(fun), do: "<function/1>"
-  defp format_llm_spec({model, _opts}) when is_binary(model), do: model
-  defp format_llm_spec({model, _opts}) when is_atom(model), do: Atom.to_string(model)
-  defp format_llm_spec(model) when is_binary(model), do: model
-  defp format_llm_spec(model) when is_atom(model), do: Atom.to_string(model)
-  defp format_llm_spec(other), do: inspect(other, limit: 1)
-
-  defp start_ask_task(socket, params, llm, question) do
-    repo = socket.assigns.repo
-    sub_tab = params["sub_tab"] || "advanced"
-    selected_collections = params["collections"] || []
-    parent = self()
-
-    ArcanaWeb.TaskSupervisor.start_child(fn ->
-      handler_id = "pipeline-progress-#{inspect(parent)}"
-      trace_handler_id = "trace-progress-#{inspect(parent)}"
-      loop_handler_id = "loop-progress-#{inspect(parent)}"
-
-      graph_enabled = params["graph_search"] == "true"
-
-      pipeline_steps = [
-        :gate,
-        :rewrite,
-        :expand,
-        :decompose,
-        :select,
-        :search,
-        :reason,
-        :self_correct,
-        :rerank,
-        :answer,
-        :ground
-      ]
-
-      # Pipeline progress label events (the old "Running X..." text that
-      # updates the spinner label).
-      label_events =
-        Enum.map(pipeline_steps, &[:arcana, :pipeline, &1, :start]) ++
-          [[:arcana, :graph, :search, :start]]
-
-      :telemetry.attach_many(
-        handler_id,
-        label_events,
-        fn
-          [:arcana, :graph, :search, :start], _measurements, _metadata, _config ->
-            send(parent, {:pipeline_progress, "Searching with graph connections..."})
-
-          [:arcana, :pipeline, step, :start], _measurements, _metadata, _config ->
-            label =
-              if step == :search and graph_enabled,
-                do: "Searching with graph connections...",
-                else: pipeline_step_label(step)
-
-            if label, do: send(parent, {:pipeline_progress, label})
-        end,
-        nil
+    defp run_ask("pipeline", question, repo, llm, all_collections, params, selected_collections) do
+      run_pipeline_ask(
+        question,
+        repo,
+        llm,
+        all_collections,
+        collections: selected_collections,
+        use_llm_select: params["llm_select"] == "true",
+        use_gate: params["use_gate"] == "true",
+        use_rewrite: params["use_rewrite"] == "true",
+        use_expand: params["use_expand"] == "true",
+        use_decompose: params["use_decompose"] == "true",
+        use_reason: params["use_reason"] == "true",
+        use_rerank: params["use_rerank"] == "true",
+        use_ground: params["use_ground"] == "true",
+        self_correct: params["self_correct"] == "true",
+        hallucinate_demo: params["answer_mode"] == "hallucinate",
+        graph: params["graph_search"] == "true"
       )
+    end
 
-      # Trace events for the live step-by-step panel. Every sub-tab
-      # subscribes, the handler normalizes the event path to a
-      # `{:trace_step_start, atom}` / `{:trace_step_stop, atom, ms, meta}`
-      # tuple. Pipeline and Advanced both flow through this pathway.
-      trace_events =
-        Enum.flat_map(pipeline_steps, fn step ->
-          [
-            [:arcana, :pipeline, step, :start],
-            [:arcana, :pipeline, step, :stop]
-          ]
-        end) ++
-          [
-            [:arcana, :search, :start],
-            [:arcana, :search, :stop],
-            [:arcana, :graph, :search, :start],
-            [:arcana, :graph, :search, :stop],
-            [:arcana, :llm, :complete, :start],
-            [:arcana, :llm, :complete, :stop]
-          ]
+    @impl true
+    def handle_info({:pipeline_progress, step}, socket) do
+      {:noreply, assign(socket, pipeline_step: step)}
+    end
 
-      :telemetry.attach_many(
-        trace_handler_id,
-        trace_events,
-        fn event, measurements, metadata, _config ->
-          case {event, measurements} do
-            {[:arcana, :pipeline, step, :start], _} ->
-              send(parent, {:trace_step_start, step})
+    def handle_info({:loop_progress, entry}, socket) do
+      # Append, not prepend: render order matches iteration order so the
+      # newest entry visually lands at the bottom of the trace.
+      {:noreply, assign(socket, loop_live_history: socket.assigns.loop_live_history ++ [entry])}
+    end
 
-            {[:arcana, :pipeline, step, :stop], %{duration: d}} ->
-              send(parent, {:trace_step_stop, step, native_to_ms(d), metadata})
+    def handle_info({:loop_phase, phase}, socket) do
+      {:noreply, assign(socket, loop_phase: phase)}
+    end
 
-            {[:arcana, :search, :start], _} ->
-              send(parent, {:trace_step_start, :search})
+    def handle_info({:trace_step_start, step}, socket) do
+      entry = %{step: step, status: :running, duration_ms: nil, meta: nil}
 
-            {[:arcana, :search, :stop], %{duration: d}} ->
-              send(parent, {:trace_step_stop, :search, native_to_ms(d), metadata})
+      {:noreply, assign(socket, trace_history: socket.assigns.trace_history ++ [entry])}
+    end
 
-            {[:arcana, :graph, :search, :start], _} ->
-              send(parent, {:trace_step_start, :graph_search})
+    def handle_info({:trace_step_stop, step, duration_ms, metadata}, socket) do
+      history =
+        socket.assigns.trace_history
+        |> Enum.reverse()
+        |> mark_step_done(step, duration_ms, metadata)
+        |> Enum.reverse()
 
-            {[:arcana, :graph, :search, :stop], %{duration: d}} ->
-              send(parent, {:trace_step_stop, :graph_search, native_to_ms(d), metadata})
+      {:noreply, assign(socket, trace_history: history)}
+    end
 
-            {[:arcana, :llm, :complete, :start], _} ->
-              send(parent, {:trace_step_start, :llm_complete})
+    def handle_info({:ask_complete, result}, socket) do
+      socket =
+        case result do
+          {:ok, ctx} ->
+            ctx = Map.put(ctx, :document_titles, load_document_titles(ctx, socket.assigns.repo))
 
-            {[:arcana, :llm, :complete, :stop], %{duration: d}} ->
-              send(parent, {:trace_step_stop, :llm_complete, native_to_ms(d), metadata})
+            assign(socket,
+              ask_running: false,
+              ask_context: ctx,
+              ask_error: nil,
+              pipeline_step: nil
+            )
 
-            _ ->
-              :ok
+          {:error, reason} ->
+            assign(socket, ask_running: false, ask_error: inspect(reason), pipeline_step: nil)
+        end
+
+      {:noreply, socket}
+    end
+
+    # Batch-loads document titles for every chunk in the result. All three
+    # sub-tabs put chunks under :results, so one helper covers everything.
+    # Falls back to an empty map on any error — the component already
+    # degrades to a shortened UUID when a title is missing.
+    defp load_document_titles(%{results: chunks}, repo)
+         when is_list(chunks) and not is_nil(repo) do
+      ids =
+        chunks
+        |> Enum.map(&Map.get(&1, :document_id))
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+
+      case ids do
+        [] ->
+          %{}
+
+        ids ->
+          try do
+            from(d in Document, where: d.id in ^ids, select: {d.id, d.metadata})
+            |> repo.all()
+            |> Map.new(fn {id, metadata} -> {id, extract_title(metadata)} end)
+          rescue
+            _ -> %{}
           end
-        end,
-        nil
-      )
+      end
+    end
 
-      # Per-tool-call telemetry for the Loop sub-tab. Each event carries
-      # the same shape as a tool_history entry, so the LV can render
-      # the live trace incrementally as the loop unfolds.
-      :telemetry.attach_many(
-        loop_handler_id,
+    defp load_document_titles(_ctx, _repo), do: %{}
+
+    defp extract_title(nil), do: nil
+
+    defp extract_title(metadata) when is_map(metadata) do
+      Map.get(metadata, "title") || Map.get(metadata, :title)
+    end
+
+    defp extract_title(_), do: nil
+
+    # Update the most recent :running entry that matches `step`. Walking
+    # the reversed list and replacing the first match is correct because
+    # pipeline steps are sequential — the latest :running entry for a
+    # given step name is always the one that just stopped.
+    defp mark_step_done(
+           [%{step: step, status: :running} = entry | rest],
+           step,
+           duration_ms,
+           metadata
+         ) do
+      [%{entry | status: :done, duration_ms: duration_ms, meta: metadata} | rest]
+    end
+
+    defp mark_step_done([head | rest], step, duration_ms, metadata) do
+      [head | mark_step_done(rest, step, duration_ms, metadata)]
+    end
+
+    defp mark_step_done([], _step, _duration_ms, _metadata), do: []
+
+    defp run_loop_ask(question, repo, llm, selected_collections, params) do
+      max_iterations =
+        case Integer.parse(params["max_iterations"] || "10") do
+          {n, _} when n > 0 -> n
+          _ -> 10
+        end
+
+      chunk_cap =
+        case Integer.parse(params["chunk_cap"] || "50") do
+          {n, _} when n > 0 -> n
+          _ -> 50
+        end
+
+      controller_temperature = parse_temperature(params["controller_temperature"])
+      answer_temperature = parse_temperature(params["answer_temperature"])
+      fallback_temperature = parse_temperature(params["fallback_temperature"])
+
+      run_ground? = params["use_ground_loop"] == "true"
+      ground_opts = [grounder: Arcana.Grounder.LLMJudge, judge_model: llm]
+
+      new_opts =
+        [repo: repo]
+        |> maybe_put_collection_opt(selected_collections)
+
+      run_opts =
         [
-          [:arcana, :loop, :tool_call],
-          [:arcana, :loop, :ground, :start],
-          [:arcana, :loop, :ground, :stop]
-        ],
-        fn
-          [:arcana, :loop, :tool_call], _measurements, metadata, _config ->
-            send(parent, {:loop_progress, metadata})
+          controller_llm: llm,
+          max_iterations: max_iterations,
+          chunk_cap: chunk_cap
+        ]
+        |> maybe_put(:controller_temperature, controller_temperature)
+        |> maybe_put(:answer_temperature, answer_temperature)
+        |> maybe_put(:fallback_temperature, fallback_temperature)
 
-          [:arcana, :loop, :ground, :start], _measurements, _metadata, _config ->
-            send(parent, {:loop_phase, :grounding})
+      ctx = Arcana.Loop.new(question, new_opts)
+      runner = loop_runner()
 
-          [:arcana, :loop, :ground, :stop], _measurements, _metadata, _config ->
-            send(parent, {:loop_phase, :idle})
-        end,
-        nil
-      )
+      with {:ok, ctx} <- runner.(ctx, run_opts) do
+        ctx = if run_ground?, do: Arcana.Loop.ground(ctx, ground_opts), else: ctx
+        {:ok, format_loop_result(ctx, question)}
+      end
+    rescue
+      e ->
+        require Logger
+        Logger.error(Exception.format(:error, e, __STACKTRACE__))
+        {:error, Exception.message(e)}
+    end
 
-      result =
-        run_ask(
-          sub_tab,
-          question,
-          repo,
-          llm,
-          socket.assigns.collections,
-          params,
-          selected_collections
-        )
+    defp maybe_put(opts, _key, nil), do: opts
+    defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
 
-      :telemetry.detach(handler_id)
-      :telemetry.detach(trace_handler_id)
-      :telemetry.detach(loop_handler_id)
-      send(parent, {:ask_complete, result})
-    end)
-  end
+    defp parse_temperature(nil), do: nil
+    defp parse_temperature(""), do: nil
 
-  defp native_to_ms(duration) do
-    System.convert_time_unit(duration, :native, :millisecond)
-  end
+    defp parse_temperature(str) when is_binary(str) do
+      case Float.parse(str) do
+        {t, _} when t >= 0 and t <= 2 -> t
+        _ -> nil
+      end
+    end
 
-  defp run_ask("advanced", question, repo, llm, _all_collections, params, selected_collections) do
-    run_advanced_ask(question, repo, llm, selected_collections, params)
-  end
+    # Hook for tests to stub out Loop execution. Defaults to the real Loop.run/2.
+    defp loop_runner do
+      Arcana.Config.get_env(:loop_runner) || (&Arcana.Loop.run/2)
+    end
 
-  defp run_ask("loop", question, repo, llm, _all_collections, params, selected_collections) do
-    run_loop_ask(question, repo, llm, selected_collections, params)
-  end
+    # Arcana.Loop.new/2 (and Arcana.search, Arcana.ask, Arcana.Pipeline.new)
+    # all normalize `:collection` and `:collections` to the same internal
+    # representation, so we can always pass the plural form and let the
+    # library sort it out.
+    defp maybe_put_collection_opt(opts, []), do: opts
+    defp maybe_put_collection_opt(opts, list), do: Keyword.put(opts, :collections, list)
 
-  defp run_ask("pipeline", question, repo, llm, all_collections, params, selected_collections) do
-    run_pipeline_ask(
-      question,
-      repo,
-      llm,
-      all_collections,
-      collections: selected_collections,
-      use_llm_select: params["llm_select"] == "true",
-      use_gate: params["use_gate"] == "true",
-      use_rewrite: params["use_rewrite"] == "true",
-      use_expand: params["use_expand"] == "true",
-      use_decompose: params["use_decompose"] == "true",
-      use_reason: params["use_reason"] == "true",
-      use_rerank: params["use_rerank"] == "true",
-      use_ground: params["use_ground"] == "true",
-      self_correct: params["self_correct"] == "true",
-      hallucinate_demo: params["answer_mode"] == "hallucinate",
-      graph: params["graph_search"] == "true"
-    )
-  end
+    defp format_loop_result(%Arcana.Loop.Context{} = ctx, question) do
+      %{
+        result_type: :loop,
+        question: question,
+        answer: ctx.answer,
+        tool_history: ctx.tool_history,
+        terminated_by: ctx.terminated_by,
+        iterations: ctx.iterations,
+        chunks: ctx.chunks,
+        grounding: ctx.grounding,
+        # Mirror the Pipeline result shape so existing result sections
+        # (grounding, chunks) can reuse the same rendering. The extras are
+        # what drives the agent trace view.
+        results: ctx.chunks,
+        expanded_query: nil,
+        sub_questions: nil,
+        selected_collections: nil
+      }
+    end
 
-  @impl true
-  def handle_info({:pipeline_progress, step}, socket) do
-    {:noreply, assign(socket, pipeline_step: step)}
-  end
+    defp run_advanced_ask(question, repo, llm, selected_collections, params) do
+      graph = params["graph_search"] == "true"
 
-  def handle_info({:loop_progress, entry}, socket) do
-    # Append, not prepend: render order matches iteration order so the
-    # newest entry visually lands at the bottom of the trace.
-    {:noreply, assign(socket, loop_live_history: socket.assigns.loop_live_history ++ [entry])}
-  end
+      opts =
+        [repo: repo, llm: llm, graph: graph]
+        |> maybe_put_collection_opt(selected_collections)
 
-  def handle_info({:loop_phase, phase}, socket) do
-    {:noreply, assign(socket, loop_phase: phase)}
-  end
-
-  def handle_info({:trace_step_start, step}, socket) do
-    entry = %{step: step, status: :running, duration_ms: nil, meta: nil}
-
-    {:noreply, assign(socket, trace_history: socket.assigns.trace_history ++ [entry])}
-  end
-
-  def handle_info({:trace_step_stop, step, duration_ms, metadata}, socket) do
-    history =
-      socket.assigns.trace_history
-      |> Enum.reverse()
-      |> mark_step_done(step, duration_ms, metadata)
-      |> Enum.reverse()
-
-    {:noreply, assign(socket, trace_history: history)}
-  end
-
-  def handle_info({:ask_complete, result}, socket) do
-    socket =
-      case result do
-        {:ok, ctx} ->
-          ctx = Map.put(ctx, :document_titles, load_document_titles(ctx, socket.assigns.repo))
-          assign(socket, ask_running: false, ask_context: ctx, ask_error: nil, pipeline_step: nil)
+      case Arcana.ask(question, opts) do
+        {:ok, answer, results} ->
+          # Build a context-like struct for consistent UI display
+          {:ok,
+           %{
+             question: question,
+             answer: answer,
+             results: results,
+             expanded_query: nil,
+             sub_questions: nil,
+             selected_collections:
+               if(selected_collections == [], do: nil, else: selected_collections)
+           }}
 
         {:error, reason} ->
-          assign(socket, ask_running: false, ask_error: inspect(reason), pipeline_step: nil)
+          {:error, reason}
       end
-
-    {:noreply, socket}
-  end
-
-  # Batch-loads document titles for every chunk in the result. All three
-  # sub-tabs put chunks under :results, so one helper covers everything.
-  # Falls back to an empty map on any error — the component already
-  # degrades to a shortened UUID when a title is missing.
-  defp load_document_titles(%{results: chunks}, repo)
-       when is_list(chunks) and not is_nil(repo) do
-    ids =
-      chunks
-      |> Enum.map(&Map.get(&1, :document_id))
-      |> Enum.reject(&is_nil/1)
-      |> Enum.uniq()
-
-    case ids do
-      [] ->
-        %{}
-
-      ids ->
-        try do
-          from(d in Document, where: d.id in ^ids, select: {d.id, d.metadata})
-          |> repo.all()
-          |> Map.new(fn {id, metadata} -> {id, extract_title(metadata)} end)
-        rescue
-          _ -> %{}
-        end
+    rescue
+      e -> {:error, Exception.message(e)}
     end
-  end
 
-  defp load_document_titles(_ctx, _repo), do: %{}
+    defp run_pipeline_ask(question, repo, llm, all_collections, opts) do
+      alias Arcana.Pipeline
 
-  defp extract_title(nil), do: nil
+      all_collection_names = Enum.map(all_collections, & &1.name)
+      search_opts = build_search_opts(opts, all_collection_names)
 
-  defp extract_title(metadata) when is_map(metadata) do
-    Map.get(metadata, "title") || Map.get(metadata, :title)
-  end
+      Pipeline.new(question, repo: repo, llm: llm)
+      |> maybe_gate(opts)
+      |> maybe_rewrite(opts)
+      |> maybe_select(opts, all_collection_names)
+      |> maybe_expand(opts)
+      |> maybe_decompose(opts)
+      |> Pipeline.search(search_opts)
+      |> maybe_reason(opts)
+      |> maybe_rerank(opts)
+      |> maybe_answer_with_hallucinations(opts)
+      |> maybe_ground(opts)
+      |> format_pipeline_result(question)
+    rescue
+      e -> {:error, Exception.message(e)}
+    end
 
-  defp extract_title(_), do: nil
+    defp maybe_gate(ctx, opts) do
+      if Keyword.get(opts, :use_gate, false), do: Arcana.Pipeline.gate(ctx), else: ctx
+    end
 
-  # Update the most recent :running entry that matches `step`. Walking
-  # the reversed list and replacing the first match is correct because
-  # pipeline steps are sequential — the latest :running entry for a
-  # given step name is always the one that just stopped.
-  defp mark_step_done(
-         [%{step: step, status: :running} = entry | rest],
-         step,
-         duration_ms,
-         metadata
-       ) do
-    [%{entry | status: :done, duration_ms: duration_ms, meta: metadata} | rest]
-  end
+    defp maybe_rewrite(ctx, opts) do
+      if Keyword.get(opts, :use_rewrite, false), do: Arcana.Pipeline.rewrite(ctx), else: ctx
+    end
 
-  defp mark_step_done([head | rest], step, duration_ms, metadata) do
-    [head | mark_step_done(rest, step, duration_ms, metadata)]
-  end
-
-  defp mark_step_done([], _step, _duration_ms, _metadata), do: []
-
-  defp run_loop_ask(question, repo, llm, selected_collections, params) do
-    max_iterations =
-      case Integer.parse(params["max_iterations"] || "10") do
-        {n, _} when n > 0 -> n
-        _ -> 10
+    defp maybe_select(ctx, opts, all_collection_names) do
+      if Keyword.get(opts, :use_llm_select, false) and length(all_collection_names) > 1 do
+        Arcana.Pipeline.select(ctx, collections: all_collection_names)
+      else
+        ctx
       end
+    end
 
-    chunk_cap =
-      case Integer.parse(params["chunk_cap"] || "50") do
-        {n, _} when n > 0 -> n
-        _ -> 50
+    defp maybe_expand(ctx, opts) do
+      if Keyword.get(opts, :use_expand, false), do: Arcana.Pipeline.expand(ctx), else: ctx
+    end
+
+    defp maybe_decompose(ctx, opts) do
+      if Keyword.get(opts, :use_decompose, false), do: Arcana.Pipeline.decompose(ctx), else: ctx
+    end
+
+    defp maybe_reason(ctx, opts) do
+      if Keyword.get(opts, :use_reason, false), do: Arcana.Pipeline.reason(ctx), else: ctx
+    end
+
+    defp maybe_rerank(ctx, opts) do
+      # Use the local CrossEncoder reranker for the dashboard: it reorders
+      # without filtering, which matches the UI copy ("Cross-encoder
+      # rescoring") and avoids the LLM reranker's aggressive threshold that
+      # can drop every chunk on the demo questions. Passing :top_k bypasses
+      # the reranker's default threshold=0.0 filter since cross-encoder
+      # logits can land entirely negative on broad questions.
+      if Keyword.get(opts, :use_rerank, false) do
+        Arcana.Pipeline.rerank(ctx,
+          reranker: Arcana.Reranker.CrossEncoder,
+          top_k: 30
+        )
+      else
+        ctx
       end
+    end
 
-    controller_temperature = parse_temperature(params["controller_temperature"])
-    answer_temperature = parse_temperature(params["answer_temperature"])
-    fallback_temperature = parse_temperature(params["fallback_temperature"])
+    defp maybe_answer_with_hallucinations(ctx, opts) do
+      if Keyword.get(opts, :hallucinate_demo, false) do
+        Arcana.Pipeline.answer(ctx, prompt: &hallucination_demo_prompt/2)
+      else
+        Arcana.Pipeline.answer(ctx)
+      end
+    end
 
-    run_ground? = params["use_ground_loop"] == "true"
-    ground_opts = [grounder: Arcana.Grounder.LLMJudge, judge_model: llm]
+    defp hallucination_demo_prompt(question, chunks) do
+      reference_material =
+        chunks
+        |> Enum.with_index(1)
+        |> Enum.map_join("\n\n", fn {chunk, i} -> "[#{i}] #{chunk.text}" end)
 
-    new_opts =
-      [repo: repo]
-      |> maybe_put_collection_opt(selected_collections)
+      """
+      Context:
+      #{reference_material}
 
-    run_opts =
-      [
-        controller_llm: llm,
-        max_iterations: max_iterations,
-        chunk_cap: chunk_cap
+      Question: "#{question}"
+
+      Answer the question using the context above, but deliberately slip in 1-2 plausible-sounding statements that are NOT supported by the context. These fabricated facts should blend naturally into the answer. Do not flag or mark which statements are made up.
+      """
+    end
+
+    defp maybe_ground(ctx, opts) do
+      # Pipeline grounding uses default Hallmark. HallmarkServing now
+      # takes the top K reranked chunks (default 5), concats them into
+      # one context, and scores each sentence against that. Synthesis
+      # sentences that need evidence from multiple chunks land correctly
+      # because the top-K concat preserves the full combined context.
+      # Falls back to per-chunk max if the concat would exceed HHEM's
+      # input window.
+      if Keyword.get(opts, :use_ground, false) do
+        Arcana.Pipeline.ground(ctx)
+      else
+        ctx
+      end
+    end
+
+    defp build_search_opts(opts, all_collection_names) do
+      base = [
+        self_correct: Keyword.get(opts, :self_correct, false),
+        graph: Keyword.get(opts, :graph, false)
       ]
-      |> maybe_put(:controller_temperature, controller_temperature)
-      |> maybe_put(:answer_temperature, answer_temperature)
-      |> maybe_put(:fallback_temperature, fallback_temperature)
 
-    ctx = Arcana.Loop.new(question, new_opts)
-    runner = loop_runner()
+      use_llm_select = Keyword.get(opts, :use_llm_select, false)
 
-    with {:ok, ctx} <- runner.(ctx, run_opts) do
-      ctx = if run_ground?, do: Arcana.Loop.ground(ctx, ground_opts), else: ctx
-      {:ok, format_loop_result(ctx, question)}
+      if use_llm_select and length(all_collection_names) > 1 do
+        base
+      else
+        add_collection_opts(base, Keyword.get(opts, :collections, []))
+      end
     end
-  rescue
-    e ->
-      require Logger
-      Logger.error(Exception.format(:error, e, __STACKTRACE__))
-      {:error, Exception.message(e)}
-  end
 
-  defp maybe_put(opts, _key, nil), do: opts
-  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+    defp add_collection_opts(opts, []), do: opts
+    defp add_collection_opts(opts, list), do: Keyword.put(opts, :collections, list)
 
-  defp parse_temperature(nil), do: nil
-  defp parse_temperature(""), do: nil
-
-  defp parse_temperature(str) when is_binary(str) do
-    case Float.parse(str) do
-      {t, _} when t >= 0 and t <= 2 -> t
-      _ -> nil
+    defp format_pipeline_result(%{error: error}, _question) when not is_nil(error) do
+      {:error, error}
     end
-  end
 
-  # Hook for tests to stub out Loop execution. Defaults to the real Loop.run/2.
-  defp loop_runner do
-    Arcana.Config.get_env(:loop_runner) || (&Arcana.Loop.run/2)
-  end
+    defp format_pipeline_result(ctx, question) do
+      # Flatten chunks from nested results to match simple mode format
+      all_chunks =
+        (ctx.results || [])
+        |> Enum.flat_map(fn
+          %{chunks: chunks} -> chunks
+          chunk -> [chunk]
+        end)
+        |> Enum.uniq_by(& &1.id)
 
-  # Arcana.Loop.new/2 (and Arcana.search, Arcana.ask, Arcana.Pipeline.new)
-  # all normalize `:collection` and `:collections` to the same internal
-  # representation, so we can always pass the plural form and let the
-  # library sort it out.
-  defp maybe_put_collection_opt(opts, []), do: opts
-  defp maybe_put_collection_opt(opts, list), do: Keyword.put(opts, :collections, list)
+      graph_sourced_count =
+        Enum.count(all_chunks, fn c ->
+          sources = Map.get(c, :graph_sources) || []
+          sources != []
+        end)
 
-  defp format_loop_result(%Arcana.Loop.Context{} = ctx, question) do
-    %{
-      result_type: :loop,
-      question: question,
-      answer: ctx.answer,
-      tool_history: ctx.tool_history,
-      terminated_by: ctx.terminated_by,
-      iterations: ctx.iterations,
-      chunks: ctx.chunks,
-      grounding: ctx.grounding,
-      # Mirror the Pipeline result shape so existing result sections
-      # (grounding, chunks) can reuse the same rendering. The extras are
-      # what drives the agent trace view.
-      results: ctx.chunks,
-      expanded_query: nil,
-      sub_questions: nil,
-      selected_collections: nil
-    }
-  end
+      rerank_scores = Map.get(ctx, :rerank_scores) || %{}
 
-  defp run_advanced_ask(question, repo, llm, selected_collections, params) do
-    graph = params["graph_search"] == "true"
-
-    opts =
-      [repo: repo, llm: llm, graph: graph]
-      |> maybe_put_collection_opt(selected_collections)
-
-    case Arcana.ask(question, opts) do
-      {:ok, answer, results} ->
-        # Build a context-like struct for consistent UI display
-        {:ok,
-         %{
-           question: question,
-           answer: answer,
-           results: results,
-           expanded_query: nil,
-           sub_questions: nil,
-           selected_collections:
-             if(selected_collections == [], do: nil, else: selected_collections)
-         }}
-
-      {:error, reason} ->
-        {:error, reason}
+      {:ok,
+       %{
+         question: question,
+         answer: ctx.answer,
+         results: all_chunks,
+         retrieved_count: length(all_chunks),
+         graph_sourced_count: graph_sourced_count,
+         rewritten_query: ctx.rewritten_query,
+         expanded_query: ctx.expanded_query,
+         sub_questions: ctx.sub_questions,
+         skip_retrieval: ctx.skip_retrieval,
+         gate_reasoning: ctx.gate_reasoning,
+         reason_iterations: ctx.reason_iterations,
+         queries_tried: ctx.queries_tried,
+         correction_count: ctx.correction_count,
+         corrections: ctx.corrections,
+         rerank_scores: rerank_scores,
+         rerank_kept: map_size(rerank_scores),
+         selected_collections: ctx.collections,
+         grounding: ctx.grounding
+       }}
     end
-  rescue
-    e -> {:error, Exception.message(e)}
-  end
 
-  defp run_pipeline_ask(question, repo, llm, all_collections, opts) do
-    alias Arcana.Pipeline
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.dashboard_layout stats={@stats} current_tab={:ask} prefix={@prefix}>
+        <div class="arcana-ask">
+          <h2>Ask</h2>
+          <p class="arcana-tab-description">
+            Send a question through one of three retrieval strategies.
+          </p>
 
-    all_collection_names = Enum.map(all_collections, & &1.name)
-    search_opts = build_search_opts(opts, all_collection_names)
-
-    Pipeline.new(question, repo: repo, llm: llm)
-    |> maybe_gate(opts)
-    |> maybe_rewrite(opts)
-    |> maybe_select(opts, all_collection_names)
-    |> maybe_expand(opts)
-    |> maybe_decompose(opts)
-    |> Pipeline.search(search_opts)
-    |> maybe_reason(opts)
-    |> maybe_rerank(opts)
-    |> maybe_answer_with_hallucinations(opts)
-    |> maybe_ground(opts)
-    |> format_pipeline_result(question)
-  rescue
-    e -> {:error, Exception.message(e)}
-  end
-
-  defp maybe_gate(ctx, opts) do
-    if Keyword.get(opts, :use_gate, false), do: Arcana.Pipeline.gate(ctx), else: ctx
-  end
-
-  defp maybe_rewrite(ctx, opts) do
-    if Keyword.get(opts, :use_rewrite, false), do: Arcana.Pipeline.rewrite(ctx), else: ctx
-  end
-
-  defp maybe_select(ctx, opts, all_collection_names) do
-    if Keyword.get(opts, :use_llm_select, false) and length(all_collection_names) > 1 do
-      Arcana.Pipeline.select(ctx, collections: all_collection_names)
-    else
-      ctx
-    end
-  end
-
-  defp maybe_expand(ctx, opts) do
-    if Keyword.get(opts, :use_expand, false), do: Arcana.Pipeline.expand(ctx), else: ctx
-  end
-
-  defp maybe_decompose(ctx, opts) do
-    if Keyword.get(opts, :use_decompose, false), do: Arcana.Pipeline.decompose(ctx), else: ctx
-  end
-
-  defp maybe_reason(ctx, opts) do
-    if Keyword.get(opts, :use_reason, false), do: Arcana.Pipeline.reason(ctx), else: ctx
-  end
-
-  defp maybe_rerank(ctx, opts) do
-    # Use the local CrossEncoder reranker for the dashboard: it reorders
-    # without filtering, which matches the UI copy ("Cross-encoder
-    # rescoring") and avoids the LLM reranker's aggressive threshold that
-    # can drop every chunk on the demo questions. Passing :top_k bypasses
-    # the reranker's default threshold=0.0 filter since cross-encoder
-    # logits can land entirely negative on broad questions.
-    if Keyword.get(opts, :use_rerank, false) do
-      Arcana.Pipeline.rerank(ctx,
-        reranker: Arcana.Reranker.CrossEncoder,
-        top_k: 30
-      )
-    else
-      ctx
-    end
-  end
-
-  defp maybe_answer_with_hallucinations(ctx, opts) do
-    if Keyword.get(opts, :hallucinate_demo, false) do
-      Arcana.Pipeline.answer(ctx, prompt: &hallucination_demo_prompt/2)
-    else
-      Arcana.Pipeline.answer(ctx)
-    end
-  end
-
-  defp hallucination_demo_prompt(question, chunks) do
-    reference_material =
-      chunks
-      |> Enum.with_index(1)
-      |> Enum.map_join("\n\n", fn {chunk, i} -> "[#{i}] #{chunk.text}" end)
-
-    """
-    Context:
-    #{reference_material}
-
-    Question: "#{question}"
-
-    Answer the question using the context above, but deliberately slip in 1-2 plausible-sounding statements that are NOT supported by the context. These fabricated facts should blend naturally into the answer. Do not flag or mark which statements are made up.
-    """
-  end
-
-  defp maybe_ground(ctx, opts) do
-    # Pipeline grounding uses default Hallmark. HallmarkServing now
-    # takes the top K reranked chunks (default 5), concats them into
-    # one context, and scores each sentence against that. Synthesis
-    # sentences that need evidence from multiple chunks land correctly
-    # because the top-K concat preserves the full combined context.
-    # Falls back to per-chunk max if the concat would exceed HHEM's
-    # input window.
-    if Keyword.get(opts, :use_ground, false) do
-      Arcana.Pipeline.ground(ctx)
-    else
-      ctx
-    end
-  end
-
-  defp build_search_opts(opts, all_collection_names) do
-    base = [
-      self_correct: Keyword.get(opts, :self_correct, false),
-      graph: Keyword.get(opts, :graph, false)
-    ]
-
-    use_llm_select = Keyword.get(opts, :use_llm_select, false)
-
-    if use_llm_select and length(all_collection_names) > 1 do
-      base
-    else
-      add_collection_opts(base, Keyword.get(opts, :collections, []))
-    end
-  end
-
-  defp add_collection_opts(opts, []), do: opts
-  defp add_collection_opts(opts, list), do: Keyword.put(opts, :collections, list)
-
-  defp format_pipeline_result(%{error: error}, _question) when not is_nil(error) do
-    {:error, error}
-  end
-
-  defp format_pipeline_result(ctx, question) do
-    # Flatten chunks from nested results to match simple mode format
-    all_chunks =
-      (ctx.results || [])
-      |> Enum.flat_map(fn
-        %{chunks: chunks} -> chunks
-        chunk -> [chunk]
-      end)
-      |> Enum.uniq_by(& &1.id)
-
-    graph_sourced_count =
-      Enum.count(all_chunks, fn c ->
-        sources = Map.get(c, :graph_sources) || []
-        sources != []
-      end)
-
-    rerank_scores = Map.get(ctx, :rerank_scores) || %{}
-
-    {:ok,
-     %{
-       question: question,
-       answer: ctx.answer,
-       results: all_chunks,
-       retrieved_count: length(all_chunks),
-       graph_sourced_count: graph_sourced_count,
-       rewritten_query: ctx.rewritten_query,
-       expanded_query: ctx.expanded_query,
-       sub_questions: ctx.sub_questions,
-       skip_retrieval: ctx.skip_retrieval,
-       gate_reasoning: ctx.gate_reasoning,
-       reason_iterations: ctx.reason_iterations,
-       queries_tried: ctx.queries_tried,
-       correction_count: ctx.correction_count,
-       corrections: ctx.corrections,
-       rerank_scores: rerank_scores,
-       rerank_kept: map_size(rerank_scores),
-       selected_collections: ctx.collections,
-       grounding: ctx.grounding
-     }}
-  end
-
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:ask} prefix={@prefix}>
-      <div class="arcana-ask">
-        <h2>Ask</h2>
-        <p class="arcana-tab-description">
-          Send a question through one of three retrieval strategies.
-        </p>
-
-        <div class="arcana-ask-sub-tab-nav">
-          <button
-            type="button"
-            class={"arcana-ask-sub-tab #{if @ask_sub_tab == :advanced, do: "active", else: ""}"}
-            phx-click="ask_switch_sub_tab"
-            phx-value-sub_tab="advanced"
-          >
-            Advanced
-          </button>
-          <button
-            type="button"
-            class={"arcana-ask-sub-tab #{if @ask_sub_tab == :pipeline, do: "active", else: ""}"}
-            phx-click="ask_switch_sub_tab"
-            phx-value-sub_tab="pipeline"
-          >
-            Pipeline
-          </button>
-          <button
-            type="button"
-            class={"arcana-ask-sub-tab #{if @ask_sub_tab == :loop, do: "active", else: ""}"}
-            phx-click="ask_switch_sub_tab"
-            phx-value-sub_tab="loop"
-          >
-            Loop
-          </button>
-        </div>
-
-        <p class="arcana-sub-tab-description">
-          <%= case @ask_sub_tab do %>
-            <% :advanced -> %>
-              <code>Arcana.ask/2</code> — one call with sensible defaults. Query rewriting,
-              hybrid search, reranking, optional graph fusion.
-            <% :pipeline -> %>
-              <code>Arcana.Pipeline</code> — Modular RAG. Compose the steps yourself,
-              toggle each one on or off below.
-            <% :loop -> %>
-              <code>Arcana.Loop</code> — Agentic RAG. The LLM picks tools each turn
-              until it can answer or hits the iteration cap.
-          <% end %>
-        </p>
-
-        <%= if @ask_error do %>
-          <div class="arcana-eval-message error">
-            <%= @ask_error %>
-          </div>
-        <% end %>
-
-        <form id="ask-form" phx-submit="ask_submit" phx-change="form_changed" class="arcana-ask-form">
-          <input type="hidden" name="sub_tab" value={@ask_sub_tab} />
-
-          <div class="arcana-ask-input">
-            <textarea
-              name="question"
-              id="ask-question"
-              placeholder="Ask a question about your documents..."
-              rows="3"
-              phx-hook="CmdEnterSubmit"
-              disabled={@ask_running}
-            ><%= @ask_question %></textarea>
-
-            <%= if @ask_sub_tab == :advanced and selected_graph_enabled?(@collections, @selected_collections) do %>
-              <label class="arcana-deep-search-toggle">
-                <input
-                  type="checkbox"
-                  name="graph_search"
-                  value="true"
-                  checked={@graph_search}
-                  disabled={@ask_running}
-                />
-                <span>Graph-Assisted</span>
-                <small>Find results through entity relationships</small>
-              </label>
-            <% end %>
+          <div class="arcana-ask-sub-tab-nav">
+            <button
+              type="button"
+              class={"arcana-ask-sub-tab #{if @ask_sub_tab == :advanced, do: "active", else: ""}"}
+              phx-click="ask_switch_sub_tab"
+              phx-value-sub_tab="advanced"
+            >
+              Advanced
+            </button>
+            <button
+              type="button"
+              class={"arcana-ask-sub-tab #{if @ask_sub_tab == :pipeline, do: "active", else: ""}"}
+              phx-click="ask_switch_sub_tab"
+              phx-value-sub_tab="pipeline"
+            >
+              Pipeline
+            </button>
+            <button
+              type="button"
+              class={"arcana-ask-sub-tab #{if @ask_sub_tab == :loop, do: "active", else: ""}"}
+              phx-click="ask_switch_sub_tab"
+              phx-value-sub_tab="loop"
+            >
+              Loop
+            </button>
           </div>
 
-          <div class="arcana-ask-collections">
-            <label>Collections</label>
-            <%= if @ask_sub_tab == :pipeline and length(@collections) > 1 do %>
-              <div class="arcana-llm-select-toggle">
-                <label class="arcana-checkbox-label">
-                  <input
-                    type="checkbox"
-                    name="llm_select"
-                    value="true"
-                    checked={@llm_select}
-                    disabled={@ask_running}
-                    phx-click="toggle_llm_select"
-                  />
-                  <span>Let LLM select automatically</span>
-                  <small>LLM will choose the most relevant collection(s) based on your question</small>
-                </label>
-              </div>
+          <p class="arcana-sub-tab-description">
+            <%= case @ask_sub_tab do %>
+              <% :advanced -> %>
+                <code>Arcana.ask/2</code> — one call with sensible defaults. Query rewriting,
+                hybrid search, reranking, optional graph fusion.
+              <% :pipeline -> %>
+                <code>Arcana.Pipeline</code> — Modular RAG. Compose the steps yourself,
+                toggle each one on or off below.
+              <% :loop -> %>
+                <code>Arcana.Loop</code> — Agentic RAG. The LLM picks tools each turn
+                until it can answer or hits the iteration cap.
             <% end %>
-            <%= if not @llm_select do %>
-              <div class="arcana-collection-checkboxes">
-                <%= for coll <- @collections do %>
-                  <label class="arcana-collection-check">
-                    <input
-                      type="checkbox"
-                      name="collections[]"
-                      value={coll.name}
-                      checked={coll.name in @selected_collections}
-                      disabled={@ask_running}
-                    />
-                    <span><%= coll.name %></span>
-                  </label>
-                <% end %>
-              </div>
-              <small class="arcana-collection-hint">Select none for all collections</small>
-            <% end %>
-          </div>
+          </p>
 
-          <%= if @ask_sub_tab == :pipeline do %>
-            <div class="arcana-ask-options">
-              <h4>
-                Pipeline
-                <span style="font-size: 0.75em; font-weight: normal; opacity: 0.6;">
-                  <button
-                    type="button"
-                    class="arcana-pipeline-toggle-link"
-                    phx-click="set_pipeline_steps"
-                    phx-value-mode="all"
-                  >all</button>
-                  /
-                  <button
-                    type="button"
-                    class="arcana-pipeline-toggle-link"
-                    phx-click="set_pipeline_steps"
-                    phx-value-mode="none"
-                  >none</button>
-                </span>
-              </h4>
-              <div class="arcana-pipeline-phases">
-                <section class="arcana-pipeline-phase">
-                  <header class="arcana-pipeline-phase-header">
-                    <h5>Query preparation</h5>
-                    <span class="arcana-pipeline-phase-toggle">
-                      <button type="button" class="arcana-pipeline-toggle-link"
-                        phx-click="set_pipeline_steps" phx-value-mode="all" phx-value-group="query">all</button>
-                      /
-                      <button type="button" class="arcana-pipeline-toggle-link"
-                        phx-click="set_pipeline_steps" phx-value-mode="none" phx-value-group="query">none</button>
-                    </span>
-                  </header>
-                  <ol class="arcana-pipeline">
-                    <li>
-                      <label class="arcana-pipeline-step">
-                        <input type="checkbox" name="use_gate" value="true" checked={@pipeline_steps["use_gate"]} disabled={@ask_running} />
-                        <span class="arcana-step-label">Gate</span>
-                        <small>Skip retrieval if the LLM can answer from general knowledge</small>
-                      </label>
-                    </li>
-                    <li>
-                      <label class="arcana-pipeline-step">
-                        <input type="checkbox" name="use_rewrite" value="true" checked={@pipeline_steps["use_rewrite"]} disabled={@ask_running} />
-                        <span class="arcana-step-label">Query Rewriting</span>
-                        <small>Clean up conversational input before search</small>
-                      </label>
-                    </li>
-                    <li>
-                      <label class="arcana-pipeline-step">
-                        <input type="checkbox" name="use_expand" value="true" checked={@pipeline_steps["use_expand"]} disabled={@ask_running} />
-                        <span class="arcana-step-label">Query Expansion</span>
-                        <small>Generate related queries</small>
-                      </label>
-                    </li>
-                    <li>
-                      <label class="arcana-pipeline-step">
-                        <input type="checkbox" name="use_decompose" value="true" checked={@pipeline_steps["use_decompose"]} disabled={@ask_running} />
-                        <span class="arcana-step-label">Decomposition</span>
-                        <small>Break into sub-questions</small>
-                      </label>
-                    </li>
-                  </ol>
-                </section>
-
-                <section class="arcana-pipeline-phase">
-                  <header class="arcana-pipeline-phase-header">
-                    <h5>Retrieval</h5>
-                    <span class="arcana-pipeline-phase-toggle">
-                      <button type="button" class="arcana-pipeline-toggle-link"
-                        phx-click="set_pipeline_steps" phx-value-mode="all" phx-value-group="retrieval">all</button>
-                      /
-                      <button type="button" class="arcana-pipeline-toggle-link"
-                        phx-click="set_pipeline_steps" phx-value-mode="none" phx-value-group="retrieval">none</button>
-                    </span>
-                  </header>
-                  <ol class="arcana-pipeline">
-                    <li>
-                      <%= if selected_graph_enabled?(@collections, @selected_collections) do %>
-                        <div class="arcana-pipeline-fork">
-                          <label class="arcana-pipeline-step">
-                            <input type="radio" name="graph_search" value="false" disabled={@ask_running} />
-                            <span class="arcana-step-label">Search</span>
-                            <small>Retrieve relevant chunks</small>
-                          </label>
-                          <span class="arcana-fork-or">or</span>
-                          <label class="arcana-pipeline-step">
-                            <input type="radio" name="graph_search" value="true" checked disabled={@ask_running} />
-                            <span class="arcana-step-label">Graph-Assisted Search</span>
-                            <small>Find results through entity relationships</small>
-                          </label>
-                        </div>
-                      <% else %>
-                        <div class="arcana-pipeline-step fixed">
-                          <span class="arcana-step-label">Search</span>
-                          <small>Retrieve relevant chunks</small>
-                        </div>
-                      <% end %>
-                    </li>
-                    <li class="arcana-pipeline-substep">
-                      <label class="arcana-pipeline-step">
-                        <input type="checkbox" name="use_reason" value="true" checked={@pipeline_steps["use_reason"]} disabled={@ask_running} />
-                        <span class="arcana-step-label"><span class="arcana-loop-glyph">↻</span>Multi-hop Reasoning</span>
-                        <small>Loops search with a follow-up query when chunks are thin</small>
-                      </label>
-                    </li>
-                    <li>
-                      <label class="arcana-pipeline-step">
-                        <input type="checkbox" name="use_rerank" value="true" checked={@pipeline_steps["use_rerank"]} disabled={@ask_running} />
-                        <span class="arcana-step-label">Reranking</span>
-                        <small>Cross-encoder rescoring of retrieved chunks</small>
-                      </label>
-                    </li>
-                  </ol>
-                </section>
-
-                <section class="arcana-pipeline-phase">
-                  <header class="arcana-pipeline-phase-header">
-                    <h5>Answer</h5>
-                    <span class="arcana-pipeline-phase-toggle">
-                      <button type="button" class="arcana-pipeline-toggle-link"
-                        phx-click="set_pipeline_steps" phx-value-mode="all" phx-value-group="answer">all</button>
-                      /
-                      <button type="button" class="arcana-pipeline-toggle-link"
-                        phx-click="set_pipeline_steps" phx-value-mode="none" phx-value-group="answer">none</button>
-                    </span>
-                  </header>
-                  <ol class="arcana-pipeline">
-                    <li>
-                      <div class="arcana-pipeline-fork">
-                        <label class="arcana-pipeline-step">
-                          <input type="radio" name="answer_mode" value="normal" checked disabled={@ask_running} />
-                          <span class="arcana-step-label">Answer</span>
-                          <small>Generate faithful answer</small>
-                        </label>
-                        <span class="arcana-fork-or">or</span>
-                        <label class="arcana-pipeline-step">
-                          <input type="radio" name="answer_mode" value="hallucinate" disabled={@ask_running} />
-                          <span class="arcana-step-label">Answer with Hallucination</span>
-                          <small>Mix in fake facts to showcase grounding</small>
-                        </label>
-                      </div>
-                    </li>
-                    <li class="arcana-pipeline-substep">
-                      <label class="arcana-pipeline-step">
-                        <input type="checkbox" name="self_correct" value="true" checked={@pipeline_steps["self_correct"]} disabled={@ask_running} />
-                        <span class="arcana-step-label"><span class="arcana-loop-glyph">↻</span>Self-Correction</span>
-                        <small>Regenerate the answer if it isn't grounded in the chunks</small>
-                      </label>
-                    </li>
-                    <li>
-                      <label class="arcana-pipeline-step">
-                        <input type="checkbox" name="use_ground" value="true" checked={@pipeline_steps["use_ground"]} disabled={@ask_running} />
-                        <span class="arcana-step-label">Grounding</span>
-                        <small>Detect hallucinated vs faithful spans</small>
-                      </label>
-                    </li>
-                  </ol>
-                </section>
-              </div>
+          <%= if @ask_error do %>
+            <div class="arcana-eval-message error">
+              <%= @ask_error %>
             </div>
           <% end %>
 
-          <%= if @ask_sub_tab == :loop do %>
-            <% llms = loop_llm_roles() %>
-            <div class="arcana-loop-settings">
-              <h4>Loop settings</h4>
-              <div class="arcana-loop-settings-grid">
-                <div class="arcana-loop-setting arcana-loop-setting--info">
-                  <label>Controller LLM</label>
-                  <small>Picks tools each turn.</small>
-                  <div class="arcana-loop-setting-value"><%= llms.controller || "—" %></div>
-                  <div class="arcana-loop-setting-temp">
-                    <label for="controller_temperature">temp</label>
+          <form id="ask-form" phx-submit="ask_submit" phx-change="form_changed" class="arcana-ask-form">
+            <input type="hidden" name="sub_tab" value={@ask_sub_tab} />
+
+            <div class="arcana-ask-input">
+              <textarea
+                name="question"
+                id="ask-question"
+                placeholder="Ask a question about your documents..."
+                rows="3"
+                phx-hook="CmdEnterSubmit"
+                disabled={@ask_running}
+              ><%= @ask_question %></textarea>
+
+              <%= if @ask_sub_tab == :advanced and selected_graph_enabled?(@collections, @selected_collections) do %>
+                <label class="arcana-deep-search-toggle">
+                  <input
+                    type="checkbox"
+                    name="graph_search"
+                    value="true"
+                    checked={@graph_search}
+                    disabled={@ask_running}
+                  />
+                  <span>Graph-Assisted</span>
+                  <small>Find results through entity relationships</small>
+                </label>
+              <% end %>
+            </div>
+
+            <div class="arcana-ask-collections">
+              <label>Collections</label>
+              <%= if @ask_sub_tab == :pipeline and length(@collections) > 1 do %>
+                <div class="arcana-llm-select-toggle">
+                  <label class="arcana-checkbox-label">
                     <input
-                      type="number"
-                      name="controller_temperature"
-                      id="controller_temperature"
-                      value="0.1"
-                      min="0"
-                      max="2"
-                      step="0.1"
+                      type="checkbox"
+                      name="llm_select"
+                      value="true"
+                      checked={@llm_select}
                       disabled={@ask_running}
+                      phx-click="toggle_llm_select"
                     />
-                  </div>
+                    <span>Let LLM select automatically</span>
+                    <small>LLM will choose the most relevant collection(s) based on your question</small>
+                  </label>
                 </div>
-                <div class="arcana-loop-setting arcana-loop-setting--info">
-                  <label>Answer LLM</label>
-                  <small>
-                    <%= if llms.answer,
-                      do: "Rewrites the final user-facing answer.",
-                      else: "Not set. Uses the controller's tool text directly." %>
-                  </small>
-                  <div class="arcana-loop-setting-value">
-                    <%= llms.answer || "(uses controller)" %>
-                  </div>
-                  <%= if llms.answer do %>
+              <% end %>
+              <%= if not @llm_select do %>
+                <div class="arcana-collection-checkboxes">
+                  <%= for coll <- @collections do %>
+                    <label class="arcana-collection-check">
+                      <input
+                        type="checkbox"
+                        name="collections[]"
+                        value={coll.name}
+                        checked={coll.name in @selected_collections}
+                        disabled={@ask_running}
+                      />
+                      <span><%= coll.name %></span>
+                    </label>
+                  <% end %>
+                </div>
+                <small class="arcana-collection-hint">Select none for all collections</small>
+              <% end %>
+            </div>
+
+            <%= if @ask_sub_tab == :pipeline do %>
+              <div class="arcana-ask-options">
+                <h4>
+                  Pipeline
+                  <span style="font-size: 0.75em; font-weight: normal; opacity: 0.6;">
+                    <button
+                      type="button"
+                      class="arcana-pipeline-toggle-link"
+                      phx-click="set_pipeline_steps"
+                      phx-value-mode="all"
+                    >all</button>
+                    /
+                    <button
+                      type="button"
+                      class="arcana-pipeline-toggle-link"
+                      phx-click="set_pipeline_steps"
+                      phx-value-mode="none"
+                    >none</button>
+                  </span>
+                </h4>
+                <div class="arcana-pipeline-phases">
+                  <section class="arcana-pipeline-phase">
+                    <header class="arcana-pipeline-phase-header">
+                      <h5>Query preparation</h5>
+                      <span class="arcana-pipeline-phase-toggle">
+                        <button type="button" class="arcana-pipeline-toggle-link"
+                          phx-click="set_pipeline_steps" phx-value-mode="all" phx-value-group="query">all</button>
+                        /
+                        <button type="button" class="arcana-pipeline-toggle-link"
+                          phx-click="set_pipeline_steps" phx-value-mode="none" phx-value-group="query">none</button>
+                      </span>
+                    </header>
+                    <ol class="arcana-pipeline">
+                      <li>
+                        <label class="arcana-pipeline-step">
+                          <input type="checkbox" name="use_gate" value="true" checked={@pipeline_steps["use_gate"]} disabled={@ask_running} />
+                          <span class="arcana-step-label">Gate</span>
+                          <small>Skip retrieval if the LLM can answer from general knowledge</small>
+                        </label>
+                      </li>
+                      <li>
+                        <label class="arcana-pipeline-step">
+                          <input type="checkbox" name="use_rewrite" value="true" checked={@pipeline_steps["use_rewrite"]} disabled={@ask_running} />
+                          <span class="arcana-step-label">Query Rewriting</span>
+                          <small>Clean up conversational input before search</small>
+                        </label>
+                      </li>
+                      <li>
+                        <label class="arcana-pipeline-step">
+                          <input type="checkbox" name="use_expand" value="true" checked={@pipeline_steps["use_expand"]} disabled={@ask_running} />
+                          <span class="arcana-step-label">Query Expansion</span>
+                          <small>Generate related queries</small>
+                        </label>
+                      </li>
+                      <li>
+                        <label class="arcana-pipeline-step">
+                          <input type="checkbox" name="use_decompose" value="true" checked={@pipeline_steps["use_decompose"]} disabled={@ask_running} />
+                          <span class="arcana-step-label">Decomposition</span>
+                          <small>Break into sub-questions</small>
+                        </label>
+                      </li>
+                    </ol>
+                  </section>
+
+                  <section class="arcana-pipeline-phase">
+                    <header class="arcana-pipeline-phase-header">
+                      <h5>Retrieval</h5>
+                      <span class="arcana-pipeline-phase-toggle">
+                        <button type="button" class="arcana-pipeline-toggle-link"
+                          phx-click="set_pipeline_steps" phx-value-mode="all" phx-value-group="retrieval">all</button>
+                        /
+                        <button type="button" class="arcana-pipeline-toggle-link"
+                          phx-click="set_pipeline_steps" phx-value-mode="none" phx-value-group="retrieval">none</button>
+                      </span>
+                    </header>
+                    <ol class="arcana-pipeline">
+                      <li>
+                        <%= if selected_graph_enabled?(@collections, @selected_collections) do %>
+                          <div class="arcana-pipeline-fork">
+                            <label class="arcana-pipeline-step">
+                              <input type="radio" name="graph_search" value="false" disabled={@ask_running} />
+                              <span class="arcana-step-label">Search</span>
+                              <small>Retrieve relevant chunks</small>
+                            </label>
+                            <span class="arcana-fork-or">or</span>
+                            <label class="arcana-pipeline-step">
+                              <input type="radio" name="graph_search" value="true" checked disabled={@ask_running} />
+                              <span class="arcana-step-label">Graph-Assisted Search</span>
+                              <small>Find results through entity relationships</small>
+                            </label>
+                          </div>
+                        <% else %>
+                          <div class="arcana-pipeline-step fixed">
+                            <span class="arcana-step-label">Search</span>
+                            <small>Retrieve relevant chunks</small>
+                          </div>
+                        <% end %>
+                      </li>
+                      <li class="arcana-pipeline-substep">
+                        <label class="arcana-pipeline-step">
+                          <input type="checkbox" name="use_reason" value="true" checked={@pipeline_steps["use_reason"]} disabled={@ask_running} />
+                          <span class="arcana-step-label"><span class="arcana-loop-glyph">↻</span>Multi-hop Reasoning</span>
+                          <small>Loops search with a follow-up query when chunks are thin</small>
+                        </label>
+                      </li>
+                      <li>
+                        <label class="arcana-pipeline-step">
+                          <input type="checkbox" name="use_rerank" value="true" checked={@pipeline_steps["use_rerank"]} disabled={@ask_running} />
+                          <span class="arcana-step-label">Reranking</span>
+                          <small>Cross-encoder rescoring of retrieved chunks</small>
+                        </label>
+                      </li>
+                    </ol>
+                  </section>
+
+                  <section class="arcana-pipeline-phase">
+                    <header class="arcana-pipeline-phase-header">
+                      <h5>Answer</h5>
+                      <span class="arcana-pipeline-phase-toggle">
+                        <button type="button" class="arcana-pipeline-toggle-link"
+                          phx-click="set_pipeline_steps" phx-value-mode="all" phx-value-group="answer">all</button>
+                        /
+                        <button type="button" class="arcana-pipeline-toggle-link"
+                          phx-click="set_pipeline_steps" phx-value-mode="none" phx-value-group="answer">none</button>
+                      </span>
+                    </header>
+                    <ol class="arcana-pipeline">
+                      <li>
+                        <div class="arcana-pipeline-fork">
+                          <label class="arcana-pipeline-step">
+                            <input type="radio" name="answer_mode" value="normal" checked disabled={@ask_running} />
+                            <span class="arcana-step-label">Answer</span>
+                            <small>Generate faithful answer</small>
+                          </label>
+                          <span class="arcana-fork-or">or</span>
+                          <label class="arcana-pipeline-step">
+                            <input type="radio" name="answer_mode" value="hallucinate" disabled={@ask_running} />
+                            <span class="arcana-step-label">Answer with Hallucination</span>
+                            <small>Mix in fake facts to showcase grounding</small>
+                          </label>
+                        </div>
+                      </li>
+                      <li class="arcana-pipeline-substep">
+                        <label class="arcana-pipeline-step">
+                          <input type="checkbox" name="self_correct" value="true" checked={@pipeline_steps["self_correct"]} disabled={@ask_running} />
+                          <span class="arcana-step-label"><span class="arcana-loop-glyph">↻</span>Self-Correction</span>
+                          <small>Regenerate the answer if it isn't grounded in the chunks</small>
+                        </label>
+                      </li>
+                      <li>
+                        <label class="arcana-pipeline-step">
+                          <input type="checkbox" name="use_ground" value="true" checked={@pipeline_steps["use_ground"]} disabled={@ask_running} />
+                          <span class="arcana-step-label">Grounding</span>
+                          <small>Detect hallucinated vs faithful spans</small>
+                        </label>
+                      </li>
+                    </ol>
+                  </section>
+                </div>
+              </div>
+            <% end %>
+
+            <%= if @ask_sub_tab == :loop do %>
+              <% llms = loop_llm_roles() %>
+              <div class="arcana-loop-settings">
+                <h4>Loop settings</h4>
+                <div class="arcana-loop-settings-grid">
+                  <div class="arcana-loop-setting arcana-loop-setting--info">
+                    <label>Controller LLM</label>
+                    <small>Picks tools each turn.</small>
+                    <div class="arcana-loop-setting-value"><%= llms.controller || "—" %></div>
                     <div class="arcana-loop-setting-temp">
-                      <label for="answer_temperature">temp</label>
+                      <label for="controller_temperature">temp</label>
                       <input
                         type="number"
-                        name="answer_temperature"
-                        id="answer_temperature"
+                        name="controller_temperature"
+                        id="controller_temperature"
+                        value="0.1"
+                        min="0"
+                        max="2"
+                        step="0.1"
+                        disabled={@ask_running}
+                      />
+                    </div>
+                  </div>
+                  <div class="arcana-loop-setting arcana-loop-setting--info">
+                    <label>Answer LLM</label>
+                    <small>
+                      <%= if llms.answer,
+                        do: "Rewrites the final user-facing answer.",
+                        else: "Not set. Uses the controller's tool text directly." %>
+                    </small>
+                    <div class="arcana-loop-setting-value">
+                      <%= llms.answer || "(uses controller)" %>
+                    </div>
+                    <%= if llms.answer do %>
+                      <div class="arcana-loop-setting-temp">
+                        <label for="answer_temperature">temp</label>
+                        <input
+                          type="number"
+                          name="answer_temperature"
+                          id="answer_temperature"
+                          value="0.3"
+                          min="0"
+                          max="2"
+                          step="0.1"
+                          disabled={@ask_running}
+                        />
+                      </div>
+                    <% end %>
+                  </div>
+                  <div class="arcana-loop-setting arcana-loop-setting--info">
+                    <label>Fallback synthesizer</label>
+                    <small>Used when max_iterations hits with chunks but no answer call.</small>
+                    <div class="arcana-loop-setting-value"><%= llms.fallback || "—" %></div>
+                    <div class="arcana-loop-setting-temp">
+                      <label for="fallback_temperature">temp</label>
+                      <input
+                        type="number"
+                        name="fallback_temperature"
+                        id="fallback_temperature"
                         value="0.3"
                         min="0"
                         max="2"
@@ -1202,651 +1231,633 @@ defmodule ArcanaWeb.AskLive do
                         disabled={@ask_running}
                       />
                     </div>
-                  <% end %>
-                </div>
-                <div class="arcana-loop-setting arcana-loop-setting--info">
-                  <label>Fallback synthesizer</label>
-                  <small>Used when max_iterations hits with chunks but no answer call.</small>
-                  <div class="arcana-loop-setting-value"><%= llms.fallback || "—" %></div>
-                  <div class="arcana-loop-setting-temp">
-                    <label for="fallback_temperature">temp</label>
+                  </div>
+                  <div class="arcana-loop-setting arcana-loop-setting--info">
+                    <label>Tools (default set)</label>
+                    <small>
+                      <code>search</code> · <code>answer</code> · <code>give_up</code>
+                    </small>
+                  </div>
+                  <div class="arcana-loop-setting arcana-loop-setting--number">
+                    <label for="max_iterations">Max iterations</label>
+                    <small>Hard cap on controller turns.</small>
                     <input
                       type="number"
-                      name="fallback_temperature"
-                      id="fallback_temperature"
-                      value="0.3"
-                      min="0"
-                      max="2"
-                      step="0.1"
+                      name="max_iterations"
+                      id="max_iterations"
+                      value="10"
+                      min="1"
+                      max="50"
                       disabled={@ask_running}
                     />
                   </div>
+                  <div class="arcana-loop-setting arcana-loop-setting--number">
+                    <label for="chunk_cap">Chunk cap</label>
+                    <small>Max chunks accumulated across iterations.</small>
+                    <input
+                      type="number"
+                      name="chunk_cap"
+                      id="chunk_cap"
+                      value="50"
+                      min="1"
+                      max="200"
+                      disabled={@ask_running}
+                    />
+                  </div>
+                  <label class="arcana-loop-setting arcana-loop-setting--toggle">
+                    <input
+                      type="checkbox"
+                      name="use_ground_loop"
+                      value="true"
+                      disabled={@ask_running}
+                    />
+                    <span class="arcana-loop-toggle-content">
+                      <span class="arcana-loop-toggle-label">Run grounding after loop</span>
+                      <small>LLM-as-judge faithfulness over accumulated chunks.</small>
+                    </span>
+                  </label>
                 </div>
-                <div class="arcana-loop-setting arcana-loop-setting--info">
-                  <label>Tools (default set)</label>
-                  <small>
-                    <code>search</code> · <code>answer</code> · <code>give_up</code>
-                  </small>
-                </div>
-                <div class="arcana-loop-setting arcana-loop-setting--number">
-                  <label for="max_iterations">Max iterations</label>
-                  <small>Hard cap on controller turns.</small>
-                  <input
-                    type="number"
-                    name="max_iterations"
-                    id="max_iterations"
-                    value="10"
-                    min="1"
-                    max="50"
-                    disabled={@ask_running}
-                  />
-                </div>
-                <div class="arcana-loop-setting arcana-loop-setting--number">
-                  <label for="chunk_cap">Chunk cap</label>
-                  <small>Max chunks accumulated across iterations.</small>
-                  <input
-                    type="number"
-                    name="chunk_cap"
-                    id="chunk_cap"
-                    value="50"
-                    min="1"
-                    max="200"
-                    disabled={@ask_running}
-                  />
-                </div>
-                <label class="arcana-loop-setting arcana-loop-setting--toggle">
-                  <input
-                    type="checkbox"
-                    name="use_ground_loop"
-                    value="true"
-                    disabled={@ask_running}
-                  />
-                  <span class="arcana-loop-toggle-content">
-                    <span class="arcana-loop-toggle-label">Run grounding after loop</span>
-                    <small>LLM-as-judge faithfulness over accumulated chunks.</small>
-                  </span>
-                </label>
               </div>
-            </div>
-          <% end %>
+            <% end %>
 
-          <div class="arcana-ask-actions">
-            <button type="submit" disabled={@ask_running}>
-              <%= if @ask_running, do: "Asking...", else: "Ask" %>
-            </button>
-            <%= if @ask_context do %>
-              <button type="button" phx-click="ask_clear" disabled={@ask_running}>
-                Clear
+            <div class="arcana-ask-actions">
+              <button type="submit" disabled={@ask_running}>
+                <%= if @ask_running, do: "Asking...", else: "Ask" %>
               </button>
-            <% end %>
-          </div>
-        </form>
-
-        <%= if @ask_running do %>
-          <div class="arcana-ask-loading">
-            <div class="arcana-spinner"></div>
-            <span><%= ask_loading_label(@ask_sub_tab, @pipeline_step, @loop_phase) %></span>
-          </div>
-
-          <%= if @ask_sub_tab == :loop do %>
-            <div class="arcana-loop-live-trace" id="loop-live-trace">
-              <div class="arcana-loop-live-header">
-                <span class="arcana-loop-live-pulse"></span>
-                <span class="arcana-loop-live-title">Agent thinking</span>
-                <span class="arcana-loop-live-count">
-                  <%= length(@loop_live_history) %> <%= if length(@loop_live_history) == 1, do: "iteration", else: "iterations" %>
-                </span>
-              </div>
-
-              <%= if @loop_live_history == [] do %>
-                <div class="arcana-loop-live-empty">
-                  Waiting for the controller's first move…
-                </div>
-              <% else %>
-                <ol class="arcana-loop-iterations arcana-loop-iterations--live">
-                  <%= for entry <- @loop_live_history do %>
-                    <li class={"arcana-loop-iteration arcana-tool-#{entry.tool}"}>
-                      <div class="arcana-loop-iter-header">
-                        <span class="arcana-loop-iter-num">[<%= entry.iteration %>]</span>
-                        <span class="arcana-loop-tool"><%= to_string(entry.tool) %></span>
-                        <span class="arcana-loop-args">
-                          <%= loop_arg_summary(entry.tool, entry.args) %>
-                        </span>
-                        <%= if length(entry.returned_chunk_ids) > 0 do %>
-                          <span class="arcana-loop-chunk-count">
-                            → <%= length(entry.returned_chunk_ids) %> chunks
-                          </span>
-                        <% end %>
-                      </div>
-                    </li>
-                  <% end %>
-                </ol>
+              <%= if @ask_context do %>
+                <button type="button" phx-click="ask_clear" disabled={@ask_running}>
+                  Clear
+                </button>
               <% end %>
             </div>
-          <% end %>
+          </form>
 
-          <%= if @ask_sub_tab in [:pipeline, :advanced] do %>
-            <div class="arcana-loop-live-trace" id="trace-live-trace">
-              <div class="arcana-loop-live-header">
-                <span class="arcana-loop-live-pulse"></span>
-                <span class="arcana-loop-live-title">
-                  <%= if @ask_sub_tab == :pipeline, do: "Pipeline", else: "Retrieval" %>
-                </span>
-                <span class="arcana-loop-live-count">
-                  <%= length(@trace_history) %> <%= if length(@trace_history) == 1, do: "step", else: "steps" %>
-                </span>
-              </div>
+          <%= if @ask_running do %>
+            <div class="arcana-ask-loading">
+              <div class="arcana-spinner"></div>
+              <span><%= ask_loading_label(@ask_sub_tab, @pipeline_step, @loop_phase) %></span>
+            </div>
 
-              <%= if @trace_history == [] do %>
-                <div class="arcana-loop-live-empty">
-                  Waiting for the first step…
+            <%= if @ask_sub_tab == :loop do %>
+              <div class="arcana-loop-live-trace" id="loop-live-trace">
+                <div class="arcana-loop-live-header">
+                  <span class="arcana-loop-live-pulse"></span>
+                  <span class="arcana-loop-live-title">Agent thinking</span>
+                  <span class="arcana-loop-live-count">
+                    <%= length(@loop_live_history) %> <%= if length(@loop_live_history) == 1, do: "iteration", else: "iterations" %>
+                  </span>
                 </div>
-              <% else %>
-                <ol class="arcana-loop-iterations arcana-loop-iterations--live arcana-pipeline-iterations">
-                  <%= for {entry, index} <- Enum.with_index(@trace_history, 1) do %>
-                    <li class={"arcana-loop-iteration arcana-pipeline-step-trace arcana-pipeline-step-trace--#{entry.status}"}>
-                      <div class="arcana-loop-iter-header">
-                        <span class="arcana-loop-iter-num">
-                          <%= if entry.status == :running do %>
-                            <span class="arcana-pipeline-step-spinner"></span>
-                          <% else %>
-                            <%= index %>
+
+                <%= if @loop_live_history == [] do %>
+                  <div class="arcana-loop-live-empty">
+                    Waiting for the controller's first move…
+                  </div>
+                <% else %>
+                  <ol class="arcana-loop-iterations arcana-loop-iterations--live">
+                    <%= for entry <- @loop_live_history do %>
+                      <li class={"arcana-loop-iteration arcana-tool-#{entry.tool}"}>
+                        <div class="arcana-loop-iter-header">
+                          <span class="arcana-loop-iter-num">[<%= entry.iteration %>]</span>
+                          <span class="arcana-loop-tool"><%= to_string(entry.tool) %></span>
+                          <span class="arcana-loop-args">
+                            <%= loop_arg_summary(entry.tool, entry.args) %>
+                          </span>
+                          <%= if length(entry.returned_chunk_ids) > 0 do %>
+                            <span class="arcana-loop-chunk-count">
+                              → <%= length(entry.returned_chunk_ids) %> chunks
+                            </span>
                           <% end %>
-                        </span>
-                        <span class="arcana-loop-tool">
-                          <%= pipeline_step_short(entry.step) %>
-                        </span>
-                        <span class="arcana-loop-args">
-                          <%= pipeline_step_meta_summary(entry.step, entry.meta) %>
-                        </span>
-                        <%= if entry.status == :done and entry.duration_ms do %>
-                          <span class="arcana-loop-chunk-count">
-                            <%= format_duration(entry.duration_ms) %>
+                        </div>
+                      </li>
+                    <% end %>
+                  </ol>
+                <% end %>
+              </div>
+            <% end %>
+
+            <%= if @ask_sub_tab in [:pipeline, :advanced] do %>
+              <div class="arcana-loop-live-trace" id="trace-live-trace">
+                <div class="arcana-loop-live-header">
+                  <span class="arcana-loop-live-pulse"></span>
+                  <span class="arcana-loop-live-title">
+                    <%= if @ask_sub_tab == :pipeline, do: "Pipeline", else: "Retrieval" %>
+                  </span>
+                  <span class="arcana-loop-live-count">
+                    <%= length(@trace_history) %> <%= if length(@trace_history) == 1, do: "step", else: "steps" %>
+                  </span>
+                </div>
+
+                <%= if @trace_history == [] do %>
+                  <div class="arcana-loop-live-empty">
+                    Waiting for the first step…
+                  </div>
+                <% else %>
+                  <ol class="arcana-loop-iterations arcana-loop-iterations--live arcana-pipeline-iterations">
+                    <%= for {entry, index} <- Enum.with_index(@trace_history, 1) do %>
+                      <li class={"arcana-loop-iteration arcana-pipeline-step-trace arcana-pipeline-step-trace--#{entry.status}"}>
+                        <div class="arcana-loop-iter-header">
+                          <span class="arcana-loop-iter-num">
+                            <%= if entry.status == :running do %>
+                              <span class="arcana-pipeline-step-spinner"></span>
+                            <% else %>
+                              <%= index %>
+                            <% end %>
                           </span>
-                        <% end %>
-                      </div>
-                    </li>
-                  <% end %>
-                </ol>
-              <% end %>
-            </div>
+                          <span class="arcana-loop-tool">
+                            <%= pipeline_step_short(entry.step) %>
+                          </span>
+                          <span class="arcana-loop-args">
+                            <%= pipeline_step_meta_summary(entry.step, entry.meta) %>
+                          </span>
+                          <%= if entry.status == :done and entry.duration_ms do %>
+                            <span class="arcana-loop-chunk-count">
+                              <%= format_duration(entry.duration_ms) %>
+                            </span>
+                          <% end %>
+                        </div>
+                      </li>
+                    <% end %>
+                  </ol>
+                <% end %>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
 
-        <%= if @ask_context do %>
-          <div class="arcana-ask-results">
-            <div class="arcana-ask-answer">
-              <h3>Answer</h3>
-              <div class="arcana-answer-content">
-                <%= cond do %>
-                  <% is_nil(@ask_context.answer) -> %>
-                    <span style="color: #9ca3af; font-style: italic;">No answer generated</span>
-                  <% Map.get(@ask_context, :grounding) -> %>
-                    <%= render_highlighted_answer(@ask_context.answer, @ask_context.grounding) %>
-                  <% true -> %>
-                    <%= render_markdown_answer(@ask_context.answer) %>
-                <% end %>
+          <%= if @ask_context do %>
+            <div class="arcana-ask-results">
+              <div class="arcana-ask-answer">
+                <h3>Answer</h3>
+                <div class="arcana-answer-content">
+                  <%= cond do %>
+                    <% is_nil(@ask_context.answer) -> %>
+                      <span style="color: #9ca3af; font-style: italic;">No answer generated</span>
+                    <% Map.get(@ask_context, :grounding) -> %>
+                      <%= render_highlighted_answer(@ask_context.answer, @ask_context.grounding) %>
+                    <% true -> %>
+                      <%= render_markdown_answer(@ask_context.answer) %>
+                  <% end %>
+                </div>
               </div>
-            </div>
 
-            <%= if Map.get(@ask_context, :result_type) == :loop do %>
-              <div class="arcana-ask-section arcana-loop-trace">
-                <h4>
-                  Agent trace
-                  <span class="arcana-loop-meta">
-                    <code><%= to_string(@ask_context.terminated_by) %></code>
-                    &middot; <%= @ask_context.iterations %> iterations
-                    &middot; <%= length(@ask_context.chunks) %> chunks accumulated
-                  </span>
-                </h4>
+              <%= if Map.get(@ask_context, :result_type) == :loop do %>
+                <div class="arcana-ask-section arcana-loop-trace">
+                  <h4>
+                    Agent trace
+                    <span class="arcana-loop-meta">
+                      <code><%= to_string(@ask_context.terminated_by) %></code>
+                      &middot; <%= @ask_context.iterations %> iterations
+                      &middot; <%= length(@ask_context.chunks) %> chunks accumulated
+                    </span>
+                  </h4>
 
-                <ol class="arcana-loop-iterations">
-                  <%= for entry <- @ask_context.tool_history do %>
-                    <li class={"arcana-loop-iteration arcana-tool-#{entry.tool}"}>
-                      <div class="arcana-loop-iter-header">
-                        <span class="arcana-loop-iter-num">[<%= entry.iteration %>]</span>
-                        <span class="arcana-loop-tool"><%= to_string(entry.tool) %></span>
-                        <span class="arcana-loop-args">
-                          <%= loop_arg_summary(entry.tool, entry.args) %>
-                        </span>
-                        <%= if length(entry.returned_chunk_ids) > 0 do %>
-                          <span class="arcana-loop-chunk-count">
-                            → <%= length(entry.returned_chunk_ids) %> chunks
+                  <ol class="arcana-loop-iterations">
+                    <%= for entry <- @ask_context.tool_history do %>
+                      <li class={"arcana-loop-iteration arcana-tool-#{entry.tool}"}>
+                        <div class="arcana-loop-iter-header">
+                          <span class="arcana-loop-iter-num">[<%= entry.iteration %>]</span>
+                          <span class="arcana-loop-tool"><%= to_string(entry.tool) %></span>
+                          <span class="arcana-loop-args">
+                            <%= loop_arg_summary(entry.tool, entry.args) %>
                           </span>
-                        <% end %>
-                      </div>
-                    </li>
-                  <% end %>
-                </ol>
-              </div>
-            <% end %>
-
-            <%= if Map.get(@ask_context, :grounding) do %>
-              <div class="arcana-ask-section arcana-grounding-results">
-                <h4>
-                  Grounding
-                  <span class={"arcana-grounding-score #{if @ask_context.grounding.score >= 0.8, do: "good", else: if(@ask_context.grounding.score >= 0.5, do: "warn", else: "bad")}"}>
-                    <%= Float.round(@ask_context.grounding.score * 100, 1) %>% faithful
-                  </span>
-                </h4>
-
-                <% chunks = Map.get(@ask_context, :results, []) %>
-
-                <%= if length(@ask_context.grounding.hallucinated_spans) > 0 do %>
-                  <div class="arcana-grounding-spans">
-                    <h5>Hallucinated Spans</h5>
-                    <%= for span <- @ask_context.grounding.hallucinated_spans do %>
-                      <div class="arcana-span hallucinated">
-                        <span class="arcana-span-text"><%= span.text %></span>
-                        <span class="arcana-span-score"><%= Float.round(span.score, 2) %></span>
-                        <.source_previews sources={Map.get(span, :sources, [])} chunks={chunks} />
-                      </div>
+                          <%= if length(entry.returned_chunk_ids) > 0 do %>
+                            <span class="arcana-loop-chunk-count">
+                              → <%= length(entry.returned_chunk_ids) %> chunks
+                            </span>
+                          <% end %>
+                        </div>
+                      </li>
                     <% end %>
-                  </div>
-                <% end %>
+                  </ol>
+                </div>
+              <% end %>
 
-                <%= if length(@ask_context.grounding.faithful_spans) > 0 do %>
-                  <div class="arcana-grounding-spans">
-                    <h5>Faithful Spans (<%= length(@ask_context.grounding.faithful_spans) %>)</h5>
-                    <%= for span <- @ask_context.grounding.faithful_spans do %>
-                      <div class="arcana-span faithful">
-                        <span class="arcana-span-text"><%= span.text %></span>
-                        <.source_previews sources={Map.get(span, :sources, [])} chunks={chunks} />
-                      </div>
+              <%= if Map.get(@ask_context, :grounding) do %>
+                <div class="arcana-ask-section arcana-grounding-results">
+                  <h4>
+                    Grounding
+                    <span class={"arcana-grounding-score #{if @ask_context.grounding.score >= 0.8, do: "good", else: if(@ask_context.grounding.score >= 0.5, do: "warn", else: "bad")}"}>
+                      <%= Float.round(@ask_context.grounding.score * 100, 1) %>% faithful
+                    </span>
+                  </h4>
+
+                  <% chunks = Map.get(@ask_context, :results, []) %>
+
+                  <%= if length(@ask_context.grounding.hallucinated_spans) > 0 do %>
+                    <div class="arcana-grounding-spans">
+                      <h5>Hallucinated Spans</h5>
+                      <%= for span <- @ask_context.grounding.hallucinated_spans do %>
+                        <div class="arcana-span hallucinated">
+                          <span class="arcana-span-text"><%= span.text %></span>
+                          <span class="arcana-span-score"><%= Float.round(span.score, 2) %></span>
+                          <.source_previews sources={Map.get(span, :sources, [])} chunks={chunks} />
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
+
+                  <%= if length(@ask_context.grounding.faithful_spans) > 0 do %>
+                    <div class="arcana-grounding-spans">
+                      <h5>Faithful Spans (<%= length(@ask_context.grounding.faithful_spans) %>)</h5>
+                      <%= for span <- @ask_context.grounding.faithful_spans do %>
+                        <div class="arcana-span faithful">
+                          <span class="arcana-span-text"><%= span.text %></span>
+                          <.source_previews sources={Map.get(span, :sources, [])} chunks={chunks} />
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+
+              <%= if pipeline_internals?(@ask_context) do %>
+                <div class="arcana-ask-section arcana-pipeline-internals">
+                  <h4>Pipeline internals</h4>
+                  <dl class="arcana-pipeline-internals-list">
+                    <%= if rq = Map.get(@ask_context, :rewritten_query) do %>
+                      <dt>Rewritten query</dt>
+                      <dd class="arcana-pipeline-internals-quote">"<%= rq %>"</dd>
                     <% end %>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
 
-            <%= if pipeline_internals?(@ask_context) do %>
-              <div class="arcana-ask-section arcana-pipeline-internals">
-                <h4>Pipeline internals</h4>
-                <dl class="arcana-pipeline-internals-list">
-                  <%= if rq = Map.get(@ask_context, :rewritten_query) do %>
-                    <dt>Rewritten query</dt>
-                    <dd class="arcana-pipeline-internals-quote">"<%= rq %>"</dd>
-                  <% end %>
+                    <%= case Map.get(@ask_context, :skip_retrieval) do %>
+                      <% nil -> %>
+                      <% skip -> %>
+                        <dt>Gate decision</dt>
+                        <dd>
+                          <span class={"arcana-pipeline-internals-badge #{if skip, do: "skip", else: "retrieve"}"}>
+                            <%= if skip, do: "skip retrieval", else: "retrieve" %>
+                          </span>
+                          <%= if reasoning = Map.get(@ask_context, :gate_reasoning) do %>
+                            <span class="arcana-pipeline-internals-reasoning"><%= reasoning %></span>
+                          <% end %>
+                        </dd>
+                    <% end %>
 
-                  <%= case Map.get(@ask_context, :skip_retrieval) do %>
-                    <% nil -> %>
-                    <% skip -> %>
-                      <dt>Gate decision</dt>
+                    <%= if eq = Map.get(@ask_context, :expanded_query) do %>
+                      <dt>Expanded query</dt>
+                      <dd class="arcana-pipeline-internals-quote">"<%= eq %>"</dd>
+                    <% end %>
+
+                    <% sub_qs = Map.get(@ask_context, :sub_questions) %>
+                    <%= if sub_qs && length(sub_qs) > 0 do %>
+                      <dt>Sub-questions (<%= length(sub_qs) %>)</dt>
                       <dd>
-                        <span class={"arcana-pipeline-internals-badge #{if skip, do: "skip", else: "retrieve"}"}>
-                          <%= if skip, do: "skip retrieval", else: "retrieve" %>
-                        </span>
-                        <%= if reasoning = Map.get(@ask_context, :gate_reasoning) do %>
-                          <span class="arcana-pipeline-internals-reasoning"><%= reasoning %></span>
-                        <% end %>
-                      </dd>
-                  <% end %>
-
-                  <%= if eq = Map.get(@ask_context, :expanded_query) do %>
-                    <dt>Expanded query</dt>
-                    <dd class="arcana-pipeline-internals-quote">"<%= eq %>"</dd>
-                  <% end %>
-
-                  <% sub_qs = Map.get(@ask_context, :sub_questions) %>
-                  <%= if sub_qs && length(sub_qs) > 0 do %>
-                    <dt>Sub-questions (<%= length(sub_qs) %>)</dt>
-                    <dd>
-                      <ul class="arcana-query-list">
-                        <%= for sq <- sub_qs do %>
-                          <li><%= sq %></li>
-                        <% end %>
-                      </ul>
-                    </dd>
-                  <% end %>
-
-                  <%= case Map.get(@ask_context, :reason_iterations) do %>
-                    <% nil -> %>
-                    <% 0 -> %>
-                      <dt>Multi-hop reasoning</dt>
-                      <dd>
-                        <span class="arcana-pipeline-internals-badge neutral">chunks sufficient, no follow-up</span>
-                      </dd>
-                    <% n -> %>
-                      <dt>Multi-hop reasoning (<%= n %> follow-ups)</dt>
-                      <dd>
-                        <% tried = Map.get(@ask_context, :queries_tried) || MapSet.new() %>
                         <ul class="arcana-query-list">
-                          <%= for q <- MapSet.to_list(tried) do %>
-                            <li>"<%= q %>"</li>
+                          <%= for sq <- sub_qs do %>
+                            <li><%= sq %></li>
                           <% end %>
                         </ul>
                       </dd>
-                  <% end %>
+                    <% end %>
 
-                  <% graph_count = Map.get(@ask_context, :graph_sourced_count) || 0 %>
-                  <% retrieved = Map.get(@ask_context, :retrieved_count) || 0 %>
-                  <%= if graph_count > 0 do %>
-                    <dt>Graph-assisted retrieval</dt>
-                    <dd>
-                      <span class="arcana-pipeline-internals-badge neutral">
-                        <%= graph_count %>/<%= retrieved %> chunks found via entity relationships
-                      </span>
-                    </dd>
-                  <% end %>
+                    <%= case Map.get(@ask_context, :reason_iterations) do %>
+                      <% nil -> %>
+                      <% 0 -> %>
+                        <dt>Multi-hop reasoning</dt>
+                        <dd>
+                          <span class="arcana-pipeline-internals-badge neutral">chunks sufficient, no follow-up</span>
+                        </dd>
+                      <% n -> %>
+                        <dt>Multi-hop reasoning (<%= n %> follow-ups)</dt>
+                        <dd>
+                          <% tried = Map.get(@ask_context, :queries_tried) || MapSet.new() %>
+                          <ul class="arcana-query-list">
+                            <%= for q <- MapSet.to_list(tried) do %>
+                              <li>"<%= q %>"</li>
+                            <% end %>
+                          </ul>
+                        </dd>
+                    <% end %>
 
-                  <% rerank_kept = Map.get(@ask_context, :rerank_kept) || 0 %>
-                  <%= if rerank_kept > 0 do %>
-                    <dt>Reranking</dt>
-                    <dd>
-                      <% scores = Map.get(@ask_context, :rerank_scores) || %{} %>
-                      <% sorted = scores |> Map.values() |> Enum.sort(:desc) %>
-                      <% top = List.first(sorted) %>
-                      <% bottom = List.last(sorted) %>
-                      <span class="arcana-pipeline-internals-badge neutral">
-                        <%= rerank_kept %> chunks reordered
-                        <%= if top && bottom && rerank_kept > 1 do %>
-                          (top score <%= :erlang.float_to_binary(top * 1.0, decimals: 2) %>, bottom <%= :erlang.float_to_binary(bottom * 1.0, decimals: 2) %>)
-                        <% end %>
-                      </span>
-                    </dd>
-                  <% end %>
-
-                  <%= case Map.get(@ask_context, :correction_count) do %>
-                    <% nil -> %>
-                    <% 0 -> %>
-                    <% n -> %>
-                      <dt>Self-correction (<%= n %> <%= if n == 1, do: "retry", else: "retries" %>)</dt>
+                    <% graph_count = Map.get(@ask_context, :graph_sourced_count) || 0 %>
+                    <% retrieved = Map.get(@ask_context, :retrieved_count) || 0 %>
+                    <%= if graph_count > 0 do %>
+                      <dt>Graph-assisted retrieval</dt>
                       <dd>
-                        <% corrs = Map.get(@ask_context, :corrections) || [] %>
-                        <%= for {_prev, feedback} <- corrs do %>
-                          <div class="arcana-pipeline-internals-feedback"><%= feedback %></div>
-                        <% end %>
+                        <span class="arcana-pipeline-internals-badge neutral">
+                          <%= graph_count %>/<%= retrieved %> chunks found via entity relationships
+                        </span>
                       </dd>
-                  <% end %>
-                </dl>
-              </div>
-            <% end %>
+                    <% end %>
 
-            <% sel_cols = Map.get(@ask_context, :selected_collections) %>
-            <%= if sel_cols && length(sel_cols) > 0 do %>
-              <div class="arcana-ask-section">
-                <h4>Selected Collections</h4>
-                <div class="arcana-collection-badges">
-                  <%= for coll <- sel_cols do %>
-                    <span class="arcana-collection-badge"><%= coll %></span>
-                  <% end %>
+                    <% rerank_kept = Map.get(@ask_context, :rerank_kept) || 0 %>
+                    <%= if rerank_kept > 0 do %>
+                      <dt>Reranking</dt>
+                      <dd>
+                        <% scores = Map.get(@ask_context, :rerank_scores) || %{} %>
+                        <% sorted = scores |> Map.values() |> Enum.sort(:desc) %>
+                        <% top = List.first(sorted) %>
+                        <% bottom = List.last(sorted) %>
+                        <span class="arcana-pipeline-internals-badge neutral">
+                          <%= rerank_kept %> chunks reordered
+                          <%= if top && bottom && rerank_kept > 1 do %>
+                            (top score <%= :erlang.float_to_binary(top * 1.0, decimals: 2) %>, bottom <%= :erlang.float_to_binary(bottom * 1.0, decimals: 2) %>)
+                          <% end %>
+                        </span>
+                      </dd>
+                    <% end %>
+
+                    <%= case Map.get(@ask_context, :correction_count) do %>
+                      <% nil -> %>
+                      <% 0 -> %>
+                      <% n -> %>
+                        <dt>Self-correction (<%= n %> <%= if n == 1, do: "retry", else: "retries" %>)</dt>
+                        <dd>
+                          <% corrs = Map.get(@ask_context, :corrections) || [] %>
+                          <%= for {_prev, feedback} <- corrs do %>
+                            <div class="arcana-pipeline-internals-feedback"><%= feedback %></div>
+                          <% end %>
+                        </dd>
+                    <% end %>
+                  </dl>
                 </div>
-              </div>
-            <% end %>
+              <% end %>
 
-            <%= if Map.get(@ask_context, :graph_enhanced) do %>
-              <.graph_context_section
-                prefix={@prefix}
-                matched_entities={Map.get(@ask_context, :matched_entities, [])}
-                matched_relationships={Map.get(@ask_context, :matched_relationships, [])}
-                expanded={@graph_context_expanded}
-              />
-            <% end %>
+              <% sel_cols = Map.get(@ask_context, :selected_collections) %>
+              <%= if sel_cols && length(sel_cols) > 0 do %>
+                <div class="arcana-ask-section">
+                  <h4>Selected Collections</h4>
+                  <div class="arcana-collection-badges">
+                    <%= for coll <- sel_cols do %>
+                      <span class="arcana-collection-badge"><%= coll %></span>
+                    <% end %>
+                  </div>
+                </div>
+              <% end %>
 
-            <% all_results = Map.get(@ask_context, :results) %>
-            <%= if all_results && length(all_results) > 0 do %>
-              <div class="arcana-ask-section">
-                <h4>Retrieved Chunks (<%= length(all_results) %>)</h4>
-                <ChunkResultsComponent.chunk_results
+              <%= if Map.get(@ask_context, :graph_enhanced) do %>
+                <.graph_context_section
                   prefix={@prefix}
-                  chunks={all_results}
-                  document_titles={Map.get(@ask_context, :document_titles, %{})}
-                  grounding={Map.get(@ask_context, :grounding)}
-                  id="ask-chunk-results"
+                  matched_entities={Map.get(@ask_context, :matched_entities, [])}
+                  matched_relationships={Map.get(@ask_context, :matched_relationships, [])}
+                  expanded={@graph_context_expanded}
                 />
-              </div>
+              <% end %>
+
+              <% all_results = Map.get(@ask_context, :results) %>
+              <%= if all_results && length(all_results) > 0 do %>
+                <div class="arcana-ask-section">
+                  <h4>Retrieved Chunks (<%= length(all_results) %>)</h4>
+                  <ChunkResultsComponent.chunk_results
+                    prefix={@prefix}
+                    chunks={all_results}
+                    document_titles={Map.get(@ask_context, :document_titles, %{})}
+                    grounding={Map.get(@ask_context, :grounding)}
+                    id="ask-chunk-results"
+                  />
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </.dashboard_layout>
+      """
+    end
+
+    defp graph_context_section(assigns) do
+      ~H"""
+      <div class="arcana-graph-context">
+        <div class="arcana-graph-context-header">
+          <h4>Graph Context</h4>
+          <button type="button" phx-click="toggle_graph_context" class="arcana-toggle-btn">
+            <%= if @expanded, do: "▼", else: "▶" %>
+          </button>
+        </div>
+
+        <%= if @expanded do %>
+          <div class="arcana-graph-context-content">
+            <%= if length(@matched_entities) == 0 and length(@matched_relationships) == 0 do %>
+              <p class="arcana-no-matches">No entity matches — used vector search only</p>
+            <% else %>
+              <%= if length(@matched_entities) > 0 do %>
+                <div class="arcana-matched-entities">
+                  <h5>Matched Entities</h5>
+                  <ul>
+                    <%= for entity <- @matched_entities do %>
+                      <li>
+                        <span class="arcana-entity-name"><%= entity.name %></span>
+                        <span class="arcana-entity-type"><%= entity.type %></span>
+                        <%= if Map.get(entity, :id) do %>
+                          <a href={"#{@prefix}/graph?entity=#{entity.id}"} class="arcana-view-in-graph">
+                            View in Graph
+                          </a>
+                        <% end %>
+                      </li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
+
+              <%= if length(@matched_relationships) > 0 do %>
+                <div class="arcana-matched-relationships">
+                  <h5>Key Relationships</h5>
+                  <ul>
+                    <%= for rel <- @matched_relationships do %>
+                      <li>
+                        <span class="arcana-rel-source"><%= rel.source %></span>
+                        <span class="arcana-rel-type">—<%= rel.type %>→</span>
+                        <span class="arcana-rel-target"><%= rel.target %></span>
+                      </li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
             <% end %>
           </div>
         <% end %>
       </div>
-    </.dashboard_layout>
-    """
-  end
+      """
+    end
 
-  defp graph_context_section(assigns) do
-    ~H"""
-    <div class="arcana-graph-context">
-      <div class="arcana-graph-context-header">
-        <h4>Graph Context</h4>
-        <button type="button" phx-click="toggle_graph_context" class="arcana-toggle-btn">
-          <%= if @expanded, do: "▼", else: "▶" %>
-        </button>
-      </div>
-
-      <%= if @expanded do %>
-        <div class="arcana-graph-context-content">
-          <%= if length(@matched_entities) == 0 and length(@matched_relationships) == 0 do %>
-            <p class="arcana-no-matches">No entity matches — used vector search only</p>
-          <% else %>
-            <%= if length(@matched_entities) > 0 do %>
-              <div class="arcana-matched-entities">
-                <h5>Matched Entities</h5>
-                <ul>
-                  <%= for entity <- @matched_entities do %>
-                    <li>
-                      <span class="arcana-entity-name"><%= entity.name %></span>
-                      <span class="arcana-entity-type"><%= entity.type %></span>
-                      <%= if Map.get(entity, :id) do %>
-                        <a href={"#{@prefix}/graph?entity=#{entity.id}"} class="arcana-view-in-graph">
-                          View in Graph
-                        </a>
-                      <% end %>
-                    </li>
-                  <% end %>
-                </ul>
-              </div>
-            <% end %>
-
-            <%= if length(@matched_relationships) > 0 do %>
-              <div class="arcana-matched-relationships">
-                <h5>Key Relationships</h5>
-                <ul>
-                  <%= for rel <- @matched_relationships do %>
-                    <li>
-                      <span class="arcana-rel-source"><%= rel.source %></span>
-                      <span class="arcana-rel-type">—<%= rel.type %>→</span>
-                      <span class="arcana-rel-target"><%= rel.target %></span>
-                    </li>
-                  <% end %>
-                </ul>
-              </div>
-            <% end %>
+    defp source_previews(assigns) do
+      ~H"""
+      <%= if @sources != [] do %>
+        <div class="arcana-span-sources">
+          <%= for source <- @sources do %>
+            <% chunk = find_chunk(@chunks, source.chunk_id) %>
+            <details class="arcana-source-detail">
+              <summary class="arcana-source-badge clickable">
+                <span class="arcana-source-label">
+                  <%= chunk_label(chunk) %>
+                </span>
+                <span class="arcana-source-overlap"><%= Float.round(source.score * 100) %>% overlap</span>
+              </summary>
+              <%= if chunk do %>
+                <div class="arcana-source-preview"><%= chunk.text %></div>
+              <% end %>
+            </details>
           <% end %>
         </div>
       <% end %>
-    </div>
-    """
+      """
+    end
+
+    defp find_chunk(chunks, chunk_id) do
+      Enum.find(chunks, fn chunk ->
+        id = if is_struct(chunk), do: chunk.id, else: Map.get(chunk, :id)
+        to_string(id) == to_string(chunk_id)
+      end)
+    end
+
+    defp chunk_label(nil), do: "unknown chunk"
+
+    defp chunk_label(chunk) do
+      index = Map.get(chunk, :chunk_index, nil)
+      if index, do: "Chunk #{index}", else: "Source"
+    end
+
+    defp render_highlighted_answer(answer, grounding) do
+      hallucinated = Map.get(grounding, :hallucinated_spans, [])
+      faithful = Map.get(grounding, :faithful_spans, [])
+
+      spans =
+        (Enum.map(hallucinated, &Map.put(&1, :type, :hallucinated)) ++
+           Enum.map(faithful, &Map.put(&1, :type, :faithful)))
+        |> Enum.sort_by(& &1.start)
+
+      build_highlighted_parts(answer, spans, 0, [])
+      |> Enum.reverse()
+      |> Phoenix.HTML.raw()
+    end
+
+    defp build_highlighted_parts(answer, [], pos, acc) do
+      rest = binary_slice(answer, pos, byte_size(answer) - pos)
+      if rest == "", do: acc, else: [html_escape(rest) | acc]
+    end
+
+    defp build_highlighted_parts(answer, [span | rest], pos, acc) do
+      span_start = span.start
+      span_end = Map.get(span, :end, span_start)
+
+      # Text before this span
+      acc =
+        if span_start > pos do
+          gap = binary_slice(answer, pos, span_start - pos)
+          [html_escape(gap) | acc]
+        else
+          acc
+        end
+
+      # The span itself
+      span_text = binary_slice(answer, span_start, span_end - span_start)
+
+      class =
+        if span.type == :hallucinated, do: "arcana-hl-hallucinated", else: "arcana-hl-faithful"
+
+      acc = [
+        ~s(<mark class="#{class}" title="#{span.type}">#{html_escape(span_text)}</mark>) | acc
+      ]
+
+      build_highlighted_parts(answer, rest, span_end, acc)
+    end
+
+    defp html_escape(text) do
+      text
+      |> Phoenix.HTML.html_escape()
+      |> Phoenix.HTML.safe_to_string()
+    end
+
+    # tool_history entries go through Loop.atomize_keys/1 before they're
+    # recorded, so args always have atom keys by the time they reach here.
+    # The fallback clause handles custom tools with unknown arg shapes.
+    defp loop_arg_summary(:search, %{query: q}) when is_binary(q), do: ~s("#{q}")
+    defp loop_arg_summary(:answer, %{text: t}) when is_binary(t), do: truncate_arg(t)
+    defp loop_arg_summary(:synthesis, %{text: t}) when is_binary(t), do: truncate_arg(t)
+    defp loop_arg_summary(:give_up, %{reason: r}) when is_binary(r), do: truncate_arg(r)
+    defp loop_arg_summary(_, _), do: ""
+
+    defp truncate_arg(s) when byte_size(s) <= 80, do: ~s("#{s}")
+
+    defp truncate_arg(s) do
+      head = binary_part(s, 0, 77)
+      ~s("#{head}...")
+    end
+
+    defp pipeline_step_label(:gate), do: "Deciding if retrieval is needed..."
+    defp pipeline_step_label(:rewrite), do: "Rewriting query..."
+    defp pipeline_step_label(:expand), do: "Expanding query..."
+    defp pipeline_step_label(:decompose), do: "Decomposing question..."
+    defp pipeline_step_label(:select), do: "Selecting collections..."
+    defp pipeline_step_label(:search), do: "Searching..."
+    defp pipeline_step_label(:reason), do: "Multi-hop reasoning..."
+    defp pipeline_step_label(:self_correct), do: "Refining search..."
+    defp pipeline_step_label(:rerank), do: "Reranking results..."
+    defp pipeline_step_label(:answer), do: "Generating answer..."
+    defp pipeline_step_label(:ground), do: "Checking for hallucinations..."
+    defp pipeline_step_label(_), do: nil
+
+    # True when at least one pipeline step wrote an inspectable output to
+    # the ask_context. Keeps the "Pipeline internals" section from showing
+    # an empty shell on Advanced runs that don't touch these fields.
+    defp pipeline_internals?(%{} = ctx) do
+      not is_nil(Map.get(ctx, :rewritten_query)) or
+        not is_nil(Map.get(ctx, :expanded_query)) or
+        not is_nil(Map.get(ctx, :skip_retrieval)) or
+        not is_nil(Map.get(ctx, :reason_iterations)) or
+        (Map.get(ctx, :correction_count) || 0) > 0 or
+        (Map.get(ctx, :rerank_kept) || 0) > 0 or
+        (Map.get(ctx, :graph_sourced_count) || 0) > 0 or
+        match?([_ | _], Map.get(ctx, :sub_questions))
+    end
+
+    defp pipeline_internals?(_), do: false
+
+    # Short labels for the trace tool badge. Covers both Pipeline step
+    # names and the top-level events that fire during an Advanced run
+    # (Arcana.search/2 → graph search → LLM answer generation).
+    defp pipeline_step_short(:gate), do: "gate"
+    defp pipeline_step_short(:rewrite), do: "rewrite"
+    defp pipeline_step_short(:expand), do: "expand"
+    defp pipeline_step_short(:decompose), do: "decompose"
+    defp pipeline_step_short(:select), do: "select"
+    defp pipeline_step_short(:search), do: "search"
+    defp pipeline_step_short(:reason), do: "reason"
+    defp pipeline_step_short(:self_correct), do: "self_correct"
+    defp pipeline_step_short(:rerank), do: "rerank"
+    defp pipeline_step_short(:answer), do: "answer"
+    defp pipeline_step_short(:ground), do: "ground"
+    defp pipeline_step_short(:graph_search), do: "graph_search"
+    defp pipeline_step_short(:llm_complete), do: "llm"
+    defp pipeline_step_short(other), do: to_string(other)
+
+    # Picks the most useful one-liner from a pipeline step's :stop
+    # telemetry metadata. Each step emits different keys, so we look
+    # for the ones the pipeline actually populates and fall back to "".
+    defp pipeline_step_meta_summary(_step, nil), do: ""
+
+    defp pipeline_step_meta_summary(:rewrite, %{rewritten_query: q}) when is_binary(q),
+      do: ~s("#{q}")
+
+    defp pipeline_step_meta_summary(:expand, %{expanded_query: q}) when is_binary(q),
+      do: ~s("#{q}")
+
+    defp pipeline_step_meta_summary(:decompose, %{sub_questions: subs}) when is_list(subs),
+      do: "#{length(subs)} sub-questions"
+
+    defp pipeline_step_meta_summary(:select, %{collections: colls}) when is_list(colls),
+      do: Enum.join(colls, ", ")
+
+    defp pipeline_step_meta_summary(:search, %{result_count: n}), do: "#{n} chunks"
+
+    defp pipeline_step_meta_summary(:search, %{results: r}) when is_list(r),
+      do: "#{length(r)} chunks"
+
+    defp pipeline_step_meta_summary(:rerank, %{result_count: n}), do: "#{n} kept"
+    defp pipeline_step_meta_summary(:gate, %{skip_retrieval: true}), do: "skip retrieval"
+    defp pipeline_step_meta_summary(:gate, %{skip_retrieval: false}), do: "retrieve"
+
+    defp pipeline_step_meta_summary(:graph_search, %{entity_count: n, result_count: r}),
+      do: "#{n} entities → #{r} chunks"
+
+    defp pipeline_step_meta_summary(:graph_search, %{entity_count: n}),
+      do: "#{n} entities"
+
+    defp pipeline_step_meta_summary(:llm_complete, %{model: model}) when is_binary(model),
+      do: model
+
+    defp pipeline_step_meta_summary(:llm_complete, _), do: ""
+    defp pipeline_step_meta_summary(_step, _meta), do: ""
+
+    defp format_duration(ms) when ms < 1000, do: "#{ms}ms"
+    defp format_duration(ms), do: "#{Float.round(ms / 1000, 1)}s"
   end
-
-  defp source_previews(assigns) do
-    ~H"""
-    <%= if @sources != [] do %>
-      <div class="arcana-span-sources">
-        <%= for source <- @sources do %>
-          <% chunk = find_chunk(@chunks, source.chunk_id) %>
-          <details class="arcana-source-detail">
-            <summary class="arcana-source-badge clickable">
-              <span class="arcana-source-label">
-                <%= chunk_label(chunk) %>
-              </span>
-              <span class="arcana-source-overlap"><%= Float.round(source.score * 100) %>% overlap</span>
-            </summary>
-            <%= if chunk do %>
-              <div class="arcana-source-preview"><%= chunk.text %></div>
-            <% end %>
-          </details>
-        <% end %>
-      </div>
-    <% end %>
-    """
-  end
-
-  defp find_chunk(chunks, chunk_id) do
-    Enum.find(chunks, fn chunk ->
-      id = if is_struct(chunk), do: chunk.id, else: Map.get(chunk, :id)
-      to_string(id) == to_string(chunk_id)
-    end)
-  end
-
-  defp chunk_label(nil), do: "unknown chunk"
-
-  defp chunk_label(chunk) do
-    index = Map.get(chunk, :chunk_index, nil)
-    if index, do: "Chunk #{index}", else: "Source"
-  end
-
-  defp render_highlighted_answer(answer, grounding) do
-    hallucinated = Map.get(grounding, :hallucinated_spans, [])
-    faithful = Map.get(grounding, :faithful_spans, [])
-
-    spans =
-      (Enum.map(hallucinated, &Map.put(&1, :type, :hallucinated)) ++
-         Enum.map(faithful, &Map.put(&1, :type, :faithful)))
-      |> Enum.sort_by(& &1.start)
-
-    build_highlighted_parts(answer, spans, 0, [])
-    |> Enum.reverse()
-    |> Phoenix.HTML.raw()
-  end
-
-  defp build_highlighted_parts(answer, [], pos, acc) do
-    rest = binary_slice(answer, pos, byte_size(answer) - pos)
-    if rest == "", do: acc, else: [html_escape(rest) | acc]
-  end
-
-  defp build_highlighted_parts(answer, [span | rest], pos, acc) do
-    span_start = span.start
-    span_end = Map.get(span, :end, span_start)
-
-    # Text before this span
-    acc =
-      if span_start > pos do
-        gap = binary_slice(answer, pos, span_start - pos)
-        [html_escape(gap) | acc]
-      else
-        acc
-      end
-
-    # The span itself
-    span_text = binary_slice(answer, span_start, span_end - span_start)
-
-    class =
-      if span.type == :hallucinated, do: "arcana-hl-hallucinated", else: "arcana-hl-faithful"
-
-    acc = [
-      ~s(<mark class="#{class}" title="#{span.type}">#{html_escape(span_text)}</mark>) | acc
-    ]
-
-    build_highlighted_parts(answer, rest, span_end, acc)
-  end
-
-  defp html_escape(text) do
-    text
-    |> Phoenix.HTML.html_escape()
-    |> Phoenix.HTML.safe_to_string()
-  end
-
-  # tool_history entries go through Loop.atomize_keys/1 before they're
-  # recorded, so args always have atom keys by the time they reach here.
-  # The fallback clause handles custom tools with unknown arg shapes.
-  defp loop_arg_summary(:search, %{query: q}) when is_binary(q), do: ~s("#{q}")
-  defp loop_arg_summary(:answer, %{text: t}) when is_binary(t), do: truncate_arg(t)
-  defp loop_arg_summary(:synthesis, %{text: t}) when is_binary(t), do: truncate_arg(t)
-  defp loop_arg_summary(:give_up, %{reason: r}) when is_binary(r), do: truncate_arg(r)
-  defp loop_arg_summary(_, _), do: ""
-
-  defp truncate_arg(s) when byte_size(s) <= 80, do: ~s("#{s}")
-
-  defp truncate_arg(s) do
-    head = binary_part(s, 0, 77)
-    ~s("#{head}...")
-  end
-
-  defp pipeline_step_label(:gate), do: "Deciding if retrieval is needed..."
-  defp pipeline_step_label(:rewrite), do: "Rewriting query..."
-  defp pipeline_step_label(:expand), do: "Expanding query..."
-  defp pipeline_step_label(:decompose), do: "Decomposing question..."
-  defp pipeline_step_label(:select), do: "Selecting collections..."
-  defp pipeline_step_label(:search), do: "Searching..."
-  defp pipeline_step_label(:reason), do: "Multi-hop reasoning..."
-  defp pipeline_step_label(:self_correct), do: "Refining search..."
-  defp pipeline_step_label(:rerank), do: "Reranking results..."
-  defp pipeline_step_label(:answer), do: "Generating answer..."
-  defp pipeline_step_label(:ground), do: "Checking for hallucinations..."
-  defp pipeline_step_label(_), do: nil
-
-  # True when at least one pipeline step wrote an inspectable output to
-  # the ask_context. Keeps the "Pipeline internals" section from showing
-  # an empty shell on Advanced runs that don't touch these fields.
-  defp pipeline_internals?(%{} = ctx) do
-    not is_nil(Map.get(ctx, :rewritten_query)) or
-      not is_nil(Map.get(ctx, :expanded_query)) or
-      not is_nil(Map.get(ctx, :skip_retrieval)) or
-      not is_nil(Map.get(ctx, :reason_iterations)) or
-      (Map.get(ctx, :correction_count) || 0) > 0 or
-      (Map.get(ctx, :rerank_kept) || 0) > 0 or
-      (Map.get(ctx, :graph_sourced_count) || 0) > 0 or
-      match?([_ | _], Map.get(ctx, :sub_questions))
-  end
-
-  defp pipeline_internals?(_), do: false
-
-  # Short labels for the trace tool badge. Covers both Pipeline step
-  # names and the top-level events that fire during an Advanced run
-  # (Arcana.search/2 → graph search → LLM answer generation).
-  defp pipeline_step_short(:gate), do: "gate"
-  defp pipeline_step_short(:rewrite), do: "rewrite"
-  defp pipeline_step_short(:expand), do: "expand"
-  defp pipeline_step_short(:decompose), do: "decompose"
-  defp pipeline_step_short(:select), do: "select"
-  defp pipeline_step_short(:search), do: "search"
-  defp pipeline_step_short(:reason), do: "reason"
-  defp pipeline_step_short(:self_correct), do: "self_correct"
-  defp pipeline_step_short(:rerank), do: "rerank"
-  defp pipeline_step_short(:answer), do: "answer"
-  defp pipeline_step_short(:ground), do: "ground"
-  defp pipeline_step_short(:graph_search), do: "graph_search"
-  defp pipeline_step_short(:llm_complete), do: "llm"
-  defp pipeline_step_short(other), do: to_string(other)
-
-  # Picks the most useful one-liner from a pipeline step's :stop
-  # telemetry metadata. Each step emits different keys, so we look
-  # for the ones the pipeline actually populates and fall back to "".
-  defp pipeline_step_meta_summary(_step, nil), do: ""
-
-  defp pipeline_step_meta_summary(:rewrite, %{rewritten_query: q}) when is_binary(q),
-    do: ~s("#{q}")
-
-  defp pipeline_step_meta_summary(:expand, %{expanded_query: q}) when is_binary(q),
-    do: ~s("#{q}")
-
-  defp pipeline_step_meta_summary(:decompose, %{sub_questions: subs}) when is_list(subs),
-    do: "#{length(subs)} sub-questions"
-
-  defp pipeline_step_meta_summary(:select, %{collections: colls}) when is_list(colls),
-    do: Enum.join(colls, ", ")
-
-  defp pipeline_step_meta_summary(:search, %{result_count: n}), do: "#{n} chunks"
-
-  defp pipeline_step_meta_summary(:search, %{results: r}) when is_list(r),
-    do: "#{length(r)} chunks"
-
-  defp pipeline_step_meta_summary(:rerank, %{result_count: n}), do: "#{n} kept"
-  defp pipeline_step_meta_summary(:gate, %{skip_retrieval: true}), do: "skip retrieval"
-  defp pipeline_step_meta_summary(:gate, %{skip_retrieval: false}), do: "retrieve"
-
-  defp pipeline_step_meta_summary(:graph_search, %{entity_count: n, result_count: r}),
-    do: "#{n} entities → #{r} chunks"
-
-  defp pipeline_step_meta_summary(:graph_search, %{entity_count: n}),
-    do: "#{n} entities"
-
-  defp pipeline_step_meta_summary(:llm_complete, %{model: model}) when is_binary(model),
-    do: model
-
-  defp pipeline_step_meta_summary(:llm_complete, _), do: ""
-  defp pipeline_step_meta_summary(_step, _meta), do: ""
-
-  defp format_duration(ms) when ms < 1000, do: "#{ms}ms"
-  defp format_duration(ms), do: "#{Float.round(ms / 1000, 1)}s"
 end

--- a/lib/arcana_web/live/chunk_results_component.ex
+++ b/lib/arcana_web/live/chunk_results_component.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.ChunkResultsComponent do

--- a/lib/arcana_web/live/chunk_results_component.ex
+++ b/lib/arcana_web/live/chunk_results_component.ex
@@ -1,218 +1,223 @@
-defmodule ArcanaWeb.ChunkResultsComponent do
-  @moduledoc """
-  Shared component for rendering retrieved chunks across the Advanced,
-  Pipeline, and Loop sub-tabs of the Ask dashboard.
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  ## Features
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.ChunkResultsComponent do
+    @moduledoc """
+    Shared component for rendering retrieved chunks across the Advanced,
+    Pipeline, and Loop sub-tabs of the Ask dashboard.
 
-  - Groups chunks by document with a compact header per document.
-  - Shows document titles when available (falls back to a shortened UUID).
-  - Click-to-expand details for each chunk, revealing the full text.
-  - When `:grounding` is supplied, centers the snippet around the text the
-    grounder cited from this chunk (instead of the first N chars).
-  - Highlights chunks that the grounder used as a source.
-  - Score rendered as `score: 0.0246`.
+    ## Features
 
-  ## Usage
+    - Groups chunks by document with a compact header per document.
+    - Shows document titles when available (falls back to a shortened UUID).
+    - Click-to-expand details for each chunk, revealing the full text.
+    - When `:grounding` is supplied, centers the snippet around the text the
+      grounder cited from this chunk (instead of the first N chars).
+    - Highlights chunks that the grounder used as a source.
+    - Score rendered as `score: 0.0246`.
 
-      <ChunkResultsComponent.chunk_results
-        prefix={@prefix}
-        chunks={@ask_context.results}
-        document_titles={@ask_context.document_titles || %{}}
-        grounding={Map.get(@ask_context, :grounding)}
-        id="ask-chunks"
-      />
-  """
-  use Phoenix.Component
+    ## Usage
 
-  attr(:prefix, :string,
-    required: true,
-    doc: "Dashboard mount prefix used to build document links"
-  )
-
-  attr(:chunks, :list,
-    required: true,
-    doc: "List of chunk maps with id/text/score/document_id/chunk_index"
-  )
-
-  attr(:document_titles, :map, default: %{}, doc: "Map of document_id to display title")
-  attr(:grounding, :any, default: nil, doc: "Optional %Arcana.Grounding.Result{}")
-  attr(:id, :string, default: "chunk-results")
-
-  def chunk_results(assigns) do
-    assigns =
-      assigns
-      |> assign(:grouped, group_by_document(assigns.chunks))
-      |> assign(:chunk_sources, build_chunk_source_index(assigns.grounding))
-
-    ~H"""
-    <div class="arcana-chunk-results" id={@id}>
-      <%= for {doc_id, doc_chunks} <- @grouped do %>
-        <section class={["arcana-chunk-doc", any_source?(doc_chunks, @chunk_sources) && "arcana-chunk-doc--has-source"]}>
-          <header class="arcana-chunk-doc-header">
-            <h5 class="arcana-chunk-doc-title">
-              <%= if doc_id do %>
-                <.link navigate={"#{@prefix}/documents?doc=#{doc_id}"} title={"Document " <> doc_id} class="arcana-chunk-doc-link"><%= document_label(doc_id, @document_titles) %></.link>
-              <% else %>
-                <span title="(unknown document)"><%= document_label(doc_id, @document_titles) %></span>
-              <% end %>
-            </h5>
-            <span class="arcana-chunk-doc-meta">
-              <%= length(doc_chunks) %> <%= chunk_word(length(doc_chunks)) %>
-              <%= if any_source?(doc_chunks, @chunk_sources) do %>
-                <span class="arcana-chunk-source-dot" title="Cited as grounding source"></span>
-              <% end %>
-            </span>
-          </header>
-          <ul class="arcana-chunk-list">
-            <%= for chunk <- doc_chunks do %>
-              <li class={["arcana-chunk-item", Map.has_key?(@chunk_sources, Map.get(chunk, :id)) && "arcana-chunk-item--source"]}>
-                <details class="arcana-chunk-details">
-                  <summary class="arcana-chunk-summary" title={chunk_tooltip(chunk)}>
-                    <span class="arcana-chunk-score">score: <%= score_str(chunk.score) %></span>
-                    <span class="arcana-chunk-index">Chunk <%= chunk.chunk_index %></span>
-                    <%= if graph_sources = Map.get(chunk, :graph_sources) do %>
-                      <%= if is_list(graph_sources) and graph_sources != [] do %>
-                        <span class="arcana-chunk-via" title={"via: " <> Enum.join(graph_sources, ", ")}>via: <%= Enum.join(graph_sources, ", ") %></span>
-                      <% end %>
-                    <% end %>
-                    <%= if Map.has_key?(@chunk_sources, Map.get(chunk, :id)) do %>
-                      <span class="arcana-chunk-supports">✓ source</span>
-                    <% end %>
-                    <span class="arcana-chunk-preview"><%= snippet(chunk, @chunk_sources) %></span>
-                  </summary>
-                  <div class="arcana-chunk-full"><%= String.trim(chunk.text || "") %></div>
-                </details>
-              </li>
-            <% end %>
-          </ul>
-        </section>
-      <% end %>
-    </div>
+        <ChunkResultsComponent.chunk_results
+          prefix={@prefix}
+          chunks={@ask_context.results}
+          document_titles={@ask_context.document_titles || %{}}
+          grounding={Map.get(@ask_context, :grounding)}
+          id="ask-chunks"
+        />
     """
-  end
+    use Phoenix.Component
 
-  # --- Grouping ---
+    attr(:prefix, :string,
+      required: true,
+      doc: "Dashboard mount prefix used to build document links"
+    )
 
-  # Sort docs by their highest-scoring chunk descending so the most
-  # relevant document is rendered first.
-  defp group_by_document(chunks) do
-    chunks
-    |> Enum.group_by(&Map.get(&1, :document_id))
-    |> Enum.map(fn {doc_id, cs} -> {doc_id, Enum.sort_by(cs, & &1.score, :desc)} end)
-    |> Enum.sort_by(fn {_doc_id, cs} ->
-      -(cs |> Enum.map(& &1.score) |> Enum.max(fn -> 0 end))
-    end)
-  end
+    attr(:chunks, :list,
+      required: true,
+      doc: "List of chunk maps with id/text/score/document_id/chunk_index"
+    )
 
-  # --- Document label resolution ---
+    attr(:document_titles, :map, default: %{}, doc: "Map of document_id to display title")
+    attr(:grounding, :any, default: nil, doc: "Optional %Arcana.Grounding.Result{}")
+    attr(:id, :string, default: "chunk-results")
 
-  defp document_label(nil, _titles), do: "(unknown document)"
+    def chunk_results(assigns) do
+      assigns =
+        assigns
+        |> assign(:grouped, group_by_document(assigns.chunks))
+        |> assign(:chunk_sources, build_chunk_source_index(assigns.grounding))
 
-  defp document_label(doc_id, titles) do
-    case Map.get(titles, doc_id) do
-      title when is_binary(title) and title != "" -> title
-      _ -> shorten_uuid(doc_id)
+      ~H"""
+      <div class="arcana-chunk-results" id={@id}>
+        <%= for {doc_id, doc_chunks} <- @grouped do %>
+          <section class={["arcana-chunk-doc", any_source?(doc_chunks, @chunk_sources) && "arcana-chunk-doc--has-source"]}>
+            <header class="arcana-chunk-doc-header">
+              <h5 class="arcana-chunk-doc-title">
+                <%= if doc_id do %>
+                  <.link navigate={"#{@prefix}/documents?doc=#{doc_id}"} title={"Document " <> doc_id} class="arcana-chunk-doc-link"><%= document_label(doc_id, @document_titles) %></.link>
+                <% else %>
+                  <span title="(unknown document)"><%= document_label(doc_id, @document_titles) %></span>
+                <% end %>
+              </h5>
+              <span class="arcana-chunk-doc-meta">
+                <%= length(doc_chunks) %> <%= chunk_word(length(doc_chunks)) %>
+                <%= if any_source?(doc_chunks, @chunk_sources) do %>
+                  <span class="arcana-chunk-source-dot" title="Cited as grounding source"></span>
+                <% end %>
+              </span>
+            </header>
+            <ul class="arcana-chunk-list">
+              <%= for chunk <- doc_chunks do %>
+                <li class={["arcana-chunk-item", Map.has_key?(@chunk_sources, Map.get(chunk, :id)) && "arcana-chunk-item--source"]}>
+                  <details class="arcana-chunk-details">
+                    <summary class="arcana-chunk-summary" title={chunk_tooltip(chunk)}>
+                      <span class="arcana-chunk-score">score: <%= score_str(chunk.score) %></span>
+                      <span class="arcana-chunk-index">Chunk <%= chunk.chunk_index %></span>
+                      <%= if graph_sources = Map.get(chunk, :graph_sources) do %>
+                        <%= if is_list(graph_sources) and graph_sources != [] do %>
+                          <span class="arcana-chunk-via" title={"via: " <> Enum.join(graph_sources, ", ")}>via: <%= Enum.join(graph_sources, ", ") %></span>
+                        <% end %>
+                      <% end %>
+                      <%= if Map.has_key?(@chunk_sources, Map.get(chunk, :id)) do %>
+                        <span class="arcana-chunk-supports">✓ source</span>
+                      <% end %>
+                      <span class="arcana-chunk-preview"><%= snippet(chunk, @chunk_sources) %></span>
+                    </summary>
+                    <div class="arcana-chunk-full"><%= String.trim(chunk.text || "") %></div>
+                  </details>
+                </li>
+              <% end %>
+            </ul>
+          </section>
+        <% end %>
+      </div>
+      """
     end
-  end
 
-  defp shorten_uuid(uuid) when is_binary(uuid), do: String.slice(uuid, 0, 8)
-  defp shorten_uuid(other), do: inspect(other)
+    # --- Grouping ---
 
-  # Native title tooltip showing the full chunk id and owning document id.
-  # Falls back gracefully when either is missing (search results can lack
-  # the chunk id field).
-  defp chunk_tooltip(chunk) do
-    [
-      chunk |> Map.get(:id) |> format_tooltip_line("Chunk"),
-      chunk |> Map.get(:document_id) |> format_tooltip_line("Document")
-    ]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.join("\n")
-  end
-
-  defp format_tooltip_line(nil, _label), do: nil
-  defp format_tooltip_line(id, label), do: "#{label}: #{id}"
-
-  # --- Score formatting ---
-
-  defp score_str(score) when is_number(score) do
-    :io_lib.format("~.4f", [score * 1.0]) |> IO.iodata_to_binary()
-  end
-
-  defp score_str(_), do: "—"
-
-  # --- Chunk count wording ---
-
-  defp chunk_word(1), do: "chunk"
-  defp chunk_word(_), do: "chunks"
-
-  # --- Grounding source index ---
-
-  # Builds a map of chunk_id -> list of spans that cited this chunk, so
-  # downstream helpers can check membership in O(1) and pick the first
-  # span to center the snippet on.
-  defp build_chunk_source_index(nil), do: %{}
-
-  defp build_chunk_source_index(%{hallucinated_spans: hs, faithful_spans: fs}) do
-    (hs ++ fs)
-    |> Enum.flat_map(fn span ->
-      span
-      |> Map.get(:sources, [])
-      |> Enum.map(fn %{chunk_id: id} -> {id, span} end)
-    end)
-    |> Enum.group_by(fn {id, _} -> id end, fn {_, span} -> span end)
-  end
-
-  defp build_chunk_source_index(_), do: %{}
-
-  defp any_source?(chunks, chunk_sources) do
-    Enum.any?(chunks, &Map.has_key?(chunk_sources, Map.get(&1, :id)))
-  end
-
-  # --- Snippet selection ---
-
-  @preview_window 220
-
-  # When grounding says this chunk backed a span, find the span text in
-  # the chunk and return a window centered on it. Otherwise, fall back
-  # to the first N characters. The snippet always gets trimmed to drop
-  # leading/trailing whitespace from the source text.
-  defp snippet(chunk, chunk_sources) do
-    text = String.trim(chunk.text || "")
-
-    case Map.get(chunk_sources, Map.get(chunk, :id)) do
-      [span | _] ->
-        center_snippet(text, Map.get(span, :text, ""), @preview_window)
-
-      _ ->
-        head_snippet(text, @preview_window)
+    # Sort docs by their highest-scoring chunk descending so the most
+    # relevant document is rendered first.
+    defp group_by_document(chunks) do
+      chunks
+      |> Enum.group_by(&Map.get(&1, :document_id))
+      |> Enum.map(fn {doc_id, cs} -> {doc_id, Enum.sort_by(cs, & &1.score, :desc)} end)
+      |> Enum.sort_by(fn {_doc_id, cs} ->
+        -(cs |> Enum.map(& &1.score) |> Enum.max(fn -> 0 end))
+      end)
     end
-  end
 
-  defp head_snippet(text, window) do
-    if String.length(text) > window do
-      String.slice(text, 0, window) <> "..."
-    else
-      text
+    # --- Document label resolution ---
+
+    defp document_label(nil, _titles), do: "(unknown document)"
+
+    defp document_label(doc_id, titles) do
+      case Map.get(titles, doc_id) do
+        title when is_binary(title) and title != "" -> title
+        _ -> shorten_uuid(doc_id)
+      end
     end
-  end
 
-  defp center_snippet(text, "", window), do: head_snippet(text, window)
+    defp shorten_uuid(uuid) when is_binary(uuid), do: String.slice(uuid, 0, 8)
+    defp shorten_uuid(other), do: inspect(other)
 
-  defp center_snippet(text, span_text, window) do
-    case :binary.match(text, span_text) do
-      :nomatch ->
-        head_snippet(text, window)
+    # Native title tooltip showing the full chunk id and owning document id.
+    # Falls back gracefully when either is missing (search results can lack
+    # the chunk id field).
+    defp chunk_tooltip(chunk) do
+      [
+        chunk |> Map.get(:id) |> format_tooltip_line("Chunk"),
+        chunk |> Map.get(:document_id) |> format_tooltip_line("Document")
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join("\n")
+    end
 
-      {start, len} ->
-        span_bytes = len
-        context = max(div(window - span_bytes, 2), 0)
-        snippet_start = max(0, start - context)
-        snippet_end = min(byte_size(text), start + span_bytes + context)
-        prefix = if snippet_start > 0, do: "...", else: ""
-        suffix = if snippet_end < byte_size(text), do: "...", else: ""
-        prefix <> binary_part(text, snippet_start, snippet_end - snippet_start) <> suffix
+    defp format_tooltip_line(nil, _label), do: nil
+    defp format_tooltip_line(id, label), do: "#{label}: #{id}"
+
+    # --- Score formatting ---
+
+    defp score_str(score) when is_number(score) do
+      :io_lib.format("~.4f", [score * 1.0]) |> IO.iodata_to_binary()
+    end
+
+    defp score_str(_), do: "—"
+
+    # --- Chunk count wording ---
+
+    defp chunk_word(1), do: "chunk"
+    defp chunk_word(_), do: "chunks"
+
+    # --- Grounding source index ---
+
+    # Builds a map of chunk_id -> list of spans that cited this chunk, so
+    # downstream helpers can check membership in O(1) and pick the first
+    # span to center the snippet on.
+    defp build_chunk_source_index(nil), do: %{}
+
+    defp build_chunk_source_index(%{hallucinated_spans: hs, faithful_spans: fs}) do
+      (hs ++ fs)
+      |> Enum.flat_map(fn span ->
+        span
+        |> Map.get(:sources, [])
+        |> Enum.map(fn %{chunk_id: id} -> {id, span} end)
+      end)
+      |> Enum.group_by(fn {id, _} -> id end, fn {_, span} -> span end)
+    end
+
+    defp build_chunk_source_index(_), do: %{}
+
+    defp any_source?(chunks, chunk_sources) do
+      Enum.any?(chunks, &Map.has_key?(chunk_sources, Map.get(&1, :id)))
+    end
+
+    # --- Snippet selection ---
+
+    @preview_window 220
+
+    # When grounding says this chunk backed a span, find the span text in
+    # the chunk and return a window centered on it. Otherwise, fall back
+    # to the first N characters. The snippet always gets trimmed to drop
+    # leading/trailing whitespace from the source text.
+    defp snippet(chunk, chunk_sources) do
+      text = String.trim(chunk.text || "")
+
+      case Map.get(chunk_sources, Map.get(chunk, :id)) do
+        [span | _] ->
+          center_snippet(text, Map.get(span, :text, ""), @preview_window)
+
+        _ ->
+          head_snippet(text, @preview_window)
+      end
+    end
+
+    defp head_snippet(text, window) do
+      if String.length(text) > window do
+        String.slice(text, 0, window) <> "..."
+      else
+        text
+      end
+    end
+
+    defp center_snippet(text, "", window), do: head_snippet(text, window)
+
+    defp center_snippet(text, span_text, window) do
+      case :binary.match(text, span_text) do
+        :nomatch ->
+          head_snippet(text, window)
+
+        {start, len} ->
+          span_bytes = len
+          context = max(div(window - span_bytes, 2), 0)
+          snippet_start = max(0, start - context)
+          snippet_end = min(byte_size(text), start + span_bytes + context)
+          prefix = if snippet_start > 0, do: "...", else: ""
+          suffix = if snippet_end < byte_size(text), do: "...", else: ""
+          prefix <> binary_part(text, snippet_start, snippet_end - snippet_start) <> suffix
+      end
     end
   end
 end

--- a/lib/arcana_web/live/collections_live.ex
+++ b/lib/arcana_web/live/collections_live.ex
@@ -1,356 +1,361 @@
-defmodule ArcanaWeb.CollectionsLive do
-  @moduledoc """
-  LiveView for managing collections in Arcana.
-  """
-  use Phoenix.LiveView
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  import Ecto.Query
-  import ArcanaWeb.DashboardComponents
-
-  alias Arcana.Collection
-
-  @impl true
-  def mount(_params, session, socket) do
-    repo = get_repo_from_session(session)
-
-    {:ok,
-     socket
-     |> assign(repo: repo)
-     |> assign(editing_collection: nil, confirm_delete_collection: nil)
-     |> assign(stats: nil, collections: [], show_graph_stats: false)}
-  end
-
-  @impl true
-  def handle_params(_params, _uri, socket) do
-    {:noreply, load_data(socket)}
-  end
-
-  defp load_data(socket) do
-    repo = socket.assigns.repo
-    {collections, has_graph_data} = load_collections_with_stats(repo)
-
-    socket
-    |> assign(stats: load_stats(repo))
-    |> assign(collections: collections)
-    |> assign(show_graph_stats: has_graph_data)
-  end
-
-  defp load_collections_with_stats(repo) do
-    # Base collection data with document count
-    collections =
-      repo.all(
-        from(c in Collection,
-          left_join: d in Arcana.Document,
-          on: d.collection_id == c.id,
-          group_by: c.id,
-          order_by: c.name,
-          select: %{
-            id: c.id,
-            name: c.name,
-            description: c.description,
-            document_count: count(d.id)
-          }
-        )
-      )
-
-    # Add chunk counts
-    chunk_counts =
-      repo.all(
-        from(ch in Arcana.Chunk,
-          join: d in Arcana.Document,
-          on: ch.document_id == d.id,
-          group_by: d.collection_id,
-          select: {d.collection_id, count(ch.id)}
-        )
-      )
-      |> Map.new()
-
-    collections =
-      Enum.map(collections, fn c ->
-        Map.put(c, :chunk_count, Map.get(chunk_counts, c.id, 0))
-      end)
-
-    # Always try to add graph stats - show columns if any data exists
-    add_graph_stats(repo, collections)
-  end
-
-  defp add_graph_stats(repo, collections) do
-    entity_counts =
-      repo.all(
-        from(e in Arcana.Graph.Entity,
-          group_by: e.collection_id,
-          select: {e.collection_id, count(e.id)}
-        )
-      )
-      |> Map.new()
-
-    # Relationships don't have collection_id directly - join through source entity
-    relationship_counts =
-      repo.all(
-        from(r in Arcana.Graph.Relationship,
-          join: e in Arcana.Graph.Entity,
-          on: r.source_id == e.id,
-          group_by: e.collection_id,
-          select: {e.collection_id, count(r.id)}
-        )
-      )
-      |> Map.new()
-
-    community_counts =
-      repo.all(
-        from(c in Arcana.Graph.Community,
-          group_by: c.collection_id,
-          select: {c.collection_id, count(c.id)}
-        )
-      )
-      |> Map.new()
-
-    has_graph_data = map_size(entity_counts) > 0 or map_size(relationship_counts) > 0
-
-    collections_with_stats =
-      Enum.map(collections, fn c ->
-        c
-        |> Map.put(:entity_count, Map.get(entity_counts, c.id, 0))
-        |> Map.put(:relationship_count, Map.get(relationship_counts, c.id, 0))
-        |> Map.put(:community_count, Map.get(community_counts, c.id, 0))
-      end)
-
-    {collections_with_stats, has_graph_data}
-  rescue
-    # Tables might not exist
-    _ -> {collections, false}
-  end
-
-  @impl true
-  def handle_event("create_collection", %{"collection" => params}, socket) do
-    repo = socket.assigns.repo
-    name = params["name"] || ""
-    description = params["description"]
-
-    case Collection.get_or_create(name, repo, description) do
-      {:ok, _collection} ->
-        {:noreply, load_data(socket)}
-
-      {:error, changeset} ->
-        {:noreply,
-         put_flash(socket, :error, "Failed to create collection: #{inspect(changeset.errors)}")}
-    end
-  end
-
-  def handle_event("edit_collection", %{"id" => id}, socket) do
-    repo = socket.assigns.repo
-    collection = repo.get(Collection, id)
-    {:noreply, assign(socket, editing_collection: collection)}
-  end
-
-  def handle_event("cancel_edit_collection", _params, socket) do
-    {:noreply, assign(socket, editing_collection: nil)}
-  end
-
-  def handle_event("update_collection", %{"id" => id, "collection" => params}, socket) do
-    repo = socket.assigns.repo
-    collection = repo.get!(Collection, id)
-
-    changeset =
-      Collection.changeset(collection, %{
-        name: params["name"] || collection.name,
-        description: params["description"]
-      })
-
-    case repo.update(changeset) do
-      {:ok, _updated} ->
-        {:noreply, socket |> assign(editing_collection: nil) |> load_data()}
-
-      {:error, changeset} ->
-        {:noreply, put_flash(socket, :error, "Failed to update: #{inspect(changeset.errors)}")}
-    end
-  end
-
-  def handle_event("confirm_delete_collection", %{"id" => id}, socket) do
-    {:noreply, assign(socket, confirm_delete_collection: id)}
-  end
-
-  def handle_event("cancel_delete_collection", _params, socket) do
-    {:noreply, assign(socket, confirm_delete_collection: nil)}
-  end
-
-  def handle_event("delete_collection", %{"id" => id}, socket) do
-    repo = socket.assigns.repo
-
-    case repo.get(Collection, id) do
-      nil ->
-        {:noreply, assign(socket, confirm_delete_collection: nil)}
-
-      collection ->
-        repo.delete!(collection)
-        {:noreply, socket |> assign(confirm_delete_collection: nil) |> load_data()}
-    end
-  end
-
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:collections} prefix={@prefix}>
-      <div class="arcana-collections">
-        <h2>Collections</h2>
-        <p class="arcana-tab-description">
-          Organize documents into collections for scoped searches and better organization.
-        </p>
-
-        <div class="arcana-ingest-form">
-          <h3>Create Collection</h3>
-          <form id="new-collection-form" phx-submit="create_collection">
-            <div class="arcana-form-row" style="margin-bottom: 0.75rem;">
-              <input
-                type="text"
-                name="collection[name]"
-                placeholder="Collection name"
-                class="arcana-input"
-                style="flex: 1; max-width: 300px;"
-                required
-              />
-            </div>
-            <div class="arcana-form-row">
-              <input
-                type="text"
-                name="collection[description]"
-                placeholder="Description (optional) - helps the agent select the right collection"
-                class="arcana-input"
-                style="flex: 1;"
-              />
-              <button type="submit" class="arcana-btn arcana-btn-primary">
-                Create
-              </button>
-            </div>
-          </form>
-        </div>
-
-        <div class="arcana-doc-list">
-          <%= if Enum.empty?(@collections) do %>
-            <div class="arcana-empty">No collections yet. Create one above.</div>
-          <% else %>
-            <table class="arcana-table">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Description</th>
-                  <th>Docs</th>
-                  <th>Chunks</th>
-                  <%= if @show_graph_stats do %>
-                    <th>Entities</th>
-                    <th>Rels</th>
-                    <th>Communities</th>
-                  <% end %>
-                  <th style="width: 120px;">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <%= for collection <- @collections do %>
-                  <tr id={"collection-#{collection.name}"}>
-                    <%= if @editing_collection && @editing_collection.id == collection.id do %>
-                      <td colspan={if @show_graph_stats, do: 8, else: 5}>
-                        <form
-                          id={"edit-collection-form-#{collection.id}"}
-                          phx-submit="update_collection"
-                          phx-value-id={collection.id}
-                          class="arcana-edit-form"
-                        >
-                          <div class="arcana-form-row">
-                            <input
-                              type="text"
-                              name="collection[name]"
-                              value={collection.name}
-                              class="arcana-input"
-                              disabled
-                            />
-                            <input
-                              type="text"
-                              name="collection[description]"
-                              value={collection.description || ""}
-                              placeholder="Description"
-                              class="arcana-input"
-                              style="flex: 2;"
-                            />
-                            <button type="submit" class="arcana-btn arcana-btn-primary">Save</button>
-                            <button
-                              type="button"
-                              class="arcana-btn"
-                              phx-click="cancel_edit_collection"
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </form>
-                      </td>
-                    <% else %>
-                      <td><code><%= collection.name %></code></td>
-                      <td><%= collection.description || "-" %></td>
-                      <td><%= collection.document_count %></td>
-                      <td><%= collection.chunk_count %></td>
-                      <%= if @show_graph_stats do %>
-                        <td><%= collection[:entity_count] || 0 %></td>
-                        <td><%= collection[:relationship_count] || 0 %></td>
-                        <td><%= collection[:community_count] || 0 %></td>
-                      <% end %>
-                      <td>
-                        <%= if @confirm_delete_collection == collection.id do %>
-                          <div class="arcana-confirm-delete">
-                            <span>Delete?</span>
-                            <button
-                              id="confirm-delete"
-                              class="arcana-btn arcana-btn-danger"
-                              phx-click="delete_collection"
-                              phx-value-id={collection.id}
-                            >
-                              Yes
-                            </button>
-                            <button
-                              class="arcana-btn"
-                              phx-click="cancel_delete_collection"
-                            >
-                              No
-                            </button>
-                          </div>
-                        <% else %>
-                          <div class="arcana-actions-cell">
-                            <button
-                              id={"edit-collection-#{collection.id}"}
-                              class="arcana-icon-btn"
-                              phx-click="edit_collection"
-                              phx-value-id={collection.id}
-                              title="Edit collection"
-                            >
-                              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-                                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-                              </svg>
-                            </button>
-                            <button
-                              id={"delete-collection-#{collection.id}"}
-                              class="arcana-delete-btn"
-                              phx-click="confirm_delete_collection"
-                              phx-value-id={collection.id}
-                              title="Delete collection"
-                            >
-                              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <polyline points="3 6 5 6 21 6"></polyline>
-                                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                                <line x1="10" y1="11" x2="10" y2="17"></line>
-                                <line x1="14" y1="11" x2="14" y2="17"></line>
-                              </svg>
-                            </button>
-                          </div>
-                        <% end %>
-                      </td>
-                    <% end %>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          <% end %>
-        </div>
-      </div>
-    </.dashboard_layout>
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.CollectionsLive do
+    @moduledoc """
+    LiveView for managing collections in Arcana.
     """
+    use Phoenix.LiveView
+
+    import Ecto.Query
+    import ArcanaWeb.DashboardComponents
+
+    alias Arcana.Collection
+
+    @impl true
+    def mount(_params, session, socket) do
+      repo = get_repo_from_session(session)
+
+      {:ok,
+       socket
+       |> assign(repo: repo)
+       |> assign(editing_collection: nil, confirm_delete_collection: nil)
+       |> assign(stats: nil, collections: [], show_graph_stats: false)}
+    end
+
+    @impl true
+    def handle_params(_params, _uri, socket) do
+      {:noreply, load_data(socket)}
+    end
+
+    defp load_data(socket) do
+      repo = socket.assigns.repo
+      {collections, has_graph_data} = load_collections_with_stats(repo)
+
+      socket
+      |> assign(stats: load_stats(repo))
+      |> assign(collections: collections)
+      |> assign(show_graph_stats: has_graph_data)
+    end
+
+    defp load_collections_with_stats(repo) do
+      # Base collection data with document count
+      collections =
+        repo.all(
+          from(c in Collection,
+            left_join: d in Arcana.Document,
+            on: d.collection_id == c.id,
+            group_by: c.id,
+            order_by: c.name,
+            select: %{
+              id: c.id,
+              name: c.name,
+              description: c.description,
+              document_count: count(d.id)
+            }
+          )
+        )
+
+      # Add chunk counts
+      chunk_counts =
+        repo.all(
+          from(ch in Arcana.Chunk,
+            join: d in Arcana.Document,
+            on: ch.document_id == d.id,
+            group_by: d.collection_id,
+            select: {d.collection_id, count(ch.id)}
+          )
+        )
+        |> Map.new()
+
+      collections =
+        Enum.map(collections, fn c ->
+          Map.put(c, :chunk_count, Map.get(chunk_counts, c.id, 0))
+        end)
+
+      # Always try to add graph stats - show columns if any data exists
+      add_graph_stats(repo, collections)
+    end
+
+    defp add_graph_stats(repo, collections) do
+      entity_counts =
+        repo.all(
+          from(e in Arcana.Graph.Entity,
+            group_by: e.collection_id,
+            select: {e.collection_id, count(e.id)}
+          )
+        )
+        |> Map.new()
+
+      # Relationships don't have collection_id directly - join through source entity
+      relationship_counts =
+        repo.all(
+          from(r in Arcana.Graph.Relationship,
+            join: e in Arcana.Graph.Entity,
+            on: r.source_id == e.id,
+            group_by: e.collection_id,
+            select: {e.collection_id, count(r.id)}
+          )
+        )
+        |> Map.new()
+
+      community_counts =
+        repo.all(
+          from(c in Arcana.Graph.Community,
+            group_by: c.collection_id,
+            select: {c.collection_id, count(c.id)}
+          )
+        )
+        |> Map.new()
+
+      has_graph_data = map_size(entity_counts) > 0 or map_size(relationship_counts) > 0
+
+      collections_with_stats =
+        Enum.map(collections, fn c ->
+          c
+          |> Map.put(:entity_count, Map.get(entity_counts, c.id, 0))
+          |> Map.put(:relationship_count, Map.get(relationship_counts, c.id, 0))
+          |> Map.put(:community_count, Map.get(community_counts, c.id, 0))
+        end)
+
+      {collections_with_stats, has_graph_data}
+    rescue
+      # Tables might not exist
+      _ -> {collections, false}
+    end
+
+    @impl true
+    def handle_event("create_collection", %{"collection" => params}, socket) do
+      repo = socket.assigns.repo
+      name = params["name"] || ""
+      description = params["description"]
+
+      case Collection.get_or_create(name, repo, description) do
+        {:ok, _collection} ->
+          {:noreply, load_data(socket)}
+
+        {:error, changeset} ->
+          {:noreply,
+           put_flash(socket, :error, "Failed to create collection: #{inspect(changeset.errors)}")}
+      end
+    end
+
+    def handle_event("edit_collection", %{"id" => id}, socket) do
+      repo = socket.assigns.repo
+      collection = repo.get(Collection, id)
+      {:noreply, assign(socket, editing_collection: collection)}
+    end
+
+    def handle_event("cancel_edit_collection", _params, socket) do
+      {:noreply, assign(socket, editing_collection: nil)}
+    end
+
+    def handle_event("update_collection", %{"id" => id, "collection" => params}, socket) do
+      repo = socket.assigns.repo
+      collection = repo.get!(Collection, id)
+
+      changeset =
+        Collection.changeset(collection, %{
+          name: params["name"] || collection.name,
+          description: params["description"]
+        })
+
+      case repo.update(changeset) do
+        {:ok, _updated} ->
+          {:noreply, socket |> assign(editing_collection: nil) |> load_data()}
+
+        {:error, changeset} ->
+          {:noreply, put_flash(socket, :error, "Failed to update: #{inspect(changeset.errors)}")}
+      end
+    end
+
+    def handle_event("confirm_delete_collection", %{"id" => id}, socket) do
+      {:noreply, assign(socket, confirm_delete_collection: id)}
+    end
+
+    def handle_event("cancel_delete_collection", _params, socket) do
+      {:noreply, assign(socket, confirm_delete_collection: nil)}
+    end
+
+    def handle_event("delete_collection", %{"id" => id}, socket) do
+      repo = socket.assigns.repo
+
+      case repo.get(Collection, id) do
+        nil ->
+          {:noreply, assign(socket, confirm_delete_collection: nil)}
+
+        collection ->
+          repo.delete!(collection)
+          {:noreply, socket |> assign(confirm_delete_collection: nil) |> load_data()}
+      end
+    end
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.dashboard_layout stats={@stats} current_tab={:collections} prefix={@prefix}>
+        <div class="arcana-collections">
+          <h2>Collections</h2>
+          <p class="arcana-tab-description">
+            Organize documents into collections for scoped searches and better organization.
+          </p>
+
+          <div class="arcana-ingest-form">
+            <h3>Create Collection</h3>
+            <form id="new-collection-form" phx-submit="create_collection">
+              <div class="arcana-form-row" style="margin-bottom: 0.75rem;">
+                <input
+                  type="text"
+                  name="collection[name]"
+                  placeholder="Collection name"
+                  class="arcana-input"
+                  style="flex: 1; max-width: 300px;"
+                  required
+                />
+              </div>
+              <div class="arcana-form-row">
+                <input
+                  type="text"
+                  name="collection[description]"
+                  placeholder="Description (optional) - helps the agent select the right collection"
+                  class="arcana-input"
+                  style="flex: 1;"
+                />
+                <button type="submit" class="arcana-btn arcana-btn-primary">
+                  Create
+                </button>
+              </div>
+            </form>
+          </div>
+
+          <div class="arcana-doc-list">
+            <%= if Enum.empty?(@collections) do %>
+              <div class="arcana-empty">No collections yet. Create one above.</div>
+            <% else %>
+              <table class="arcana-table">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Docs</th>
+                    <th>Chunks</th>
+                    <%= if @show_graph_stats do %>
+                      <th>Entities</th>
+                      <th>Rels</th>
+                      <th>Communities</th>
+                    <% end %>
+                    <th style="width: 120px;">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <%= for collection <- @collections do %>
+                    <tr id={"collection-#{collection.name}"}>
+                      <%= if @editing_collection && @editing_collection.id == collection.id do %>
+                        <td colspan={if @show_graph_stats, do: 8, else: 5}>
+                          <form
+                            id={"edit-collection-form-#{collection.id}"}
+                            phx-submit="update_collection"
+                            phx-value-id={collection.id}
+                            class="arcana-edit-form"
+                          >
+                            <div class="arcana-form-row">
+                              <input
+                                type="text"
+                                name="collection[name]"
+                                value={collection.name}
+                                class="arcana-input"
+                                disabled
+                              />
+                              <input
+                                type="text"
+                                name="collection[description]"
+                                value={collection.description || ""}
+                                placeholder="Description"
+                                class="arcana-input"
+                                style="flex: 2;"
+                              />
+                              <button type="submit" class="arcana-btn arcana-btn-primary">Save</button>
+                              <button
+                                type="button"
+                                class="arcana-btn"
+                                phx-click="cancel_edit_collection"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </form>
+                        </td>
+                      <% else %>
+                        <td><code><%= collection.name %></code></td>
+                        <td><%= collection.description || "-" %></td>
+                        <td><%= collection.document_count %></td>
+                        <td><%= collection.chunk_count %></td>
+                        <%= if @show_graph_stats do %>
+                          <td><%= collection[:entity_count] || 0 %></td>
+                          <td><%= collection[:relationship_count] || 0 %></td>
+                          <td><%= collection[:community_count] || 0 %></td>
+                        <% end %>
+                        <td>
+                          <%= if @confirm_delete_collection == collection.id do %>
+                            <div class="arcana-confirm-delete">
+                              <span>Delete?</span>
+                              <button
+                                id="confirm-delete"
+                                class="arcana-btn arcana-btn-danger"
+                                phx-click="delete_collection"
+                                phx-value-id={collection.id}
+                              >
+                                Yes
+                              </button>
+                              <button
+                                class="arcana-btn"
+                                phx-click="cancel_delete_collection"
+                              >
+                                No
+                              </button>
+                            </div>
+                          <% else %>
+                            <div class="arcana-actions-cell">
+                              <button
+                                id={"edit-collection-#{collection.id}"}
+                                class="arcana-icon-btn"
+                                phx-click="edit_collection"
+                                phx-value-id={collection.id}
+                                title="Edit collection"
+                              >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                                </svg>
+                              </button>
+                              <button
+                                id={"delete-collection-#{collection.id}"}
+                                class="arcana-delete-btn"
+                                phx-click="confirm_delete_collection"
+                                phx-value-id={collection.id}
+                                title="Delete collection"
+                              >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                  <polyline points="3 6 5 6 21 6"></polyline>
+                                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                  <line x1="10" y1="11" x2="10" y2="17"></line>
+                                  <line x1="14" y1="11" x2="14" y2="17"></line>
+                                </svg>
+                              </button>
+                            </div>
+                          <% end %>
+                        </td>
+                      <% end %>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            <% end %>
+          </div>
+        </div>
+      </.dashboard_layout>
+      """
+    end
   end
 end

--- a/lib/arcana_web/live/collections_live.ex
+++ b/lib/arcana_web/live/collections_live.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.CollectionsLive do

--- a/lib/arcana_web/live/dashboard_components.ex
+++ b/lib/arcana_web/live/dashboard_components.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.DashboardComponents do

--- a/lib/arcana_web/live/dashboard_components.ex
+++ b/lib/arcana_web/live/dashboard_components.ex
@@ -1,211 +1,219 @@
-defmodule ArcanaWeb.DashboardComponents do
-  @moduledoc """
-  Shared components for the Arcana dashboard.
-  """
-  use Phoenix.Component
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  @doc """
-  Renders the dashboard layout with stats bar, navigation, and content.
-  """
-  attr(:stats, :map, required: true)
-  attr(:current_tab, :atom, required: true)
-  attr(:prefix, :string, default: "/arcana")
-  slot(:inner_block, required: true)
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.DashboardComponents do
+    @moduledoc """
+    Shared components for the Arcana dashboard.
+    """
+    use Phoenix.Component
 
-  def dashboard_layout(assigns) do
-    ~H"""
-    <link rel="stylesheet" href={"#{@prefix}/css-#{ArcanaWeb.Assets.current_hash(:css)}"} />
-    <div class="arcana-dashboard">
-      <div class="arcana-stats">
-        <div class="arcana-brand">Arcana</div>
-        <div class="arcana-stat">
-          <div class="arcana-stat-value"><%= format_number(@stats.documents) %></div>
-          <div class="arcana-stat-label">Documents</div>
+    @doc """
+    Renders the dashboard layout with stats bar, navigation, and content.
+    """
+    attr(:stats, :map, required: true)
+    attr(:current_tab, :atom, required: true)
+    attr(:prefix, :string, default: "/arcana")
+    slot(:inner_block, required: true)
+
+    def dashboard_layout(assigns) do
+      ~H"""
+      <link rel="stylesheet" href={"#{@prefix}/css-#{ArcanaWeb.Assets.current_hash(:css)}"} />
+      <div class="arcana-dashboard">
+        <div class="arcana-stats">
+          <div class="arcana-brand">Arcana</div>
+          <div class="arcana-stat">
+            <div class="arcana-stat-value"><%= format_number(@stats.documents) %></div>
+            <div class="arcana-stat-label">Documents</div>
+          </div>
+          <div class="arcana-stat">
+            <div class="arcana-stat-value"><%= format_number(@stats.chunks) %></div>
+            <div class="arcana-stat-label">Chunks</div>
+          </div>
+          <%= if @stats[:entities] do %>
+            <div class="arcana-stat-divider"></div>
+            <div class="arcana-stat">
+              <div class="arcana-stat-value"><%= format_number(@stats.entities) %></div>
+              <div class="arcana-stat-label">Entities</div>
+            </div>
+            <div class="arcana-stat">
+              <div class="arcana-stat-value"><%= format_number(@stats.relationships) %></div>
+              <div class="arcana-stat-label">Relationships</div>
+            </div>
+            <div class="arcana-stat">
+              <div class="arcana-stat-value"><%= format_number(@stats.communities) %></div>
+              <div class="arcana-stat-label">Communities</div>
+            </div>
+          <% end %>
         </div>
-        <div class="arcana-stat">
-          <div class="arcana-stat-value"><%= format_number(@stats.chunks) %></div>
-          <div class="arcana-stat-label">Chunks</div>
+
+        <nav class="arcana-tabs">
+          <.nav_link href={"#{@prefix}/documents"} active={@current_tab == :documents}>Documents</.nav_link>
+          <.nav_link href={"#{@prefix}/collections"} active={@current_tab == :collections}>Collections</.nav_link>
+          <.nav_link href={"#{@prefix}/graph"} active={@current_tab == :graph}>Graph</.nav_link>
+          <.nav_link href={"#{@prefix}/search"} active={@current_tab == :search}>Search</.nav_link>
+          <.nav_link href={"#{@prefix}/ask"} active={@current_tab == :ask}>Ask</.nav_link>
+          <.nav_link href={"#{@prefix}/evaluation"} active={@current_tab == :evaluation}>Evaluation</.nav_link>
+          <.nav_link href={"#{@prefix}/maintenance"} active={@current_tab == :maintenance}>Maintenance</.nav_link>
+          <.nav_link href={"#{@prefix}/info"} active={@current_tab == :info}>Info</.nav_link>
+        </nav>
+
+        <div class="arcana-content">
+          <%= render_slot(@inner_block) %>
         </div>
-        <%= if @stats[:entities] do %>
-          <div class="arcana-stat-divider"></div>
-          <div class="arcana-stat">
-            <div class="arcana-stat-value"><%= format_number(@stats.entities) %></div>
-            <div class="arcana-stat-label">Entities</div>
-          </div>
-          <div class="arcana-stat">
-            <div class="arcana-stat-value"><%= format_number(@stats.relationships) %></div>
-            <div class="arcana-stat-label">Relationships</div>
-          </div>
-          <div class="arcana-stat">
-            <div class="arcana-stat-value"><%= format_number(@stats.communities) %></div>
-            <div class="arcana-stat-label">Communities</div>
-          </div>
-        <% end %>
       </div>
+      """
+    end
 
-      <nav class="arcana-tabs">
-        <.nav_link href={"#{@prefix}/documents"} active={@current_tab == :documents}>Documents</.nav_link>
-        <.nav_link href={"#{@prefix}/collections"} active={@current_tab == :collections}>Collections</.nav_link>
-        <.nav_link href={"#{@prefix}/graph"} active={@current_tab == :graph}>Graph</.nav_link>
-        <.nav_link href={"#{@prefix}/search"} active={@current_tab == :search}>Search</.nav_link>
-        <.nav_link href={"#{@prefix}/ask"} active={@current_tab == :ask}>Ask</.nav_link>
-        <.nav_link href={"#{@prefix}/evaluation"} active={@current_tab == :evaluation}>Evaluation</.nav_link>
-        <.nav_link href={"#{@prefix}/maintenance"} active={@current_tab == :maintenance}>Maintenance</.nav_link>
-        <.nav_link href={"#{@prefix}/info"} active={@current_tab == :info}>Info</.nav_link>
-      </nav>
+    attr(:href, :string, required: true)
+    attr(:active, :boolean, default: false)
+    slot(:inner_block, required: true)
 
-      <div class="arcana-content">
+    defp nav_link(assigns) do
+      ~H"""
+      <a href={@href} class={"arcana-tab #{if @active, do: "active", else: ""}"}>
         <%= render_slot(@inner_block) %>
-      </div>
-    </div>
-    """
-  end
-
-  attr(:href, :string, required: true)
-  attr(:active, :boolean, default: false)
-  slot(:inner_block, required: true)
-
-  defp nav_link(assigns) do
-    ~H"""
-    <a href={@href} class={"arcana-tab #{if @active, do: "active", else: ""}"}>
-      <%= render_slot(@inner_block) %>
-    </a>
-    """
-  end
-
-  # Helper functions shared across dashboard pages
-  def parse_int(nil, default), do: default
-  def parse_int("", default), do: default
-
-  def parse_int(val, default) when is_binary(val) do
-    case Integer.parse(val) do
-      {num, _} -> num
-      :error -> default
+      </a>
+      """
     end
-  end
 
-  def parse_float(nil, default), do: default
-  def parse_float("", default), do: default
+    # Helper functions shared across dashboard pages
+    def parse_int(nil, default), do: default
+    def parse_int("", default), do: default
 
-  def parse_float(val, default) when is_binary(val) do
-    case Float.parse(val) do
-      {num, _} -> num
-      :error -> default
+    def parse_int(val, default) when is_binary(val) do
+      case Integer.parse(val) do
+        {num, _} -> num
+        :error -> default
+      end
     end
-  end
 
-  def parse_mode("vector"), do: :vector
-  def parse_mode("keyword"), do: :keyword
-  def parse_mode("hybrid"), do: :hybrid
-  # Deprecated form values: dashboards that bookmarked an old URL or
-  # have a stale form still work, they just get normalized silently.
-  def parse_mode("semantic"), do: :vector
-  def parse_mode("fulltext"), do: :keyword
-  def parse_mode(_), do: :vector
+    def parse_float(nil, default), do: default
+    def parse_float("", default), do: default
 
-  def parse_format("plaintext"), do: :plaintext
-  def parse_format("markdown"), do: :markdown
-  def parse_format("elixir"), do: :elixir
-  def parse_format(_), do: :plaintext
-
-  def normalize_collection(""), do: "default"
-  def normalize_collection(nil), do: "default"
-  def normalize_collection(name) when is_binary(name), do: name
-
-  def blank_to_nil(""), do: nil
-  def blank_to_nil(nil), do: nil
-  def blank_to_nil(value), do: value
-
-  def format_metadata(nil), do: "-"
-  def format_metadata(metadata) when metadata == %{}, do: "-"
-
-  def format_metadata(metadata) when is_map(metadata) do
-    Enum.map_join(metadata, ", ", fn {k, v} -> "#{k}: #{v}" end)
-  end
-
-  def format_pct(nil), do: "-"
-  def format_pct(value) when is_float(value), do: "#{Float.round(value * 100, 1)}%"
-  def format_pct(value) when is_integer(value), do: "#{value}%"
-
-  def format_score(nil), do: "-"
-  def format_score(value) when is_float(value), do: "#{Float.round(value, 1)}/10"
-  def format_score(value) when is_integer(value), do: "#{value}/10"
-
-  def format_number(n) when is_integer(n) do
-    n |> Integer.to_string() |> String.replace(~r/\B(?=(\d{3})+(?!\d))/, ",")
-  end
-
-  def format_number(_), do: "-"
-
-  def error_to_string(:too_large), do: "File too large (max 10MB)"
-  def error_to_string(:too_many_files), do: "Too many files (max 10)"
-  def error_to_string(:not_accepted), do: "File type not supported"
-  def error_to_string(err), do: "Error: #{inspect(err)}"
-
-  # Shared data loading functions
-  def load_stats(repo) do
-    import Ecto.Query
-
-    doc_count = repo.aggregate(Arcana.Document, :count)
-    chunk_count = repo.one(from(c in Arcana.Chunk, select: count(c.id))) || 0
-
-    base_stats = %{documents: doc_count, chunks: chunk_count}
-
-    # Add graph stats if GraphRAG is available
-    if Arcana.Graph.enabled?() do
-      graph_stats = load_graph_stats(repo)
-      Map.merge(base_stats, graph_stats)
-    else
-      base_stats
+    def parse_float(val, default) when is_binary(val) do
+      case Float.parse(val) do
+        {num, _} -> num
+        :error -> default
+      end
     end
-  end
 
-  defp load_graph_stats(repo) do
-    import Ecto.Query
+    def parse_mode("vector"), do: :vector
+    def parse_mode("keyword"), do: :keyword
+    def parse_mode("hybrid"), do: :hybrid
+    # Deprecated form values: dashboards that bookmarked an old URL or
+    # have a stale form still work, they just get normalized silently.
+    def parse_mode("semantic"), do: :vector
+    def parse_mode("fulltext"), do: :keyword
+    def parse_mode(_), do: :vector
 
-    entity_count = repo.one(from(e in Arcana.Graph.Entity, select: count(e.id))) || 0
-    relationship_count = repo.one(from(r in Arcana.Graph.Relationship, select: count(r.id))) || 0
-    community_count = repo.one(from(c in Arcana.Graph.Community, select: count(c.id))) || 0
+    def parse_format("plaintext"), do: :plaintext
+    def parse_format("markdown"), do: :markdown
+    def parse_format("elixir"), do: :elixir
+    def parse_format(_), do: :plaintext
 
-    %{entities: entity_count, relationships: relationship_count, communities: community_count}
-  rescue
-    # Tables might not exist if GraphRAG not installed
-    _ -> %{}
-  end
+    def normalize_collection(""), do: "default"
+    def normalize_collection(nil), do: "default"
+    def normalize_collection(name) when is_binary(name), do: name
 
-  def load_collections(repo) do
-    import Ecto.Query
+    def blank_to_nil(""), do: nil
+    def blank_to_nil(nil), do: nil
+    def blank_to_nil(value), do: value
 
-    repo.all(
-      from(c in Arcana.Collection,
-        left_join: d in Arcana.Document,
-        on: d.collection_id == c.id,
-        group_by: c.id,
-        order_by: c.name,
-        select: %{
-          id: c.id,
-          name: c.name,
-          description: c.description,
-          document_count: count(d.id)
-        }
+    def format_metadata(nil), do: "-"
+    def format_metadata(metadata) when metadata == %{}, do: "-"
+
+    def format_metadata(metadata) when is_map(metadata) do
+      Enum.map_join(metadata, ", ", fn {k, v} -> "#{k}: #{v}" end)
+    end
+
+    def format_pct(nil), do: "-"
+    def format_pct(value) when is_float(value), do: "#{Float.round(value * 100, 1)}%"
+    def format_pct(value) when is_integer(value), do: "#{value}%"
+
+    def format_score(nil), do: "-"
+    def format_score(value) when is_float(value), do: "#{Float.round(value, 1)}/10"
+    def format_score(value) when is_integer(value), do: "#{value}/10"
+
+    def format_number(n) when is_integer(n) do
+      n |> Integer.to_string() |> String.replace(~r/\B(?=(\d{3})+(?!\d))/, ",")
+    end
+
+    def format_number(_), do: "-"
+
+    def error_to_string(:too_large), do: "File too large (max 10MB)"
+    def error_to_string(:too_many_files), do: "Too many files (max 10)"
+    def error_to_string(:not_accepted), do: "File type not supported"
+    def error_to_string(err), do: "Error: #{inspect(err)}"
+
+    # Shared data loading functions
+    def load_stats(repo) do
+      import Ecto.Query
+
+      doc_count = repo.aggregate(Arcana.Document, :count)
+      chunk_count = repo.one(from(c in Arcana.Chunk, select: count(c.id))) || 0
+
+      base_stats = %{documents: doc_count, chunks: chunk_count}
+
+      # Add graph stats if GraphRAG is available
+      if Arcana.Graph.enabled?() do
+        graph_stats = load_graph_stats(repo)
+        Map.merge(base_stats, graph_stats)
+      else
+        base_stats
+      end
+    end
+
+    defp load_graph_stats(repo) do
+      import Ecto.Query
+
+      entity_count = repo.one(from(e in Arcana.Graph.Entity, select: count(e.id))) || 0
+
+      relationship_count =
+        repo.one(from(r in Arcana.Graph.Relationship, select: count(r.id))) || 0
+
+      community_count = repo.one(from(c in Arcana.Graph.Community, select: count(c.id))) || 0
+
+      %{entities: entity_count, relationships: relationship_count, communities: community_count}
+    rescue
+      # Tables might not exist if GraphRAG not installed
+      _ -> %{}
+    end
+
+    def load_collections(repo) do
+      import Ecto.Query
+
+      repo.all(
+        from(c in Arcana.Collection,
+          left_join: d in Arcana.Document,
+          on: d.collection_id == c.id,
+          group_by: c.id,
+          order_by: c.name,
+          select: %{
+            id: c.id,
+            name: c.name,
+            description: c.description,
+            document_count: count(d.id)
+          }
+        )
       )
-    )
-  end
+    end
 
-  def load_source_ids(repo) do
-    import Ecto.Query
+    def load_source_ids(repo) do
+      import Ecto.Query
 
-    repo.all(
-      from(d in Arcana.Document,
-        where: not is_nil(d.source_id),
-        distinct: d.source_id,
-        select: d.source_id
+      repo.all(
+        from(d in Arcana.Document,
+          where: not is_nil(d.source_id),
+          distinct: d.source_id,
+          select: d.source_id
+        )
       )
-    )
-  end
+    end
 
-  def get_repo_from_session(session) do
-    session["repo"] || Arcana.Config.get_env(:repo) ||
-      raise "Missing :arcana, :repo config"
+    def get_repo_from_session(session) do
+      session["repo"] || Arcana.Config.get_env(:repo) ||
+        raise "Missing :arcana, :repo config"
+    end
   end
 end

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -1,526 +1,536 @@
-defmodule ArcanaWeb.DocumentsLive do
-  @moduledoc """
-  LiveView for managing documents in Arcana.
-  """
-  use Phoenix.LiveView
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
-  import ArcanaWeb.DashboardComponents
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.DocumentsLive do
+    @moduledoc """
+    LiveView for managing documents in Arcana.
+    """
+    use Phoenix.LiveView
 
-  alias Arcana.Document
+    import ArcanaWeb.DashboardComponents
 
-  import Ecto.Query
+    alias Arcana.Document
 
-  @impl true
-  def mount(_params, session, socket) do
-    repo = get_repo_from_session(session)
+    import Ecto.Query
 
-    {:ok,
-     socket
-     |> assign(repo: repo)
-     |> assign(page: 1, per_page: 10)
-     |> assign(viewing_document: nil)
-     |> assign(upload_error: nil)
-     |> assign(filter_collection: nil)
-     |> assign(graph_enabled: Arcana.Graph.enabled?())
-     |> assign(graph_indexing: false)
-     |> assign(stats: nil, collections: [], documents: [], total_pages: 1, total_count: 0)
-     |> allow_upload(:files,
-       accept: ~w(.txt .md .markdown .pdf),
-       max_entries: 10,
-       max_file_size: 10_000_000
-     )}
-  end
+    @impl true
+    def mount(_params, session, socket) do
+      repo = get_repo_from_session(session)
 
-  @impl true
-  def handle_params(%{"doc" => doc_id}, _uri, socket) do
-    socket = load_data(socket)
-    {:noreply, load_document_detail(socket, doc_id)}
-  end
+      {:ok,
+       socket
+       |> assign(repo: repo)
+       |> assign(page: 1, per_page: 10)
+       |> assign(viewing_document: nil)
+       |> assign(upload_error: nil)
+       |> assign(filter_collection: nil)
+       |> assign(graph_enabled: Arcana.Graph.enabled?())
+       |> assign(graph_indexing: false)
+       |> assign(stats: nil, collections: [], documents: [], total_pages: 1, total_count: 0)
+       |> allow_upload(:files,
+         accept: ~w(.txt .md .markdown .pdf),
+         max_entries: 10,
+         max_file_size: 10_000_000
+       )}
+    end
 
-  def handle_params(_params, _uri, socket) do
-    {:noreply, load_data(socket)}
-  end
+    @impl true
+    def handle_params(%{"doc" => doc_id}, _uri, socket) do
+      socket = load_data(socket)
+      {:noreply, load_document_detail(socket, doc_id)}
+    end
 
-  defp load_data(socket) do
-    repo = socket.assigns.repo
+    def handle_params(_params, _uri, socket) do
+      {:noreply, load_data(socket)}
+    end
 
-    socket
-    |> assign(stats: load_stats(repo))
-    |> assign(collections: load_collections(repo))
-    |> load_documents()
-  end
+    defp load_data(socket) do
+      repo = socket.assigns.repo
 
-  defp load_documents(socket) do
-    page = socket.assigns.page
-    per_page = socket.assigns.per_page
+      socket
+      |> assign(stats: load_stats(repo))
+      |> assign(collections: load_collections(repo))
+      |> load_documents()
+    end
 
-    filters = [
-      repo: socket.assigns.repo,
-      collection: socket.assigns.filter_collection
-    ]
+    defp load_documents(socket) do
+      page = socket.assigns.page
+      per_page = socket.assigns.per_page
 
-    {:ok, total_count} = Arcana.count_documents(filters)
-    total_pages = max(1, ceil(total_count / per_page))
+      filters = [
+        repo: socket.assigns.repo,
+        collection: socket.assigns.filter_collection
+      ]
 
-    {:ok, documents} =
-      Arcana.list_documents(filters ++ [limit: per_page, offset: (page - 1) * per_page])
+      {:ok, total_count} = Arcana.count_documents(filters)
+      total_pages = max(1, ceil(total_count / per_page))
 
-    assign(socket,
-      documents: documents,
-      total_pages: total_pages,
-      total_count: total_count
-    )
-  end
+      {:ok, documents} =
+        Arcana.list_documents(filters ++ [limit: per_page, offset: (page - 1) * per_page])
 
-  defp load_document_detail(socket, doc_id) do
-    repo = socket.assigns.repo
-
-    document =
-      repo.one(
-        from(d in Document,
-          where: d.id == ^doc_id,
-          preload: [:collection]
-        )
+      assign(socket,
+        documents: documents,
+        total_pages: total_pages,
+        total_count: total_count
       )
+    end
 
-    if document do
-      chunks =
-        repo.all(
-          from(c in Arcana.Chunk,
-            where: c.document_id == ^doc_id,
-            order_by: c.chunk_index
+    defp load_document_detail(socket, doc_id) do
+      repo = socket.assigns.repo
+
+      document =
+        repo.one(
+          from(d in Document,
+            where: d.id == ^doc_id,
+            preload: [:collection]
           )
         )
 
-      assign(socket, viewing_document: %{document: document, chunks: chunks})
-    else
-      socket
-    end
-  end
+      if document do
+        chunks =
+          repo.all(
+            from(c in Arcana.Chunk,
+              where: c.document_id == ^doc_id,
+              order_by: c.chunk_index
+            )
+          )
 
-  @impl true
-  def handle_event("change_page", %{"page" => page}, socket) do
-    page = String.to_integer(page)
-    {:noreply, socket |> assign(page: page) |> load_documents()}
-  end
-
-  def handle_event("view_document", %{"id" => id}, socket) do
-    {:noreply, load_document_detail(socket, id)}
-  end
-
-  def handle_event("close_detail", _params, socket) do
-    {:noreply, assign(socket, viewing_document: nil)}
-  end
-
-  def handle_event("ingest", params, socket) do
-    repo = socket.assigns.repo
-    content = params["content"] || ""
-    format = parse_format(params["format"])
-    collection = normalize_collection(params["collection"])
-    graph = params["graph"] == "true"
-
-    {:ok, _doc} =
-      Arcana.ingest(content, repo: repo, format: format, collection: collection, graph: graph)
-
-    {:noreply, load_data(socket)}
-  end
-
-  def handle_event("upload_files", params, socket) do
-    repo = socket.assigns.repo
-    collection = normalize_collection(params["collection"])
-    graph = params["graph"] == "true"
-
-    uploaded_files =
-      consume_uploaded_entries(socket, :files, fn %{path: path}, entry ->
-        dest = Path.join(System.tmp_dir!(), "arcana_#{entry.uuid}_#{entry.client_name}")
-        File.cp!(path, dest)
-        {:ok, dest}
-      end)
-
-    results =
-      Enum.map(uploaded_files, fn path ->
-        result = Arcana.ingest_file(path, repo: repo, collection: collection, graph: graph)
-        File.rm(path)
-        result
-      end)
-
-    errors = Enum.filter(results, &match?({:error, _}, &1))
-
-    socket =
-      if Enum.empty?(errors) do
-        assign(socket, upload_error: nil)
+        assign(socket, viewing_document: %{document: document, chunks: chunks})
       else
-        error_msg =
-          Enum.map_join(errors, ", ", fn {:error, reason} -> inspect(reason) end)
-
-        assign(socket, upload_error: "Some files failed: #{error_msg}")
+        socket
       end
-
-    {:noreply, load_data(socket)}
-  end
-
-  def handle_event("cancel_upload", %{"ref" => ref}, socket) do
-    {:noreply, cancel_upload(socket, :files, ref)}
-  end
-
-  def handle_event("validate_upload", _params, socket) do
-    {:noreply, socket}
-  end
-
-  def handle_event("delete", %{"id" => id}, socket) do
-    repo = socket.assigns.repo
-
-    case Arcana.delete(id, repo: repo) do
-      :ok -> {:noreply, load_data(socket)}
-      {:error, _reason} -> {:noreply, socket}
     end
-  end
 
-  def handle_event("filter_by_collection", %{"collection" => collection_name}, socket) do
-    {:noreply, socket |> assign(filter_collection: collection_name, page: 1) |> load_documents()}
-  end
+    @impl true
+    def handle_event("change_page", %{"page" => page}, socket) do
+      page = String.to_integer(page)
+      {:noreply, socket |> assign(page: page) |> load_documents()}
+    end
 
-  def handle_event("clear_collection_filter", _params, socket) do
-    {:noreply, socket |> assign(filter_collection: nil, page: 1) |> load_documents()}
-  end
+    def handle_event("view_document", %{"id" => id}, socket) do
+      {:noreply, load_document_detail(socket, id)}
+    end
 
-  def handle_event("build_graph", _params, socket) do
-    %{document: document, chunks: chunks} = socket.assigns.viewing_document
-    collection = document.collection
-    repo = socket.assigns.repo
-    parent = self()
+    def handle_event("close_detail", _params, socket) do
+      {:noreply, assign(socket, viewing_document: nil)}
+    end
 
-    socket = assign(socket, graph_indexing: true)
+    def handle_event("ingest", params, socket) do
+      repo = socket.assigns.repo
+      content = params["content"] || ""
+      format = parse_format(params["format"])
+      collection = normalize_collection(params["collection"])
+      graph = params["graph"] == "true"
 
-    ArcanaWeb.TaskSupervisor.start_child(fn ->
-      result = Arcana.Graph.build_and_persist(chunks, collection, repo, [])
-      send(parent, {:graph_complete, result})
-    end)
+      {:ok, _doc} =
+        Arcana.ingest(content, repo: repo, format: format, collection: collection, graph: graph)
 
-    {:noreply, socket}
-  end
+      {:noreply, load_data(socket)}
+    end
 
-  @impl true
-  def handle_info({:graph_complete, result}, socket) do
-    socket =
-      case result do
-        {:ok, %{entity_count: entities, relationship_count: relationships}} ->
-          socket
-          |> assign(graph_indexing: false)
-          |> put_flash(:info, "Graph built: #{entities} entities, #{relationships} relationships")
+    def handle_event("upload_files", params, socket) do
+      repo = socket.assigns.repo
+      collection = normalize_collection(params["collection"])
+      graph = params["graph"] == "true"
 
-        {:error, reason} ->
-          socket
-          |> assign(graph_indexing: false)
-          |> put_flash(:error, "Graph build failed: #{inspect(reason)}")
+      uploaded_files =
+        consume_uploaded_entries(socket, :files, fn %{path: path}, entry ->
+          dest = Path.join(System.tmp_dir!(), "arcana_#{entry.uuid}_#{entry.client_name}")
+          File.cp!(path, dest)
+          {:ok, dest}
+        end)
+
+      results =
+        Enum.map(uploaded_files, fn path ->
+          result = Arcana.ingest_file(path, repo: repo, collection: collection, graph: graph)
+          File.rm(path)
+          result
+        end)
+
+      errors = Enum.filter(results, &match?({:error, _}, &1))
+
+      socket =
+        if Enum.empty?(errors) do
+          assign(socket, upload_error: nil)
+        else
+          error_msg =
+            Enum.map_join(errors, ", ", fn {:error, reason} -> inspect(reason) end)
+
+          assign(socket, upload_error: "Some files failed: #{error_msg}")
+        end
+
+      {:noreply, load_data(socket)}
+    end
+
+    def handle_event("cancel_upload", %{"ref" => ref}, socket) do
+      {:noreply, cancel_upload(socket, :files, ref)}
+    end
+
+    def handle_event("validate_upload", _params, socket) do
+      {:noreply, socket}
+    end
+
+    def handle_event("delete", %{"id" => id}, socket) do
+      repo = socket.assigns.repo
+
+      case Arcana.delete(id, repo: repo) do
+        :ok -> {:noreply, load_data(socket)}
+        {:error, _reason} -> {:noreply, socket}
       end
+    end
 
-    {:noreply, socket}
-  end
+    def handle_event("filter_by_collection", %{"collection" => collection_name}, socket) do
+      {:noreply,
+       socket |> assign(filter_collection: collection_name, page: 1) |> load_documents()}
+    end
 
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:documents} prefix={@prefix}>
-      <div class="arcana-documents">
-        <%= if @viewing_document do %>
-          <.document_detail
-            viewing={@viewing_document}
-            graph_enabled={@graph_enabled}
-            graph_indexing={@graph_indexing}
-          />
-        <% else %>
-          <h2>Documents</h2>
-          <p class="arcana-tab-description">
-            Upload, view, and manage documents in your knowledge base.
-          </p>
+    def handle_event("clear_collection_filter", _params, socket) do
+      {:noreply, socket |> assign(filter_collection: nil, page: 1) |> load_documents()}
+    end
 
-          <div class="arcana-upload-section">
-            <form id="upload-form" phx-submit="upload_files" phx-change="validate_upload">
-              <div class="arcana-dropzone" phx-drop-target={@uploads.files.ref}>
-                <.live_file_input upload={@uploads.files} class="arcana-file-input" />
-                <p>Drag & drop files here or click to browse</p>
-                <p class="arcana-upload-hint">Supported: .txt, .md, .pdf (max 10MB each)</p>
-              </div>
+    def handle_event("build_graph", _params, socket) do
+      %{document: document, chunks: chunks} = socket.assigns.viewing_document
+      collection = document.collection
+      repo = socket.assigns.repo
+      parent = self()
 
-              <%= if @upload_error do %>
-                <p class="arcana-upload-error"><%= @upload_error %></p>
-              <% end %>
+      socket = assign(socket, graph_indexing: true)
 
-              <%= for entry <- @uploads.files.entries do %>
-                <div class="arcana-upload-entry">
-                  <span><%= entry.client_name %></span>
-                  <progress value={entry.progress} max="100"><%= entry.progress %>%</progress>
-                  <button type="button" phx-click="cancel_upload" phx-value-ref={entry.ref}>&times;</button>
+      ArcanaWeb.TaskSupervisor.start_child(fn ->
+        result = Arcana.Graph.build_and_persist(chunks, collection, repo, [])
+        send(parent, {:graph_complete, result})
+      end)
 
-                  <%= for err <- upload_errors(@uploads.files, entry) do %>
-                    <span class="arcana-upload-error"><%= error_to_string(err) %></span>
-                  <% end %>
-                </div>
-              <% end %>
+      {:noreply, socket}
+    end
 
-              <%= if length(@uploads.files.entries) > 0 do %>
-                <div class="arcana-ingest-options">
-                  <label>
-                    Collection
-                    <select name="collection">
-                      <option value="">default</option>
-                      <%= for collection <- @collections do %>
-                        <option value={collection.name}><%= collection.name %></option>
-                      <% end %>
-                    </select>
-                  </label>
-                  <div class="arcana-graph-toggle">
-                    <label>
-                      Build Graph
-                      <label class="arcana-checkbox-label">
-                        <input type="checkbox" name="graph" value="true" />
-                        <span>Extract entities and relationships</span>
-                      </label>
-                    </label>
-                  </div>
-                </div>
-                <button type="submit" class="arcana-upload-btn">Upload Files</button>
-              <% end %>
-            </form>
-          </div>
+    @impl true
+    def handle_info({:graph_complete, result}, socket) do
+      socket =
+        case result do
+          {:ok, %{entity_count: entities, relationship_count: relationships}} ->
+            socket
+            |> assign(graph_indexing: false)
+            |> put_flash(
+              :info,
+              "Graph built: #{entities} entities, #{relationships} relationships"
+            )
 
-          <div class="arcana-divider">or paste text directly</div>
+          {:error, reason} ->
+            socket
+            |> assign(graph_indexing: false)
+            |> put_flash(:error, "Graph build failed: #{inspect(reason)}")
+        end
 
-          <form id="ingest-form" phx-submit="ingest" class="arcana-ingest-form">
-            <textarea name="content" placeholder="Paste text to ingest..." rows="4"></textarea>
-            <div class="arcana-ingest-options">
-              <label>
-                Format
-                <select name="format">
-                  <option value="plaintext">Plaintext</option>
-                  <option value="markdown">Markdown</option>
-                  <option value="elixir">Elixir</option>
-                </select>
-              </label>
-              <label>
-                Collection
-                <select name="collection">
-                  <option value="">default</option>
-                  <%= for collection <- @collections do %>
-                    <option value={collection.name}><%= collection.name %></option>
-                  <% end %>
-                </select>
-              </label>
-              <div class="arcana-graph-toggle">
-                <label>
-                  Build Graph
-                  <label class="arcana-checkbox-label">
-                    <input type="checkbox" name="graph" value="true" />
-                    <span>Extract entities and relationships</span>
-                  </label>
-                </label>
-              </div>
-            </div>
-            <button type="submit">Ingest</button>
-          </form>
+      {:noreply, socket}
+    end
 
-          <%= if not Enum.empty?(@collections) do %>
-            <div class="arcana-filter-bar">
-              <span class="arcana-filter-label">Filter by collection:</span>
-              <%= for collection <- @collections do %>
-                <button
-                  id={"filter-collection-#{collection.name}"}
-                  class={"arcana-filter-btn #{if @filter_collection == collection.name, do: "active", else: ""}"}
-                  phx-click="filter_by_collection"
-                  phx-value-collection={collection.name}
-                >
-                  <%= collection.name %>
-                </button>
-              <% end %>
-              <%= if @filter_collection do %>
-                <button
-                  id="clear-collection-filter"
-                  class="arcana-filter-btn arcana-filter-clear"
-                  phx-click="clear_collection_filter"
-                >
-                  ✕ Clear
-                </button>
-              <% end %>
-            </div>
-          <% end %>
-
-          <%= if Enum.empty?(@documents) do %>
-            <p class="arcana-empty">No documents yet. Paste some text above to get started.</p>
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.dashboard_layout stats={@stats} current_tab={:documents} prefix={@prefix}>
+        <div class="arcana-documents">
+          <%= if @viewing_document do %>
+            <.document_detail
+              viewing={@viewing_document}
+              graph_enabled={@graph_enabled}
+              graph_indexing={@graph_indexing}
+            />
           <% else %>
-            <table class="arcana-documents-table">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Content</th>
-                  <th>Collection</th>
-                  <th>Source</th>
-                  <th>Chunks</th>
-                  <th>Created</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <%= for doc <- @documents do %>
-                  <tr>
-                    <td><code><%= doc.id %></code></td>
-                    <td><%= String.slice(doc.content || "", 0, 100) %>...</td>
-                    <td><%= if doc.collection, do: doc.collection.name, else: "-" %></td>
-                    <td><%= doc.source_id || "-" %></td>
-                    <td><%= doc.chunk_count %></td>
-                    <td><%= doc.inserted_at %></td>
-                    <td class="arcana-actions-cell">
-                      <button
-                        data-view-doc={doc.id}
-                        class="arcana-icon-btn"
-                        phx-click="view_document"
-                        phx-value-id={doc.id}
-                        title="View document"
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                          <circle cx="12" cy="12" r="3"></circle>
-                        </svg>
-                      </button>
-                      <button
-                        data-delete-doc={doc.id}
-                        class="arcana-delete-btn"
-                        phx-click="delete"
-                        phx-value-id={doc.id}
-                        title="Delete document"
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                          <polyline points="3 6 5 6 21 6"></polyline>
-                          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                          <line x1="10" y1="11" x2="10" y2="17"></line>
-                          <line x1="14" y1="11" x2="14" y2="17"></line>
-                        </svg>
-                      </button>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
+            <h2>Documents</h2>
+            <p class="arcana-tab-description">
+              Upload, view, and manage documents in your knowledge base.
+            </p>
 
-            <%= if @total_pages > 1 do %>
-              <div class="arcana-pagination">
-                <button
-                  class="arcana-page-btn"
-                  phx-click="change_page"
-                  phx-value-page={@page - 1}
-                  disabled={@page <= 1}
-                >
-                  &lsaquo; Prev
-                </button>
-                <%= for entry <- page_window(@page, @total_pages) do %>
-                  <%= case entry do %>
-                    <% :ellipsis -> %>
-                      <span class="arcana-page-ellipsis">&hellip;</span>
-                    <% page -> %>
-                      <button
-                        data-page={page}
-                        class={"arcana-page-btn #{if page == @page, do: "active", else: ""}"}
-                        phx-click="change_page"
-                        phx-value-page={page}
-                      >
-                        <%= format_number(page) %>
-                      </button>
-                  <% end %>
+            <div class="arcana-upload-section">
+              <form id="upload-form" phx-submit="upload_files" phx-change="validate_upload">
+                <div class="arcana-dropzone" phx-drop-target={@uploads.files.ref}>
+                  <.live_file_input upload={@uploads.files} class="arcana-file-input" />
+                  <p>Drag & drop files here or click to browse</p>
+                  <p class="arcana-upload-hint">Supported: .txt, .md, .pdf (max 10MB each)</p>
+                </div>
+
+                <%= if @upload_error do %>
+                  <p class="arcana-upload-error"><%= @upload_error %></p>
                 <% end %>
-                <button
-                  class="arcana-page-btn"
-                  phx-click="change_page"
-                  phx-value-page={@page + 1}
-                  disabled={@page >= @total_pages}
-                >
-                  Next &rsaquo;
-                </button>
+
+                <%= for entry <- @uploads.files.entries do %>
+                  <div class="arcana-upload-entry">
+                    <span><%= entry.client_name %></span>
+                    <progress value={entry.progress} max="100"><%= entry.progress %>%</progress>
+                    <button type="button" phx-click="cancel_upload" phx-value-ref={entry.ref}>&times;</button>
+
+                    <%= for err <- upload_errors(@uploads.files, entry) do %>
+                      <span class="arcana-upload-error"><%= error_to_string(err) %></span>
+                    <% end %>
+                  </div>
+                <% end %>
+
+                <%= if length(@uploads.files.entries) > 0 do %>
+                  <div class="arcana-ingest-options">
+                    <label>
+                      Collection
+                      <select name="collection">
+                        <option value="">default</option>
+                        <%= for collection <- @collections do %>
+                          <option value={collection.name}><%= collection.name %></option>
+                        <% end %>
+                      </select>
+                    </label>
+                    <div class="arcana-graph-toggle">
+                      <label>
+                        Build Graph
+                        <label class="arcana-checkbox-label">
+                          <input type="checkbox" name="graph" value="true" />
+                          <span>Extract entities and relationships</span>
+                        </label>
+                      </label>
+                    </div>
+                  </div>
+                  <button type="submit" class="arcana-upload-btn">Upload Files</button>
+                <% end %>
+              </form>
+            </div>
+
+            <div class="arcana-divider">or paste text directly</div>
+
+            <form id="ingest-form" phx-submit="ingest" class="arcana-ingest-form">
+              <textarea name="content" placeholder="Paste text to ingest..." rows="4"></textarea>
+              <div class="arcana-ingest-options">
+                <label>
+                  Format
+                  <select name="format">
+                    <option value="plaintext">Plaintext</option>
+                    <option value="markdown">Markdown</option>
+                    <option value="elixir">Elixir</option>
+                  </select>
+                </label>
+                <label>
+                  Collection
+                  <select name="collection">
+                    <option value="">default</option>
+                    <%= for collection <- @collections do %>
+                      <option value={collection.name}><%= collection.name %></option>
+                    <% end %>
+                  </select>
+                </label>
+                <div class="arcana-graph-toggle">
+                  <label>
+                    Build Graph
+                    <label class="arcana-checkbox-label">
+                      <input type="checkbox" name="graph" value="true" />
+                      <span>Extract entities and relationships</span>
+                    </label>
+                  </label>
+                </div>
+              </div>
+              <button type="submit">Ingest</button>
+            </form>
+
+            <%= if not Enum.empty?(@collections) do %>
+              <div class="arcana-filter-bar">
+                <span class="arcana-filter-label">Filter by collection:</span>
+                <%= for collection <- @collections do %>
+                  <button
+                    id={"filter-collection-#{collection.name}"}
+                    class={"arcana-filter-btn #{if @filter_collection == collection.name, do: "active", else: ""}"}
+                    phx-click="filter_by_collection"
+                    phx-value-collection={collection.name}
+                  >
+                    <%= collection.name %>
+                  </button>
+                <% end %>
+                <%= if @filter_collection do %>
+                  <button
+                    id="clear-collection-filter"
+                    class="arcana-filter-btn arcana-filter-clear"
+                    phx-click="clear_collection_filter"
+                  >
+                    ✕ Clear
+                  </button>
+                <% end %>
               </div>
             <% end %>
+
+            <%= if Enum.empty?(@documents) do %>
+              <p class="arcana-empty">No documents yet. Paste some text above to get started.</p>
+            <% else %>
+              <table class="arcana-documents-table">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Content</th>
+                    <th>Collection</th>
+                    <th>Source</th>
+                    <th>Chunks</th>
+                    <th>Created</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <%= for doc <- @documents do %>
+                    <tr>
+                      <td><code><%= doc.id %></code></td>
+                      <td><%= String.slice(doc.content || "", 0, 100) %>...</td>
+                      <td><%= if doc.collection, do: doc.collection.name, else: "-" %></td>
+                      <td><%= doc.source_id || "-" %></td>
+                      <td><%= doc.chunk_count %></td>
+                      <td><%= doc.inserted_at %></td>
+                      <td class="arcana-actions-cell">
+                        <button
+                          data-view-doc={doc.id}
+                          class="arcana-icon-btn"
+                          phx-click="view_document"
+                          phx-value-id={doc.id}
+                          title="View document"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                            <circle cx="12" cy="12" r="3"></circle>
+                          </svg>
+                        </button>
+                        <button
+                          data-delete-doc={doc.id}
+                          class="arcana-delete-btn"
+                          phx-click="delete"
+                          phx-value-id={doc.id}
+                          title="Delete document"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="3 6 5 6 21 6"></polyline>
+                            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                            <line x1="10" y1="11" x2="10" y2="17"></line>
+                            <line x1="14" y1="11" x2="14" y2="17"></line>
+                          </svg>
+                        </button>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+
+              <%= if @total_pages > 1 do %>
+                <div class="arcana-pagination">
+                  <button
+                    class="arcana-page-btn"
+                    phx-click="change_page"
+                    phx-value-page={@page - 1}
+                    disabled={@page <= 1}
+                  >
+                    &lsaquo; Prev
+                  </button>
+                  <%= for entry <- page_window(@page, @total_pages) do %>
+                    <%= case entry do %>
+                      <% :ellipsis -> %>
+                        <span class="arcana-page-ellipsis">&hellip;</span>
+                      <% page -> %>
+                        <button
+                          data-page={page}
+                          class={"arcana-page-btn #{if page == @page, do: "active", else: ""}"}
+                          phx-click="change_page"
+                          phx-value-page={page}
+                        >
+                          <%= format_number(page) %>
+                        </button>
+                    <% end %>
+                  <% end %>
+                  <button
+                    class="arcana-page-btn"
+                    phx-click="change_page"
+                    phx-value-page={@page + 1}
+                    disabled={@page >= @total_pages}
+                  >
+                    Next &rsaquo;
+                  </button>
+                </div>
+              <% end %>
+            <% end %>
           <% end %>
-        <% end %>
-      </div>
-    </.dashboard_layout>
-    """
-  end
+        </div>
+      </.dashboard_layout>
+      """
+    end
 
-  defp document_detail(assigns) do
-    ~H"""
-    <div class="arcana-doc-detail">
-      <div class="arcana-doc-header">
-        <h2>Document Details</h2>
-        <div class="arcana-doc-header-actions">
-          <%= if @graph_enabled do %>
-            <button
-              phx-click="build_graph"
-              disabled={@graph_indexing}
-              class="arcana-graph-btn"
-              style="background: #10b981; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; margin-right: 0.5rem;"
-            >
-              <%= if @graph_indexing, do: "Building...", else: "Build Graph" %>
-            </button>
-          <% end %>
-          <button class="arcana-close-btn" phx-click="close_detail">← Back to list</button>
+    defp document_detail(assigns) do
+      ~H"""
+      <div class="arcana-doc-detail">
+        <div class="arcana-doc-header">
+          <h2>Document Details</h2>
+          <div class="arcana-doc-header-actions">
+            <%= if @graph_enabled do %>
+              <button
+                phx-click="build_graph"
+                disabled={@graph_indexing}
+                class="arcana-graph-btn"
+                style="background: #10b981; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; margin-right: 0.5rem;"
+              >
+                <%= if @graph_indexing, do: "Building...", else: "Build Graph" %>
+              </button>
+            <% end %>
+            <button class="arcana-close-btn" phx-click="close_detail">← Back to list</button>
+          </div>
         </div>
-      </div>
 
-      <div class="arcana-doc-info">
-        <div class="arcana-doc-field">
-          <label>ID</label>
-          <code><%= @viewing.document.id %></code>
+        <div class="arcana-doc-info">
+          <div class="arcana-doc-field">
+            <label>ID</label>
+            <code><%= @viewing.document.id %></code>
+          </div>
+          <div class="arcana-doc-field">
+            <label>Source</label>
+            <span><%= @viewing.document.source_id || "-" %></span>
+          </div>
+          <div class="arcana-doc-field">
+            <label>Metadata</label>
+            <span><%= format_metadata(@viewing.document.metadata) %></span>
+          </div>
+          <div class="arcana-doc-field">
+            <label>Created</label>
+            <span><%= @viewing.document.inserted_at %></span>
+          </div>
         </div>
-        <div class="arcana-doc-field">
-          <label>Source</label>
-          <span><%= @viewing.document.source_id || "-" %></span>
-        </div>
-        <div class="arcana-doc-field">
-          <label>Metadata</label>
-          <span><%= format_metadata(@viewing.document.metadata) %></span>
-        </div>
-        <div class="arcana-doc-field">
-          <label>Created</label>
-          <span><%= @viewing.document.inserted_at %></span>
-        </div>
-      </div>
 
-      <div class="arcana-doc-section">
-        <h3>Full Content</h3>
-        <pre class="arcana-doc-content"><%= @viewing.document.content %></pre>
-      </div>
+        <div class="arcana-doc-section">
+          <h3>Full Content</h3>
+          <pre class="arcana-doc-content"><%= @viewing.document.content %></pre>
+        </div>
 
-      <div class="arcana-doc-section">
-        <h3>Chunks (<%= length(@viewing.chunks) %>)</h3>
-        <div class="arcana-chunks-list">
-          <%= for chunk <- @viewing.chunks do %>
-            <div class="arcana-chunk">
-              <div class="arcana-chunk-header">
-                <span class="arcana-chunk-index">Chunk <%= chunk.chunk_index %></span>
-                <span class="arcana-chunk-tokens"><%= chunk.token_count %> tokens</span>
+        <div class="arcana-doc-section">
+          <h3>Chunks (<%= length(@viewing.chunks) %>)</h3>
+          <div class="arcana-chunks-list">
+            <%= for chunk <- @viewing.chunks do %>
+              <div class="arcana-chunk">
+                <div class="arcana-chunk-header">
+                  <span class="arcana-chunk-index">Chunk <%= chunk.chunk_index %></span>
+                  <span class="arcana-chunk-tokens"><%= chunk.token_count %> tokens</span>
+                </div>
+                <pre class="arcana-chunk-text"><%= chunk.text %></pre>
               </div>
-              <pre class="arcana-chunk-text"><%= chunk.text %></pre>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
-    """
+      """
+    end
+
+    defp page_window(current, total, window \\ 2) do
+      around =
+        max(2, current - window)..min(total - 1, current + window)
+        |> Enum.to_list()
+
+      [1 | around]
+      |> then(fn pages -> if total > 1, do: pages ++ [total], else: pages end)
+      |> Enum.uniq()
+      |> Enum.sort()
+      |> insert_ellipsis()
+    end
+
+    defp insert_ellipsis([a, b | rest]) when b - a > 1,
+      do: [a, :ellipsis | insert_ellipsis([b | rest])]
+
+    defp insert_ellipsis([a | rest]), do: [a | insert_ellipsis(rest)]
+    defp insert_ellipsis([]), do: []
   end
-
-  defp page_window(current, total, window \\ 2) do
-    around =
-      max(2, current - window)..min(total - 1, current + window)
-      |> Enum.to_list()
-
-    [1 | around]
-    |> then(fn pages -> if total > 1, do: pages ++ [total], else: pages end)
-    |> Enum.uniq()
-    |> Enum.sort()
-    |> insert_ellipsis()
-  end
-
-  defp insert_ellipsis([a, b | rest]) when b - a > 1,
-    do: [a, :ellipsis | insert_ellipsis([b | rest])]
-
-  defp insert_ellipsis([a | rest]), do: [a | insert_ellipsis(rest)]
-  defp insert_ellipsis([]), do: []
 end

--- a/lib/arcana_web/live/evaluation_live.ex
+++ b/lib/arcana_web/live/evaluation_live.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.EvaluationLive do

--- a/lib/arcana_web/live/evaluation_live.ex
+++ b/lib/arcana_web/live/evaluation_live.ex
@@ -1,721 +1,726 @@
-defmodule ArcanaWeb.EvaluationLive do
-  @moduledoc """
-  LiveView for retrieval evaluation in Arcana.
-  """
-  use Phoenix.LiveView
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  import ArcanaWeb.DashboardComponents
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.EvaluationLive do
+    @moduledoc """
+    LiveView for retrieval evaluation in Arcana.
+    """
+    use Phoenix.LiveView
 
-  alias Arcana.Evaluation
+    import ArcanaWeb.DashboardComponents
 
-  @impl true
-  def mount(_params, session, socket) do
-    repo = get_repo_from_session(session)
+    alias Arcana.Evaluation
 
-    {:ok,
-     socket
-     |> assign(repo: repo)
-     |> assign(
-       eval_view: :test_cases,
-       eval_running: false,
-       eval_generating: false,
-       eval_progress: nil,
-       eval_tick: 0,
-       eval_message: nil,
-       expanded_test_case_id: nil,
-       stats: nil,
-       eval_test_cases: [],
-       eval_runs: [],
-       eval_test_case_count: 0,
-       collections: []
-     )}
-  end
+    @impl true
+    def mount(_params, session, socket) do
+      repo = get_repo_from_session(session)
 
-  @impl true
-  def handle_params(_params, _uri, socket) do
-    {:noreply, load_data(socket)}
-  end
-
-  defp load_data(socket) do
-    repo = socket.assigns.repo
-
-    socket
-    |> assign(stats: load_stats(repo))
-    |> load_evaluation_data()
-  end
-
-  defp load_evaluation_data(socket) do
-    repo = socket.assigns.repo
-
-    test_cases = Evaluation.list_test_cases(repo: repo)
-    runs = Evaluation.list_runs(repo: repo, limit: 10)
-    test_case_count = Evaluation.count_test_cases(repo: repo)
-    collections = load_collections(repo)
-
-    assign(socket,
-      eval_test_cases: test_cases,
-      eval_runs: runs,
-      eval_test_case_count: test_case_count,
-      collections: collections
-    )
-  end
-
-  @impl true
-  def handle_event("eval_switch_view", %{"view" => view}, socket) do
-    {:noreply, assign(socket, eval_view: parse_eval_view(view))}
-  end
-
-  def handle_event("eval_run", params, socket) do
-    repo = socket.assigns.repo
-    mode = parse_mode(params["mode"])
-    retriever_name = params["retriever"] || "pipeline"
-    evaluate_answers = params["evaluate_answers"] == "true"
-
-    # Check if LLM is configured when evaluate_answers or Loop is requested
-    llm = Arcana.Config.get_env(:llm)
-    needs_llm? = evaluate_answers or retriever_name == "loop"
-
-    if needs_llm? and is_nil(llm) do
-      {:noreply,
-       assign(socket,
-         eval_message: {:error, "No LLM configured. Set :arcana, :llm in your config."}
+      {:ok,
+       socket
+       |> assign(repo: repo)
+       |> assign(
+         eval_view: :test_cases,
+         eval_running: false,
+         eval_generating: false,
+         eval_progress: nil,
+         eval_tick: 0,
+         eval_message: nil,
+         expanded_test_case_id: nil,
+         stats: nil,
+         eval_test_cases: [],
+         eval_runs: [],
+         eval_test_case_count: 0,
+         collections: []
        )}
-    else
-      socket =
-        assign(socket,
-          eval_running: true,
-          eval_message: nil,
-          eval_progress: %{
-            done: 0,
-            total: socket.assigns.eval_test_case_count,
-            started_at: System.monotonic_time(:millisecond)
-          }
-        )
-
-      opts = build_run_opts(repo, mode, evaluate_answers, llm, retriever_name)
-
-      parent = self()
-      handler_id = "eval-progress-#{inspect(parent)}"
-
-      :telemetry.attach_many(
-        handler_id,
-        [
-          [:arcana, :evaluation, :test_case, :start],
-          [:arcana, :evaluation, :test_case, :complete]
-        ],
-        fn event, measurements, metadata, _config ->
-          send(parent, {:eval_progress, event, measurements, metadata})
-        end,
-        nil
-      )
-
-      Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
-        result = Evaluation.run(opts)
-        :telemetry.detach(handler_id)
-        send(parent, {:eval_run_complete, result})
-      end)
-
-      # Self-tick every second so the elapsed-time counter updates live
-      # while a test case is in flight. LiveView only re-renders on
-      # messages; without a tick the elapsed-time label freezes at
-      # whatever it was when the last telemetry event fired.
-      Process.send_after(self(), :eval_tick, 1000)
-
-      {:noreply, socket}
     end
-  end
 
-  def handle_event("eval_generate", params, socket) do
-    repo = socket.assigns.repo
-    sample_size = parse_int(params["sample_size"], 10)
-    collection = blank_to_nil(params["collection"])
+    @impl true
+    def handle_params(_params, _uri, socket) do
+      {:noreply, load_data(socket)}
+    end
 
-    case Arcana.Config.get_env(:llm) do
-      nil ->
+    defp load_data(socket) do
+      repo = socket.assigns.repo
+
+      socket
+      |> assign(stats: load_stats(repo))
+      |> load_evaluation_data()
+    end
+
+    defp load_evaluation_data(socket) do
+      repo = socket.assigns.repo
+
+      test_cases = Evaluation.list_test_cases(repo: repo)
+      runs = Evaluation.list_runs(repo: repo, limit: 10)
+      test_case_count = Evaluation.count_test_cases(repo: repo)
+      collections = load_collections(repo)
+
+      assign(socket,
+        eval_test_cases: test_cases,
+        eval_runs: runs,
+        eval_test_case_count: test_case_count,
+        collections: collections
+      )
+    end
+
+    @impl true
+    def handle_event("eval_switch_view", %{"view" => view}, socket) do
+      {:noreply, assign(socket, eval_view: parse_eval_view(view))}
+    end
+
+    def handle_event("eval_run", params, socket) do
+      repo = socket.assigns.repo
+      mode = parse_mode(params["mode"])
+      retriever_name = params["retriever"] || "pipeline"
+      evaluate_answers = params["evaluate_answers"] == "true"
+
+      # Check if LLM is configured when evaluate_answers or Loop is requested
+      llm = Arcana.Config.get_env(:llm)
+      needs_llm? = evaluate_answers or retriever_name == "loop"
+
+      if needs_llm? and is_nil(llm) do
         {:noreply,
          assign(socket,
            eval_message: {:error, "No LLM configured. Set :arcana, :llm in your config."}
          )}
+      else
+        socket =
+          assign(socket,
+            eval_running: true,
+            eval_message: nil,
+            eval_progress: %{
+              done: 0,
+              total: socket.assigns.eval_test_case_count,
+              started_at: System.monotonic_time(:millisecond)
+            }
+          )
 
-      llm ->
-        socket = assign(socket, eval_generating: true, eval_message: nil)
+        opts = build_run_opts(repo, mode, evaluate_answers, llm, retriever_name)
 
         parent = self()
-        opts = build_generate_opts(repo, llm, sample_size, collection)
+        handler_id = "eval-progress-#{inspect(parent)}"
+
+        :telemetry.attach_many(
+          handler_id,
+          [
+            [:arcana, :evaluation, :test_case, :start],
+            [:arcana, :evaluation, :test_case, :complete]
+          ],
+          fn event, measurements, metadata, _config ->
+            send(parent, {:eval_progress, event, measurements, metadata})
+          end,
+          nil
+        )
 
         Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
-          result = Evaluation.generate_test_cases(opts)
-          send(parent, {:eval_generate_complete, result})
+          result = Evaluation.run(opts)
+          :telemetry.detach(handler_id)
+          send(parent, {:eval_run_complete, result})
         end)
 
+        # Self-tick every second so the elapsed-time counter updates live
+        # while a test case is in flight. LiveView only re-renders on
+        # messages; without a tick the elapsed-time label freezes at
+        # whatever it was when the last telemetry event fired.
+        Process.send_after(self(), :eval_tick, 1000)
+
         {:noreply, socket}
+      end
     end
-  end
 
-  def handle_event("toggle_test_case", %{"id" => id}, socket) do
-    current = socket.assigns.expanded_test_case_id
-    next = if current == id, do: nil, else: id
-    {:noreply, assign(socket, expanded_test_case_id: next)}
-  end
+    def handle_event("eval_generate", params, socket) do
+      repo = socket.assigns.repo
+      sample_size = parse_int(params["sample_size"], 10)
+      collection = blank_to_nil(params["collection"])
 
-  def handle_event("eval_delete_test_case", %{"id" => id}, socket) do
-    repo = socket.assigns.repo
+      case Arcana.Config.get_env(:llm) do
+        nil ->
+          {:noreply,
+           assign(socket,
+             eval_message: {:error, "No LLM configured. Set :arcana, :llm in your config."}
+           )}
 
-    case Evaluation.delete_test_case(id, repo: repo) do
-      {:ok, _} -> {:noreply, load_evaluation_data(socket)}
-      {:error, _} -> {:noreply, socket}
+        llm ->
+          socket = assign(socket, eval_generating: true, eval_message: nil)
+
+          parent = self()
+          opts = build_generate_opts(repo, llm, sample_size, collection)
+
+          Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
+            result = Evaluation.generate_test_cases(opts)
+            send(parent, {:eval_generate_complete, result})
+          end)
+
+          {:noreply, socket}
+      end
     end
-  end
 
-  def handle_event("eval_delete_run", %{"id" => id}, socket) do
-    repo = socket.assigns.repo
-
-    case Evaluation.delete_run(id, repo: repo) do
-      {:ok, _} -> {:noreply, load_evaluation_data(socket)}
-      {:error, _} -> {:noreply, socket}
+    def handle_event("toggle_test_case", %{"id" => id}, socket) do
+      current = socket.assigns.expanded_test_case_id
+      next = if current == id, do: nil, else: id
+      {:noreply, assign(socket, expanded_test_case_id: next)}
     end
-  end
 
-  @impl true
-  def handle_info(:eval_tick, socket) do
-    # Keep ticking while the eval task is running. No assign change
-    # beyond the implicit re-render; the template reads the monotonic
-    # clock each render so the elapsed display refreshes on its own.
-    if socket.assigns.eval_running do
-      Process.send_after(self(), :eval_tick, 1000)
-      {:noreply, assign(socket, eval_tick: System.monotonic_time(:millisecond))}
-    else
+    def handle_event("eval_delete_test_case", %{"id" => id}, socket) do
+      repo = socket.assigns.repo
+
+      case Evaluation.delete_test_case(id, repo: repo) do
+        {:ok, _} -> {:noreply, load_evaluation_data(socket)}
+        {:error, _} -> {:noreply, socket}
+      end
+    end
+
+    def handle_event("eval_delete_run", %{"id" => id}, socket) do
+      repo = socket.assigns.repo
+
+      case Evaluation.delete_run(id, repo: repo) do
+        {:ok, _} -> {:noreply, load_evaluation_data(socket)}
+        {:error, _} -> {:noreply, socket}
+      end
+    end
+
+    @impl true
+    def handle_info(:eval_tick, socket) do
+      # Keep ticking while the eval task is running. No assign change
+      # beyond the implicit re-render; the template reads the monotonic
+      # clock each render so the elapsed display refreshes on its own.
+      if socket.assigns.eval_running do
+        Process.send_after(self(), :eval_tick, 1000)
+        {:noreply, assign(socket, eval_tick: System.monotonic_time(:millisecond))}
+      else
+        {:noreply, socket}
+      end
+    end
+
+    def handle_info({:eval_progress, event, _measurements, metadata}, socket) do
+      %{index: index, total: total, question: question} = metadata
+
+      base =
+        socket.assigns.eval_progress ||
+          %{done: 0, total: total, started_at: System.monotonic_time(:millisecond), current: nil}
+
+      progress =
+        case List.last(event) do
+          :start ->
+            # New test case just kicked off; surface it as "now running"
+            # so the user sees motion even while a slow Loop iteration is
+            # in flight (can take several minutes per case).
+            %{base | total: total, current: %{index: index, question: question}}
+
+          :complete ->
+            # Test case finished; bump the done count and clear current
+            # so the bar reflects the new done-out-of-total.
+            %{base | done: index, total: total, current: nil}
+        end
+
+      {:noreply, assign(socket, eval_progress: progress)}
+    end
+
+    def handle_info({:eval_run_complete, result}, socket) do
+      socket =
+        case result do
+          {:ok, _run} ->
+            socket
+            |> assign(
+              eval_running: false,
+              eval_progress: nil,
+              eval_message: {:success, "Evaluation completed!"}
+            )
+            |> load_evaluation_data()
+            |> assign(eval_view: :history)
+
+          {:error, :no_test_cases} ->
+            assign(socket,
+              eval_running: false,
+              eval_progress: nil,
+              eval_message: {:error, "No test cases. Generate some first."}
+            )
+
+          other ->
+            # Fallback: the eval task raised or returned an unexpected
+            # result. Clear the running flag so the UI doesn't get stuck
+            # on "Running..." forever.
+            require Logger
+            Logger.error("[EvaluationLive] unexpected eval result: #{inspect(other)}")
+
+            assign(socket,
+              eval_running: false,
+              eval_progress: nil,
+              eval_message: {:error, "Evaluation failed: #{inspect(other)}"}
+            )
+        end
+
       {:noreply, socket}
     end
-  end
 
-  def handle_info({:eval_progress, event, _measurements, metadata}, socket) do
-    %{index: index, total: total, question: question} = metadata
+    def handle_info({:eval_generate_complete, result}, socket) do
+      socket =
+        case result do
+          {:ok, test_cases} ->
+            socket
+            |> assign(
+              eval_generating: false,
+              eval_message: {:success, "Generated #{length(test_cases)} test case(s)!"}
+            )
+            |> load_evaluation_data()
 
-    base =
-      socket.assigns.eval_progress ||
-        %{done: 0, total: total, started_at: System.monotonic_time(:millisecond), current: nil}
+          {:error, reason} ->
+            assign(socket,
+              eval_generating: false,
+              eval_message: {:error, "Generation failed: #{inspect(reason)}"}
+            )
+        end
 
-    progress =
-      case List.last(event) do
-        :start ->
-          # New test case just kicked off; surface it as "now running"
-          # so the user sees motion even while a slow Loop iteration is
-          # in flight (can take several minutes per case).
-          %{base | total: total, current: %{index: index, question: question}}
+      {:noreply, socket}
+    end
 
-        :complete ->
-          # Test case finished; bump the done count and clear current
-          # so the bar reflects the new done-out-of-total.
-          %{base | done: index, total: total, current: nil}
+    defp build_run_opts(repo, mode, evaluate_answers, llm, retriever_name) do
+      base =
+        [repo: repo, mode: mode]
+        |> maybe_put_evaluate_answers(evaluate_answers, llm)
+        |> maybe_put_retriever(retriever_name, repo, llm)
+
+      base
+    end
+
+    defp maybe_put_evaluate_answers(opts, false, _llm), do: opts
+
+    defp maybe_put_evaluate_answers(opts, true, llm) do
+      Keyword.merge(opts, evaluate_answers: true, llm: llm)
+    end
+
+    # Pipeline is the default — no :retriever needed, Arcana.Evaluation.run/1
+    # falls back to &Arcana.search/2.
+    defp maybe_put_retriever(opts, "pipeline", _repo, _llm), do: opts
+
+    defp maybe_put_retriever(opts, "loop", repo, llm) do
+      # Loop retriever: run a full Arcana.Loop.run/2 per test case and
+      # return the 3-tuple {:ok, chunks, answer}. The answer is the one
+      # the loop produced, so when evaluate_answers: true is on, the
+      # existing machinery skips regeneration and scores it directly.
+      runner = loop_runner()
+
+      retriever = fn question, _opts ->
+        ctx = Arcana.Loop.new(question, repo: repo)
+
+        case runner.(ctx, controller_llm: llm) do
+          {:ok, %Arcana.Loop.Context{} = result_ctx} ->
+            {:ok, result_ctx.chunks, result_ctx.answer}
+
+          {:error, _} = err ->
+            err
+        end
       end
 
-    {:noreply, assign(socket, eval_progress: progress)}
-  end
+      Keyword.put(opts, :retriever, retriever)
+    end
 
-  def handle_info({:eval_run_complete, result}, socket) do
-    socket =
-      case result do
-        {:ok, _run} ->
-          socket
-          |> assign(
-            eval_running: false,
-            eval_progress: nil,
-            eval_message: {:success, "Evaluation completed!"}
-          )
-          |> load_evaluation_data()
-          |> assign(eval_view: :history)
+    # Testability seam — same pattern used in ask_live.ex so tests can
+    # stub Loop execution without spinning up a real controller.
+    defp loop_runner do
+      Arcana.Config.get_env(:loop_runner) || (&Arcana.Loop.run/2)
+    end
 
-        {:error, :no_test_cases} ->
-          assign(socket,
-            eval_running: false,
-            eval_progress: nil,
-            eval_message: {:error, "No test cases. Generate some first."}
-          )
+    defp build_generate_opts(repo, llm, sample_size, nil) do
+      [repo: repo, llm: llm, sample_size: sample_size]
+    end
 
-        other ->
-          # Fallback: the eval task raised or returned an unexpected
-          # result. Clear the running flag so the UI doesn't get stuck
-          # on "Running..." forever.
-          require Logger
-          Logger.error("[EvaluationLive] unexpected eval result: #{inspect(other)}")
+    defp build_generate_opts(repo, llm, sample_size, collection) do
+      [repo: repo, llm: llm, sample_size: sample_size, collection: collection]
+    end
 
-          assign(socket,
-            eval_running: false,
-            eval_progress: nil,
-            eval_message: {:error, "Evaluation failed: #{inspect(other)}"}
-          )
-      end
+    defp parse_eval_view("test_cases"), do: :test_cases
+    defp parse_eval_view("run"), do: :run
+    defp parse_eval_view("history"), do: :history
+    # Any other value (an unknown view name from a stale tab or a malformed
+    # phx-value-view payload) falls back to the default landing.
+    defp parse_eval_view(_), do: :test_cases
 
-    {:noreply, socket}
-  end
+    defp progress_pct(%{done: done, total: total}) when total > 0,
+      do: Float.round(done / total * 100, 1)
 
-  def handle_info({:eval_generate_complete, result}, socket) do
-    socket =
-      case result do
-        {:ok, test_cases} ->
-          socket
-          |> assign(
-            eval_generating: false,
-            eval_message: {:success, "Generated #{length(test_cases)} test case(s)!"}
-          )
-          |> load_evaluation_data()
+    defp progress_pct(_), do: 0.0
 
-        {:error, reason} ->
-          assign(socket,
-            eval_generating: false,
-            eval_message: {:error, "Generation failed: #{inspect(reason)}"}
-          )
-      end
+    defp format_elapsed(ms) when ms < 1000, do: "#{ms}ms"
 
-    {:noreply, socket}
-  end
+    defp format_elapsed(ms) when ms < 60_000,
+      do: "#{Float.round(ms / 1000, 1)}s"
 
-  defp build_run_opts(repo, mode, evaluate_answers, llm, retriever_name) do
-    base =
-      [repo: repo, mode: mode]
-      |> maybe_put_evaluate_answers(evaluate_answers, llm)
-      |> maybe_put_retriever(retriever_name, repo, llm)
+    defp format_elapsed(ms) do
+      total_s = div(ms, 1000)
+      "#{div(total_s, 60)}m #{rem(total_s, 60)}s"
+    end
 
-    base
-  end
+    # Humanized "2 hours ago"-style relative time for timestamps in lists.
+    # Falls back to the absolute string for anything older than a week so
+    # months/years don't get ambiguous.
+    defp relative_time(nil), do: ""
 
-  defp maybe_put_evaluate_answers(opts, false, _llm), do: opts
+    defp relative_time(%NaiveDateTime{} = dt) do
+      now = NaiveDateTime.utc_now()
+      diff_s = NaiveDateTime.diff(now, dt, :second)
 
-  defp maybe_put_evaluate_answers(opts, true, llm) do
-    Keyword.merge(opts, evaluate_answers: true, llm: llm)
-  end
-
-  # Pipeline is the default — no :retriever needed, Arcana.Evaluation.run/1
-  # falls back to &Arcana.search/2.
-  defp maybe_put_retriever(opts, "pipeline", _repo, _llm), do: opts
-
-  defp maybe_put_retriever(opts, "loop", repo, llm) do
-    # Loop retriever: run a full Arcana.Loop.run/2 per test case and
-    # return the 3-tuple {:ok, chunks, answer}. The answer is the one
-    # the loop produced, so when evaluate_answers: true is on, the
-    # existing machinery skips regeneration and scores it directly.
-    runner = loop_runner()
-
-    retriever = fn question, _opts ->
-      ctx = Arcana.Loop.new(question, repo: repo)
-
-      case runner.(ctx, controller_llm: llm) do
-        {:ok, %Arcana.Loop.Context{} = result_ctx} ->
-          {:ok, result_ctx.chunks, result_ctx.answer}
-
-        {:error, _} = err ->
-          err
+      cond do
+        diff_s < 0 -> "just now"
+        diff_s < 60 -> "just now"
+        diff_s < 3600 -> "#{div(diff_s, 60)}m ago"
+        diff_s < 86_400 -> "#{div(diff_s, 3600)}h ago"
+        diff_s < 604_800 -> "#{div(diff_s, 86_400)}d ago"
+        true -> NaiveDateTime.to_date(dt) |> Date.to_string()
       end
     end
 
-    Keyword.put(opts, :retriever, retriever)
-  end
+    defp relative_time(other), do: to_string(other)
 
-  # Testability seam — same pattern used in ask_live.ex so tests can
-  # stub Loop execution without spinning up a real controller.
-  defp loop_runner do
-    Arcana.Config.get_env(:loop_runner) || (&Arcana.Loop.run/2)
-  end
+    defp absolute_time(%NaiveDateTime{} = dt),
+      do: NaiveDateTime.to_string(dt)
 
-  defp build_generate_opts(repo, llm, sample_size, nil) do
-    [repo: repo, llm: llm, sample_size: sample_size]
-  end
+    defp absolute_time(other), do: to_string(other)
 
-  defp build_generate_opts(repo, llm, sample_size, collection) do
-    [repo: repo, llm: llm, sample_size: sample_size, collection: collection]
-  end
-
-  defp parse_eval_view("test_cases"), do: :test_cases
-  defp parse_eval_view("run"), do: :run
-  defp parse_eval_view("history"), do: :history
-  # Any other value (an unknown view name from a stale tab or a malformed
-  # phx-value-view payload) falls back to the default landing.
-  defp parse_eval_view(_), do: :test_cases
-
-  defp progress_pct(%{done: done, total: total}) when total > 0,
-    do: Float.round(done / total * 100, 1)
-
-  defp progress_pct(_), do: 0.0
-
-  defp format_elapsed(ms) when ms < 1000, do: "#{ms}ms"
-
-  defp format_elapsed(ms) when ms < 60_000,
-    do: "#{Float.round(ms / 1000, 1)}s"
-
-  defp format_elapsed(ms) do
-    total_s = div(ms, 1000)
-    "#{div(total_s, 60)}m #{rem(total_s, 60)}s"
-  end
-
-  # Humanized "2 hours ago"-style relative time for timestamps in lists.
-  # Falls back to the absolute string for anything older than a week so
-  # months/years don't get ambiguous.
-  defp relative_time(nil), do: ""
-
-  defp relative_time(%NaiveDateTime{} = dt) do
-    now = NaiveDateTime.utc_now()
-    diff_s = NaiveDateTime.diff(now, dt, :second)
-
-    cond do
-      diff_s < 0 -> "just now"
-      diff_s < 60 -> "just now"
-      diff_s < 3600 -> "#{div(diff_s, 60)}m ago"
-      diff_s < 86_400 -> "#{div(diff_s, 3600)}h ago"
-      diff_s < 604_800 -> "#{div(diff_s, 86_400)}d ago"
-      true -> NaiveDateTime.to_date(dt) |> Date.to_string()
-    end
-  end
-
-  defp relative_time(other), do: to_string(other)
-
-  defp absolute_time(%NaiveDateTime{} = dt),
-    do: NaiveDateTime.to_string(dt)
-
-  defp absolute_time(other), do: to_string(other)
-
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:evaluation} prefix={@prefix}>
-      <div class="arcana-evaluation">
-        <h2>Evaluation</h2>
-        <p class="arcana-tab-description">
-          Test retrieval quality with test cases and measure recall and precision metrics.
-        </p>
-
-        <div class="arcana-eval-nav">
-          <button
-            class={"arcana-eval-nav-btn #{if @eval_view == :test_cases, do: "active", else: ""}"}
-            phx-click="eval_switch_view"
-            phx-value-view="test_cases"
-          >
-            Test Cases (<%= @eval_test_case_count %>)
-          </button>
-          <button
-            class={"arcana-eval-nav-btn #{if @eval_view == :run, do: "active", else: ""}"}
-            phx-click="eval_switch_view"
-            phx-value-view="run"
-          >
-            Run Evaluation
-          </button>
-          <button
-            class={"arcana-eval-nav-btn #{if @eval_view == :history, do: "active", else: ""}"}
-            phx-click="eval_switch_view"
-            phx-value-view="history"
-          >
-            History (<%= length(@eval_runs) %>)
-          </button>
-        </div>
-
-        <%= if @eval_message do %>
-          <div class={"arcana-eval-message #{elem(@eval_message, 0)}"}>
-            <%= elem(@eval_message, 1) %>
-          </div>
-        <% end %>
-
-        <%= case @eval_view do %>
-          <% :test_cases -> %>
-            <.eval_test_cases_view
-              test_cases={@eval_test_cases}
-              generating={@eval_generating}
-              collections={@collections}
-              expanded_id={@expanded_test_case_id}
-            />
-          <% :run -> %>
-            <.eval_run_view
-              running={@eval_running}
-              progress={@eval_progress}
-              test_case_count={@eval_test_case_count}
-            />
-          <% :history -> %>
-            <.eval_history_view runs={@eval_runs} />
-        <% end %>
-      </div>
-    </.dashboard_layout>
-    """
-  end
-
-  defp eval_test_cases_view(assigns) do
-    ~H"""
-    <div class="arcana-eval-test-cases">
-      <form phx-submit="eval_generate" class="arcana-eval-run-form">
-        <div class="arcana-eval-options-row">
-          <div class="arcana-eval-field">
-            <label class="arcana-eval-field-label" for="eval-collection">Collection</label>
-            <select name="collection" id="eval-collection" class="arcana-eval-select">
-              <option value="">All collections</option>
-              <%= for col <- @collections do %>
-                <option value={col.name}><%= col.name %></option>
-              <% end %>
-            </select>
-            <small class="arcana-eval-hint">Leave blank to sample from every collection.</small>
-          </div>
-
-          <div class="arcana-eval-field">
-            <label class="arcana-eval-field-label" for="eval-sample-size">Sample size</label>
-            <select name="sample_size" id="eval-sample-size" class="arcana-eval-select">
-              <option value="5">5</option>
-              <option value="10" selected>10</option>
-              <option value="25">25</option>
-              <option value="50">50</option>
-              <option value="100">100</option>
-            </select>
-            <small class="arcana-eval-hint">
-              Random chunks sampled and paired with LLM-generated questions.
-            </small>
-          </div>
-        </div>
-
-        <div class="arcana-eval-actions">
-          <button type="submit" class="arcana-eval-run-btn" disabled={@generating}>
-            <%= if @generating, do: "Generating...", else: "Generate test cases" %>
-          </button>
-        </div>
-      </form>
-
-      <%= if Enum.empty?(@test_cases) do %>
-        <div class="arcana-eval-empty-state">
-          <div class="arcana-eval-empty-icon">○</div>
-          <h4>No test cases yet</h4>
-          <p>
-            Generate some with the form above, or seed from Mix with
-            <code>mix adept.eval.seed</code>.
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.dashboard_layout stats={@stats} current_tab={:evaluation} prefix={@prefix}>
+        <div class="arcana-evaluation">
+          <h2>Evaluation</h2>
+          <p class="arcana-tab-description">
+            Test retrieval quality with test cases and measure recall and precision metrics.
           </p>
-        </div>
-      <% else %>
-        <div class="arcana-test-case-list">
-          <%= for tc <- @test_cases do %>
-            <% expanded? = @expanded_id == tc.id %>
-            <div class={"arcana-test-case #{if expanded?, do: "expanded", else: ""}"}>
-              <div class="arcana-test-case-row">
-                <div
-                  class="arcana-test-case-row-main"
-                  phx-click="toggle_test_case"
-                  phx-value-id={tc.id}
-                >
-                  <span class="arcana-test-case-chevron" aria-hidden="true">
-                    <%= if expanded?, do: "▾", else: "▸" %>
-                  </span>
-                  <span class="arcana-test-case-question"><%= tc.question %></span>
-                  <span class={"arcana-test-case-badge arcana-test-case-badge--#{tc.source}"}>
-                    <%= tc.source %>
-                  </span>
-                  <span class="arcana-test-case-chunks">
-                    <%= length(tc.relevant_chunks) %> chunk<%= if length(tc.relevant_chunks) == 1, do: "", else: "s" %>
-                  </span>
-                  <span class="arcana-test-case-time" title={absolute_time(tc.inserted_at)}>
-                    <%= relative_time(tc.inserted_at) %>
-                  </span>
-                </div>
-                <button
-                  type="button"
-                  class="arcana-delete-btn"
-                  phx-click="eval_delete_test_case"
-                  phx-value-id={tc.id}
-                  title="Delete test case"
-                >
-                  ×
-                </button>
-              </div>
-              <%= if expanded? do %>
-                <div class="arcana-test-case-detail">
-                  <%= if tc.reference_answer do %>
-                    <div class="arcana-test-case-detail-section">
-                      <h5>Reference answer</h5>
-                      <p><%= tc.reference_answer %></p>
-                    </div>
-                  <% end %>
-                  <div class="arcana-test-case-detail-section">
-                    <h5>Expected chunks (<%= length(tc.relevant_chunks) %>)</h5>
-                    <%= if Enum.empty?(tc.relevant_chunks) do %>
-                      <p class="arcana-test-case-empty">No chunks linked.</p>
-                    <% else %>
-                      <ul class="arcana-test-case-chunk-list">
-                        <%= for chunk <- tc.relevant_chunks do %>
-                          <li>
-                            <code class="arcana-test-case-chunk-id">
-                              <%= String.slice(to_string(chunk.id), 0, 8) %>
-                            </code>
-                            <span class="arcana-test-case-chunk-text">
-                              <%= String.slice(chunk.text || "", 0, 200) %><%= if String.length(chunk.text || "") > 200, do: "..." %>
-                            </span>
-                          </li>
-                        <% end %>
-                      </ul>
-                    <% end %>
-                  </div>
-                </div>
-              <% end %>
+
+          <div class="arcana-eval-nav">
+            <button
+              class={"arcana-eval-nav-btn #{if @eval_view == :test_cases, do: "active", else: ""}"}
+              phx-click="eval_switch_view"
+              phx-value-view="test_cases"
+            >
+              Test Cases (<%= @eval_test_case_count %>)
+            </button>
+            <button
+              class={"arcana-eval-nav-btn #{if @eval_view == :run, do: "active", else: ""}"}
+              phx-click="eval_switch_view"
+              phx-value-view="run"
+            >
+              Run Evaluation
+            </button>
+            <button
+              class={"arcana-eval-nav-btn #{if @eval_view == :history, do: "active", else: ""}"}
+              phx-click="eval_switch_view"
+              phx-value-view="history"
+            >
+              History (<%= length(@eval_runs) %>)
+            </button>
+          </div>
+
+          <%= if @eval_message do %>
+            <div class={"arcana-eval-message #{elem(@eval_message, 0)}"}>
+              <%= elem(@eval_message, 1) %>
             </div>
           <% end %>
+
+          <%= case @eval_view do %>
+            <% :test_cases -> %>
+              <.eval_test_cases_view
+                test_cases={@eval_test_cases}
+                generating={@eval_generating}
+                collections={@collections}
+                expanded_id={@expanded_test_case_id}
+              />
+            <% :run -> %>
+              <.eval_run_view
+                running={@eval_running}
+                progress={@eval_progress}
+                test_case_count={@eval_test_case_count}
+              />
+            <% :history -> %>
+              <.eval_history_view runs={@eval_runs} />
+          <% end %>
         </div>
-      <% end %>
-    </div>
-    """
-  end
+      </.dashboard_layout>
+      """
+    end
 
-  defp eval_run_view(assigns) do
-    ~H"""
-    <div class="arcana-eval-run">
-      <p class="arcana-eval-run-intro">
-        Run evaluation against your <strong><%= @test_case_count %></strong> test case{if @test_case_count == 1, do: "", else: "s"} to measure retrieval quality.
-      </p>
+    defp eval_test_cases_view(assigns) do
+      ~H"""
+      <div class="arcana-eval-test-cases">
+        <form phx-submit="eval_generate" class="arcana-eval-run-form">
+          <div class="arcana-eval-options-row">
+            <div class="arcana-eval-field">
+              <label class="arcana-eval-field-label" for="eval-collection">Collection</label>
+              <select name="collection" id="eval-collection" class="arcana-eval-select">
+                <option value="">All collections</option>
+                <%= for col <- @collections do %>
+                  <option value={col.name}><%= col.name %></option>
+                <% end %>
+              </select>
+              <small class="arcana-eval-hint">Leave blank to sample from every collection.</small>
+            </div>
 
-      <form phx-submit="eval_run" class="arcana-eval-run-form">
-        <div class="arcana-eval-field">
-          <h4 class="arcana-eval-field-label">Retriever</h4>
-          <div class="arcana-eval-option-grid">
-            <label class="arcana-eval-option-card">
-              <input type="radio" name="retriever" value="pipeline" checked />
-              <div class="arcana-eval-option-title">Pipeline</div>
-              <div class="arcana-eval-option-desc">
-                Modular RAG via <code>Arcana.search/2</code>. Fast, deterministic.
-              </div>
-            </label>
-            <label class="arcana-eval-option-card">
-              <input type="radio" name="retriever" value="loop" />
-              <div class="arcana-eval-option-title">Loop</div>
-              <div class="arcana-eval-option-desc">
-                Agentic RAG via <code>Arcana.Loop</code>. LLM picks tools each turn. Much slower, needs LLM.
-              </div>
-            </label>
-          </div>
-        </div>
-
-        <div class="arcana-eval-options-row">
-          <div class="arcana-eval-field">
-            <label class="arcana-eval-field-label" for="eval-mode">Search mode</label>
-            <select name="mode" id="eval-mode" class="arcana-eval-select">
-              <option value="vector">Vector</option>
-              <option value="keyword">Keyword</option>
-              <option value="hybrid">Hybrid</option>
-            </select>
-            <small class="arcana-eval-hint">
-              Vector: embedding similarity. Keyword: exact terms. Hybrid: both fused by RRF.
-              Pipeline only; Loop always uses vector.
-            </small>
-          </div>
-
-          <label class="arcana-eval-toggle">
-            <input type="checkbox" name="evaluate_answers" value="true" />
-            <span class="arcana-eval-toggle-indicator" aria-hidden="true"></span>
-            <div class="arcana-eval-toggle-content">
-              <span class="arcana-eval-toggle-title">Evaluate answers</span>
+            <div class="arcana-eval-field">
+              <label class="arcana-eval-field-label" for="eval-sample-size">Sample size</label>
+              <select name="sample_size" id="eval-sample-size" class="arcana-eval-select">
+                <option value="5">5</option>
+                <option value="10" selected>10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+              </select>
               <small class="arcana-eval-hint">
-                Requires LLM. Scores faithfulness and correctness against reference_answer.
+                Random chunks sampled and paired with LLM-generated questions.
               </small>
             </div>
-          </label>
-        </div>
+          </div>
 
-        <div class="arcana-eval-actions">
-          <%= if @running and @progress do %>
-            <div class="arcana-eval-progress">
-              <div class="arcana-eval-progress-label">
-                <span><%= @progress.done %> / <%= @progress.total %> test cases</span>
-                <span class="arcana-eval-progress-elapsed">
-                  <%= format_elapsed(System.monotonic_time(:millisecond) - @progress.started_at) %>
-                </span>
-              </div>
-              <div class="arcana-eval-progress-bar">
-                <div
-                  class="arcana-eval-progress-fill"
-                  style={"width: #{progress_pct(@progress)}%"}
-                ></div>
-              </div>
-              <%= if current = @progress[:current] do %>
-                <div class="arcana-eval-progress-current">
-                  <span class="arcana-eval-progress-spinner" aria-hidden="true"></span>
-                  <span class="arcana-eval-progress-current-label">
-                    Running case <%= current.index %>: <%= current.question %>
-                  </span>
+          <div class="arcana-eval-actions">
+            <button type="submit" class="arcana-eval-run-btn" disabled={@generating}>
+              <%= if @generating, do: "Generating...", else: "Generate test cases" %>
+            </button>
+          </div>
+        </form>
+
+        <%= if Enum.empty?(@test_cases) do %>
+          <div class="arcana-eval-empty-state">
+            <div class="arcana-eval-empty-icon">○</div>
+            <h4>No test cases yet</h4>
+            <p>
+              Generate some with the form above, or seed from Mix with
+              <code>mix adept.eval.seed</code>.
+            </p>
+          </div>
+        <% else %>
+          <div class="arcana-test-case-list">
+            <%= for tc <- @test_cases do %>
+              <% expanded? = @expanded_id == tc.id %>
+              <div class={"arcana-test-case #{if expanded?, do: "expanded", else: ""}"}>
+                <div class="arcana-test-case-row">
+                  <div
+                    class="arcana-test-case-row-main"
+                    phx-click="toggle_test_case"
+                    phx-value-id={tc.id}
+                  >
+                    <span class="arcana-test-case-chevron" aria-hidden="true">
+                      <%= if expanded?, do: "▾", else: "▸" %>
+                    </span>
+                    <span class="arcana-test-case-question"><%= tc.question %></span>
+                    <span class={"arcana-test-case-badge arcana-test-case-badge--#{tc.source}"}>
+                      <%= tc.source %>
+                    </span>
+                    <span class="arcana-test-case-chunks">
+                      <%= length(tc.relevant_chunks) %> chunk<%= if length(tc.relevant_chunks) == 1, do: "", else: "s" %>
+                    </span>
+                    <span class="arcana-test-case-time" title={absolute_time(tc.inserted_at)}>
+                      <%= relative_time(tc.inserted_at) %>
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    class="arcana-delete-btn"
+                    phx-click="eval_delete_test_case"
+                    phx-value-id={tc.id}
+                    title="Delete test case"
+                  >
+                    ×
+                  </button>
                 </div>
-              <% end %>
-            </div>
-          <% end %>
-          <button type="submit" class="arcana-eval-run-btn" disabled={@running or @test_case_count == 0}>
-            <%= if @running, do: "Running...", else: "Run Evaluation" %>
-          </button>
-        </div>
-      </form>
-
-      <%= if @test_case_count == 0 do %>
-        <p class="arcana-empty">
-          No test cases available. Generate some first using <code>mix arcana.eval.generate</code>.
-        </p>
-      <% end %>
-    </div>
-    """
-  end
-
-  defp eval_history_view(assigns) do
-    ~H"""
-    <div class="arcana-eval-history">
-      <%= if Enum.empty?(@runs) do %>
-        <p class="arcana-empty">No evaluation runs yet. Run an evaluation to see results here.</p>
-      <% else %>
-        <%= for run <- @runs do %>
-          <div class="arcana-run-card">
-            <div class="arcana-run-header">
-              <div class="arcana-run-header-left">
-                <span class={"arcana-run-status #{run.status}"}><%= run.status %></span>
-                <span style="font-size: 0.875rem; color: #374151;">
-                  <%= run.test_case_count %> test cases
-                </span>
-              </div>
-              <div style="display: flex; gap: 0.5rem; align-items: center;">
-                <span style="font-size: 0.75rem; color: #6b7280;"><%= run.inserted_at %></span>
-                <button
-                  style="background: transparent; color: #dc2626; border: 1px solid #dc2626; padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-size: 0.75rem; cursor: pointer;"
-                  phx-click="eval_delete_run"
-                  phx-value-id={run.id}
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
-            <div class="arcana-run-body">
-              <div class="arcana-run-config">
-                Mode: <strong><%= run.config["mode"] || run.config[:mode] || "vector" %></strong>
-              </div>
-              <%= if run.status == :completed and run.metrics do %>
-                <div class="arcana-metrics-grid">
-                  <div class="arcana-metric-card">
-                    <div class="arcana-metric-value"><%= format_pct(run.metrics["recall_at_5"] || run.metrics[:recall_at_5]) %></div>
-                    <div class="arcana-metric-label">Recall@5</div>
-                  </div>
-                  <div class="arcana-metric-card">
-                    <div class="arcana-metric-value"><%= format_pct(run.metrics["precision_at_5"] || run.metrics[:precision_at_5]) %></div>
-                    <div class="arcana-metric-label">Precision@5</div>
-                  </div>
-                  <div class="arcana-metric-card">
-                    <div class="arcana-metric-value"><%= format_pct(run.metrics["mrr"] || run.metrics[:mrr]) %></div>
-                    <div class="arcana-metric-label">MRR</div>
-                  </div>
-                  <div class="arcana-metric-card">
-                    <div class="arcana-metric-value"><%= format_pct(run.metrics["hit_rate_at_5"] || run.metrics[:hit_rate_at_5]) %></div>
-                    <div class="arcana-metric-label">Hit Rate@5</div>
-                  </div>
-                  <%= if run.metrics["faithfulness"] || run.metrics[:faithfulness] do %>
-                    <div class="arcana-metric-card">
-                      <div class="arcana-metric-value"><%= format_score(run.metrics["faithfulness"] || run.metrics[:faithfulness]) %></div>
-                      <div class="arcana-metric-label">Faithfulness</div>
+                <%= if expanded? do %>
+                  <div class="arcana-test-case-detail">
+                    <%= if tc.reference_answer do %>
+                      <div class="arcana-test-case-detail-section">
+                        <h5>Reference answer</h5>
+                        <p><%= tc.reference_answer %></p>
+                      </div>
+                    <% end %>
+                    <div class="arcana-test-case-detail-section">
+                      <h5>Expected chunks (<%= length(tc.relevant_chunks) %>)</h5>
+                      <%= if Enum.empty?(tc.relevant_chunks) do %>
+                        <p class="arcana-test-case-empty">No chunks linked.</p>
+                      <% else %>
+                        <ul class="arcana-test-case-chunk-list">
+                          <%= for chunk <- tc.relevant_chunks do %>
+                            <li>
+                              <code class="arcana-test-case-chunk-id">
+                                <%= String.slice(to_string(chunk.id), 0, 8) %>
+                              </code>
+                              <span class="arcana-test-case-chunk-text">
+                                <%= String.slice(chunk.text || "", 0, 200) %><%= if String.length(chunk.text || "") > 200, do: "..." %>
+                              </span>
+                            </li>
+                          <% end %>
+                        </ul>
+                      <% end %>
                     </div>
-                  <% end %>
-                  <%= if run.metrics["correctness"] || run.metrics[:correctness] do %>
-                    <div class="arcana-metric-card">
-                      <div class="arcana-metric-value"><%= format_score(run.metrics["correctness"] || run.metrics[:correctness]) %></div>
-                      <div class="arcana-metric-label">Correctness</div>
-                    </div>
-                  <% end %>
-                </div>
-              <% end %>
-            </div>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         <% end %>
-      <% end %>
-    </div>
-    """
+      </div>
+      """
+    end
+
+    defp eval_run_view(assigns) do
+      ~H"""
+      <div class="arcana-eval-run">
+        <p class="arcana-eval-run-intro">
+          Run evaluation against your <strong><%= @test_case_count %></strong> test case{if @test_case_count == 1, do: "", else: "s"} to measure retrieval quality.
+        </p>
+
+        <form phx-submit="eval_run" class="arcana-eval-run-form">
+          <div class="arcana-eval-field">
+            <h4 class="arcana-eval-field-label">Retriever</h4>
+            <div class="arcana-eval-option-grid">
+              <label class="arcana-eval-option-card">
+                <input type="radio" name="retriever" value="pipeline" checked />
+                <div class="arcana-eval-option-title">Pipeline</div>
+                <div class="arcana-eval-option-desc">
+                  Modular RAG via <code>Arcana.search/2</code>. Fast, deterministic.
+                </div>
+              </label>
+              <label class="arcana-eval-option-card">
+                <input type="radio" name="retriever" value="loop" />
+                <div class="arcana-eval-option-title">Loop</div>
+                <div class="arcana-eval-option-desc">
+                  Agentic RAG via <code>Arcana.Loop</code>. LLM picks tools each turn. Much slower, needs LLM.
+                </div>
+              </label>
+            </div>
+          </div>
+
+          <div class="arcana-eval-options-row">
+            <div class="arcana-eval-field">
+              <label class="arcana-eval-field-label" for="eval-mode">Search mode</label>
+              <select name="mode" id="eval-mode" class="arcana-eval-select">
+                <option value="vector">Vector</option>
+                <option value="keyword">Keyword</option>
+                <option value="hybrid">Hybrid</option>
+              </select>
+              <small class="arcana-eval-hint">
+                Vector: embedding similarity. Keyword: exact terms. Hybrid: both fused by RRF.
+                Pipeline only; Loop always uses vector.
+              </small>
+            </div>
+
+            <label class="arcana-eval-toggle">
+              <input type="checkbox" name="evaluate_answers" value="true" />
+              <span class="arcana-eval-toggle-indicator" aria-hidden="true"></span>
+              <div class="arcana-eval-toggle-content">
+                <span class="arcana-eval-toggle-title">Evaluate answers</span>
+                <small class="arcana-eval-hint">
+                  Requires LLM. Scores faithfulness and correctness against reference_answer.
+                </small>
+              </div>
+            </label>
+          </div>
+
+          <div class="arcana-eval-actions">
+            <%= if @running and @progress do %>
+              <div class="arcana-eval-progress">
+                <div class="arcana-eval-progress-label">
+                  <span><%= @progress.done %> / <%= @progress.total %> test cases</span>
+                  <span class="arcana-eval-progress-elapsed">
+                    <%= format_elapsed(System.monotonic_time(:millisecond) - @progress.started_at) %>
+                  </span>
+                </div>
+                <div class="arcana-eval-progress-bar">
+                  <div
+                    class="arcana-eval-progress-fill"
+                    style={"width: #{progress_pct(@progress)}%"}
+                  ></div>
+                </div>
+                <%= if current = @progress[:current] do %>
+                  <div class="arcana-eval-progress-current">
+                    <span class="arcana-eval-progress-spinner" aria-hidden="true"></span>
+                    <span class="arcana-eval-progress-current-label">
+                      Running case <%= current.index %>: <%= current.question %>
+                    </span>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+            <button type="submit" class="arcana-eval-run-btn" disabled={@running or @test_case_count == 0}>
+              <%= if @running, do: "Running...", else: "Run Evaluation" %>
+            </button>
+          </div>
+        </form>
+
+        <%= if @test_case_count == 0 do %>
+          <p class="arcana-empty">
+            No test cases available. Generate some first using <code>mix arcana.eval.generate</code>.
+          </p>
+        <% end %>
+      </div>
+      """
+    end
+
+    defp eval_history_view(assigns) do
+      ~H"""
+      <div class="arcana-eval-history">
+        <%= if Enum.empty?(@runs) do %>
+          <p class="arcana-empty">No evaluation runs yet. Run an evaluation to see results here.</p>
+        <% else %>
+          <%= for run <- @runs do %>
+            <div class="arcana-run-card">
+              <div class="arcana-run-header">
+                <div class="arcana-run-header-left">
+                  <span class={"arcana-run-status #{run.status}"}><%= run.status %></span>
+                  <span style="font-size: 0.875rem; color: #374151;">
+                    <%= run.test_case_count %> test cases
+                  </span>
+                </div>
+                <div style="display: flex; gap: 0.5rem; align-items: center;">
+                  <span style="font-size: 0.75rem; color: #6b7280;"><%= run.inserted_at %></span>
+                  <button
+                    style="background: transparent; color: #dc2626; border: 1px solid #dc2626; padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-size: 0.75rem; cursor: pointer;"
+                    phx-click="eval_delete_run"
+                    phx-value-id={run.id}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+              <div class="arcana-run-body">
+                <div class="arcana-run-config">
+                  Mode: <strong><%= run.config["mode"] || run.config[:mode] || "vector" %></strong>
+                </div>
+                <%= if run.status == :completed and run.metrics do %>
+                  <div class="arcana-metrics-grid">
+                    <div class="arcana-metric-card">
+                      <div class="arcana-metric-value"><%= format_pct(run.metrics["recall_at_5"] || run.metrics[:recall_at_5]) %></div>
+                      <div class="arcana-metric-label">Recall@5</div>
+                    </div>
+                    <div class="arcana-metric-card">
+                      <div class="arcana-metric-value"><%= format_pct(run.metrics["precision_at_5"] || run.metrics[:precision_at_5]) %></div>
+                      <div class="arcana-metric-label">Precision@5</div>
+                    </div>
+                    <div class="arcana-metric-card">
+                      <div class="arcana-metric-value"><%= format_pct(run.metrics["mrr"] || run.metrics[:mrr]) %></div>
+                      <div class="arcana-metric-label">MRR</div>
+                    </div>
+                    <div class="arcana-metric-card">
+                      <div class="arcana-metric-value"><%= format_pct(run.metrics["hit_rate_at_5"] || run.metrics[:hit_rate_at_5]) %></div>
+                      <div class="arcana-metric-label">Hit Rate@5</div>
+                    </div>
+                    <%= if run.metrics["faithfulness"] || run.metrics[:faithfulness] do %>
+                      <div class="arcana-metric-card">
+                        <div class="arcana-metric-value"><%= format_score(run.metrics["faithfulness"] || run.metrics[:faithfulness]) %></div>
+                        <div class="arcana-metric-label">Faithfulness</div>
+                      </div>
+                    <% end %>
+                    <%= if run.metrics["correctness"] || run.metrics[:correctness] do %>
+                      <div class="arcana-metric-card">
+                        <div class="arcana-metric-value"><%= format_score(run.metrics["correctness"] || run.metrics[:correctness]) %></div>
+                        <div class="arcana-metric-label">Correctness</div>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+      """
+    end
   end
 end

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.GraphLive do

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -1,1042 +1,1050 @@
-defmodule ArcanaWeb.GraphLive do
-  @moduledoc """
-  LiveView for exploring the GraphRAG knowledge graph.
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  Provides three sub-views:
-  - Entities: Browse and search entities with their relationships and source chunks
-  - Relationships: Explore entity relationships with strength indicators
-  - Communities: View community clusters with LLM-generated summaries
-  """
-  use Phoenix.LiveView
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.GraphLive do
+    @moduledoc """
+    LiveView for exploring the GraphRAG knowledge graph.
 
-  import ArcanaWeb.DashboardComponents
-  import Ecto.Query
+    Provides three sub-views:
+    - Entities: Browse and search entities with their relationships and source chunks
+    - Relationships: Explore entity relationships with strength indicators
+    - Communities: View community clusters with LLM-generated summaries
+    """
+    use Phoenix.LiveView
 
-  alias Arcana.Graph.{Community, Entity, GraphStore, Relationship}
+    import ArcanaWeb.DashboardComponents
+    import Ecto.Query
 
-  @page_size 50
+    alias Arcana.Graph.{Community, Entity, GraphStore, Relationship}
 
-  @impl true
-  def mount(_params, session, socket) do
-    repo = get_repo_from_session(session)
+    @page_size 50
 
-    {:ok,
-     socket
-     |> assign(repo: repo)
-     |> assign(
-       current_subtab: :entities,
-       selected_collection: nil,
-       collections: [],
-       entities: [],
-       relationships: [],
-       communities: [],
-       stats: nil,
-       entity_filter: "",
-       entity_type_filter: nil,
-       entity_types: [],
-       selected_entity: nil,
-       entity_details: nil,
-       entities_page: 1,
-       entities_total: 0,
-       relationship_filter: "",
-       relationship_type_filter: nil,
-       relationship_types: [],
-       relationship_strength_filter: nil,
-       selected_relationship: nil,
-       relationship_details: nil,
-       relationships_page: 1,
-       relationships_total: 0,
-       community_filter: "",
-       community_level_filter: nil,
-       selected_community: nil,
-       community_details: nil,
-       communities_page: 1,
-       communities_total: 0
-     )}
-  end
+    @impl true
+    def mount(_params, session, socket) do
+      repo = get_repo_from_session(session)
 
-  @impl true
-  def handle_params(params, _uri, socket) do
-    subtab =
-      case params["tab"] do
-        "relationships" -> :relationships
-        "communities" -> :communities
-        _ -> :entities
-      end
-
-    selected_collection = params["collection"]
-
-    {:noreply,
-     socket
-     |> assign(current_subtab: subtab, selected_collection: selected_collection)
-     |> load_data()}
-  end
-
-  defp load_data(socket) do
-    repo = socket.assigns.repo
-
-    socket
-    |> assign(stats: load_stats(repo))
-    |> load_collections_with_graph_status()
-    |> load_subtab_data()
-  end
-
-  defp load_collections_with_graph_status(socket) do
-    repo = socket.assigns.repo
-
-    collections =
-      repo.all(
-        from(c in Arcana.Collection,
-          left_join: e in Entity,
-          on: e.collection_id == c.id,
-          group_by: c.id,
-          order_by: c.name,
-          select: %{
-            id: c.id,
-            name: c.name,
-            description: c.description,
-            entity_count: count(e.id, :distinct)
-          }
-        )
-      )
-      |> Enum.map(fn c ->
-        Map.put(c, :graph_enabled, c.entity_count > 0)
-      end)
-
-    assign(socket, collections: collections)
-  end
-
-  defp load_subtab_data(%{assigns: %{current_subtab: :entities}} = socket) do
-    load_entities(socket)
-  end
-
-  defp load_subtab_data(%{assigns: %{current_subtab: :relationships}} = socket) do
-    load_relationships(socket)
-  end
-
-  defp load_subtab_data(%{assigns: %{current_subtab: :communities}} = socket) do
-    load_communities(socket)
-  end
-
-  defp load_entities(socket) do
-    repo = socket.assigns.repo
-    collection_id = get_selected_collection_id(socket)
-    name_filter = socket.assigns.entity_filter || ""
-    type_filter = socket.assigns.entity_type_filter
-    page = socket.assigns.entities_page
-
-    offset = (page - 1) * @page_size
-
-    opts =
-      [repo: repo, limit: @page_size, offset: offset]
-      |> maybe_add_opt(:collection_id, collection_id)
-      |> maybe_add_opt(:search, if(name_filter != "", do: name_filter))
-      |> maybe_add_opt(:type, if(type_filter && type_filter != "", do: type_filter))
-
-    entities = GraphStore.list_entities(opts)
-    total = count_entities(repo, collection_id, name_filter, type_filter)
-    entity_types = load_entity_types(repo, collection_id)
-
-    assign(socket, entities: entities, entities_total: total, entity_types: entity_types)
-  end
-
-  defp count_entities(repo, collection_id, name_filter, type_filter) do
-    query = from(e in Entity, select: count(e.id))
-
-    query =
-      if collection_id, do: where(query, [e], e.collection_id == ^collection_id), else: query
-
-    query =
-      if name_filter && name_filter != "",
-        do: where(query, [e], ilike(e.name, ^"%#{name_filter}%")),
-        else: query
-
-    query =
-      if type_filter && type_filter != "",
-        do: where(query, [e], e.type == ^type_filter),
-        else: query
-
-    repo.one(query) || 0
-  rescue
-    _ -> 0
-  end
-
-  defp load_entity_types(repo, collection_id) do
-    query =
-      from(e in Entity,
-        group_by: e.type,
-        select: %{type: e.type, count: count(e.id)},
-        order_by: [desc: count(e.id), asc: e.type]
-      )
-
-    query =
-      if collection_id, do: where(query, [e], e.collection_id == ^collection_id), else: query
-
-    repo.all(query)
-    |> Enum.map(& &1.type)
-  rescue
-    _ -> []
-  end
-
-  defp load_relationship_types(repo, collection_id) do
-    query =
-      from(r in Relationship,
-        join: source in Entity,
-        on: source.id == r.source_id,
-        group_by: r.type,
-        select: %{type: r.type, count: count(r.id)},
-        order_by: [desc: count(r.id), asc: r.type],
-        limit: 100
-      )
-
-    query =
-      if collection_id,
-        do: where(query, [r, source], source.collection_id == ^collection_id),
-        else: query
-
-    repo.all(query)
-    |> Enum.map(& &1.type)
-  rescue
-    _ -> []
-  end
-
-  defp load_relationships(socket) do
-    repo = socket.assigns.repo
-    collection_id = get_selected_collection_id(socket)
-    search_filter = socket.assigns.relationship_filter
-    type_filter = socket.assigns.relationship_type_filter
-    strength_filter = socket.assigns.relationship_strength_filter
-    page = socket.assigns.relationships_page
-
-    offset = (page - 1) * @page_size
-
-    opts =
-      [repo: repo, limit: @page_size, offset: offset]
-      |> maybe_add_opt(:collection_id, collection_id)
-      |> maybe_add_opt(:search, if(search_filter && search_filter != "", do: search_filter))
-      |> maybe_add_opt(:type, if(type_filter && type_filter != "", do: type_filter))
-      |> maybe_add_opt(:strength, strength_filter)
-
-    relationships = GraphStore.list_relationships(opts)
-    total = count_relationships(repo, collection_id, search_filter, type_filter, strength_filter)
-    relationship_types = load_relationship_types(repo, collection_id)
-
-    assign(socket,
-      relationships: relationships,
-      relationships_total: total,
-      relationship_types: relationship_types
-    )
-  end
-
-  defp count_relationships(repo, collection_id, search_filter, type_filter, strength_filter) do
-    query =
-      from(r in Relationship,
-        join: source in Entity,
-        on: source.id == r.source_id,
-        select: count(r.id)
-      )
-
-    query =
-      if collection_id,
-        do: where(query, [r, source], source.collection_id == ^collection_id),
-        else: query
-
-    query =
-      if search_filter && search_filter != "" do
-        search_pattern = "%#{search_filter}%"
-
-        from([r, source] in query,
-          join: target in Entity,
-          on: target.id == r.target_id,
-          where:
-            ilike(source.name, ^search_pattern) or
-              ilike(target.name, ^search_pattern) or
-              ilike(r.type, ^search_pattern)
-        )
-      else
-        query
-      end
-
-    query =
-      if type_filter && type_filter != "",
-        do: where(query, [r], r.type == ^type_filter),
-        else: query
-
-    query =
-      case strength_filter do
-        "strong" -> where(query, [r], r.strength >= 7)
-        "medium" -> where(query, [r], r.strength >= 4 and r.strength < 7)
-        "weak" -> where(query, [r], r.strength < 4)
-        _ -> query
-      end
-
-    repo.one(query) || 0
-  rescue
-    _ -> 0
-  end
-
-  defp load_communities(socket) do
-    repo = socket.assigns.repo
-    collection_id = get_selected_collection_id(socket)
-    search_filter = socket.assigns.community_filter
-    level_filter = socket.assigns.community_level_filter
-    page = socket.assigns.communities_page
-
-    offset = (page - 1) * @page_size
-
-    # Parse level filter to integer if it's a string
-    level = parse_level_filter(level_filter)
-
-    opts =
-      [repo: repo, limit: @page_size, offset: offset]
-      |> maybe_add_opt(:collection_id, collection_id)
-      |> maybe_add_opt(:search, if(search_filter && search_filter != "", do: search_filter))
-      |> maybe_add_opt(:level, level)
-
-    communities = GraphStore.list_communities(opts)
-    total = count_communities(repo, collection_id, search_filter, level)
-
-    assign(socket, communities: communities, communities_total: total)
-  end
-
-  defp parse_level_filter(nil), do: nil
-  defp parse_level_filter(""), do: nil
-  defp parse_level_filter(level) when is_integer(level), do: level
-
-  defp parse_level_filter(level) when is_binary(level) do
-    case Integer.parse(level) do
-      {int, _} -> int
-      :error -> nil
+      {:ok,
+       socket
+       |> assign(repo: repo)
+       |> assign(
+         current_subtab: :entities,
+         selected_collection: nil,
+         collections: [],
+         entities: [],
+         relationships: [],
+         communities: [],
+         stats: nil,
+         entity_filter: "",
+         entity_type_filter: nil,
+         entity_types: [],
+         selected_entity: nil,
+         entity_details: nil,
+         entities_page: 1,
+         entities_total: 0,
+         relationship_filter: "",
+         relationship_type_filter: nil,
+         relationship_types: [],
+         relationship_strength_filter: nil,
+         selected_relationship: nil,
+         relationship_details: nil,
+         relationships_page: 1,
+         relationships_total: 0,
+         community_filter: "",
+         community_level_filter: nil,
+         selected_community: nil,
+         community_details: nil,
+         communities_page: 1,
+         communities_total: 0
+       )}
     end
-  end
 
-  defp count_communities(repo, collection_id, search_filter, level) do
-    query = from(c in Community, select: count(c.id))
+    @impl true
+    def handle_params(params, _uri, socket) do
+      subtab =
+        case params["tab"] do
+          "relationships" -> :relationships
+          "communities" -> :communities
+          _ -> :entities
+        end
 
-    query =
-      if collection_id, do: where(query, [c], c.collection_id == ^collection_id), else: query
+      selected_collection = params["collection"]
 
-    query =
-      if search_filter && search_filter != "",
-        do: where(query, [c], ilike(c.summary, ^"%#{search_filter}%")),
-        else: query
-
-    query = if level, do: where(query, [c], c.level == ^level), else: query
-
-    repo.one(query) || 0
-  rescue
-    _ -> 0
-  end
-
-  @impl true
-  def handle_event("switch_subtab", %{"tab" => tab}, socket) do
-    {:noreply, push_patch(socket, to: build_path(socket, tab: tab))}
-  end
-
-  def handle_event("select_collection", %{"collection" => ""}, socket) do
-    {:noreply, push_patch(socket, to: build_path(socket, collection: nil))}
-  end
-
-  def handle_event("select_collection", %{"collection" => collection}, socket) do
-    {:noreply, push_patch(socket, to: build_path(socket, collection: collection))}
-  end
-
-  def handle_event("filter_entities", params, socket) do
-    name_filter = params["name"] || ""
-    type_filter = params["type"]
-
-    {:noreply,
-     socket
-     |> assign(entity_filter: name_filter, entity_type_filter: type_filter, entities_page: 1)
-     |> load_entities()}
-  end
-
-  def handle_event("select_entity", %{"id" => id}, socket) do
-    details = load_entity_details(socket.assigns.repo, id)
-    {:noreply, assign(socket, selected_entity: id, entity_details: details)}
-  end
-
-  def handle_event("close_entity_detail", _params, socket) do
-    {:noreply, assign(socket, selected_entity: nil, entity_details: nil)}
-  end
-
-  def handle_event("filter_relationships", params, socket) do
-    search_filter = params["search"] || ""
-    type_filter = params["type"]
-    strength_filter = params["strength"]
-
-    {:noreply,
-     socket
-     |> assign(
-       relationship_filter: search_filter,
-       relationship_type_filter: type_filter,
-       relationship_strength_filter: strength_filter,
-       relationships_page: 1
-     )
-     |> load_relationships()}
-  end
-
-  def handle_event("select_relationship", %{"id" => id}, socket) do
-    details = load_relationship_details(socket.assigns.repo, id)
-    {:noreply, assign(socket, selected_relationship: id, relationship_details: details)}
-  end
-
-  def handle_event("close_relationship_detail", _params, socket) do
-    {:noreply, assign(socket, selected_relationship: nil, relationship_details: nil)}
-  end
-
-  def handle_event("filter_communities", params, socket) do
-    search_filter = params["search"] || ""
-    level_filter = params["level"]
-
-    {:noreply,
-     socket
-     |> assign(
-       community_filter: search_filter,
-       community_level_filter: level_filter,
-       communities_page: 1
-     )
-     |> load_communities()}
-  end
-
-  def handle_event("select_community", %{"id" => id}, socket) do
-    details = load_community_details(socket.assigns.repo, id)
-    {:noreply, assign(socket, selected_community: id, community_details: details)}
-  end
-
-  def handle_event("close_community_detail", _params, socket) do
-    {:noreply, assign(socket, selected_community: nil, community_details: nil)}
-  end
-
-  # Pagination handlers
-  def handle_event("entities_page", %{"page" => page}, socket) do
-    page = String.to_integer(page)
-    {:noreply, socket |> assign(entities_page: page) |> load_entities()}
-  end
-
-  def handle_event("relationships_page", %{"page" => page}, socket) do
-    page = String.to_integer(page)
-    {:noreply, socket |> assign(relationships_page: page) |> load_relationships()}
-  end
-
-  def handle_event("communities_page", %{"page" => page}, socket) do
-    page = String.to_integer(page)
-    {:noreply, socket |> assign(communities_page: page) |> load_communities()}
-  end
-
-  defp load_relationship_details(repo, relationship_id) do
-    case GraphStore.get_relationship(relationship_id, repo: repo) do
-      {:ok, relationship} -> %{relationship: relationship}
-      {:error, :not_found} -> %{relationship: nil}
+      {:noreply,
+       socket
+       |> assign(current_subtab: subtab, selected_collection: selected_collection)
+       |> load_data()}
     end
-  end
 
-  defp load_entity_details(repo, entity_id) do
-    entity =
-      case GraphStore.get_entity(entity_id, repo: repo) do
-        {:ok, e} -> e
+    defp load_data(socket) do
+      repo = socket.assigns.repo
+
+      socket
+      |> assign(stats: load_stats(repo))
+      |> load_collections_with_graph_status()
+      |> load_subtab_data()
+    end
+
+    defp load_collections_with_graph_status(socket) do
+      repo = socket.assigns.repo
+
+      collections =
+        repo.all(
+          from(c in Arcana.Collection,
+            left_join: e in Entity,
+            on: e.collection_id == c.id,
+            group_by: c.id,
+            order_by: c.name,
+            select: %{
+              id: c.id,
+              name: c.name,
+              description: c.description,
+              entity_count: count(e.id, :distinct)
+            }
+          )
+        )
+        |> Enum.map(fn c ->
+          Map.put(c, :graph_enabled, c.entity_count > 0)
+        end)
+
+      assign(socket, collections: collections)
+    end
+
+    defp load_subtab_data(%{assigns: %{current_subtab: :entities}} = socket) do
+      load_entities(socket)
+    end
+
+    defp load_subtab_data(%{assigns: %{current_subtab: :relationships}} = socket) do
+      load_relationships(socket)
+    end
+
+    defp load_subtab_data(%{assigns: %{current_subtab: :communities}} = socket) do
+      load_communities(socket)
+    end
+
+    defp load_entities(socket) do
+      repo = socket.assigns.repo
+      collection_id = get_selected_collection_id(socket)
+      name_filter = socket.assigns.entity_filter || ""
+      type_filter = socket.assigns.entity_type_filter
+      page = socket.assigns.entities_page
+
+      offset = (page - 1) * @page_size
+
+      opts =
+        [repo: repo, limit: @page_size, offset: offset]
+        |> maybe_add_opt(:collection_id, collection_id)
+        |> maybe_add_opt(:search, if(name_filter != "", do: name_filter))
+        |> maybe_add_opt(:type, if(type_filter && type_filter != "", do: type_filter))
+
+      entities = GraphStore.list_entities(opts)
+      total = count_entities(repo, collection_id, name_filter, type_filter)
+      entity_types = load_entity_types(repo, collection_id)
+
+      assign(socket, entities: entities, entities_total: total, entity_types: entity_types)
+    end
+
+    defp count_entities(repo, collection_id, name_filter, type_filter) do
+      query = from(e in Entity, select: count(e.id))
+
+      query =
+        if collection_id, do: where(query, [e], e.collection_id == ^collection_id), else: query
+
+      query =
+        if name_filter && name_filter != "",
+          do: where(query, [e], ilike(e.name, ^"%#{name_filter}%")),
+          else: query
+
+      query =
+        if type_filter && type_filter != "",
+          do: where(query, [e], e.type == ^type_filter),
+          else: query
+
+      repo.one(query) || 0
+    rescue
+      _ -> 0
+    end
+
+    defp load_entity_types(repo, collection_id) do
+      query =
+        from(e in Entity,
+          group_by: e.type,
+          select: %{type: e.type, count: count(e.id)},
+          order_by: [desc: count(e.id), asc: e.type]
+        )
+
+      query =
+        if collection_id, do: where(query, [e], e.collection_id == ^collection_id), else: query
+
+      repo.all(query)
+      |> Enum.map(& &1.type)
+    rescue
+      _ -> []
+    end
+
+    defp load_relationship_types(repo, collection_id) do
+      query =
+        from(r in Relationship,
+          join: source in Entity,
+          on: source.id == r.source_id,
+          group_by: r.type,
+          select: %{type: r.type, count: count(r.id)},
+          order_by: [desc: count(r.id), asc: r.type],
+          limit: 100
+        )
+
+      query =
+        if collection_id,
+          do: where(query, [r, source], source.collection_id == ^collection_id),
+          else: query
+
+      repo.all(query)
+      |> Enum.map(& &1.type)
+    rescue
+      _ -> []
+    end
+
+    defp load_relationships(socket) do
+      repo = socket.assigns.repo
+      collection_id = get_selected_collection_id(socket)
+      search_filter = socket.assigns.relationship_filter
+      type_filter = socket.assigns.relationship_type_filter
+      strength_filter = socket.assigns.relationship_strength_filter
+      page = socket.assigns.relationships_page
+
+      offset = (page - 1) * @page_size
+
+      opts =
+        [repo: repo, limit: @page_size, offset: offset]
+        |> maybe_add_opt(:collection_id, collection_id)
+        |> maybe_add_opt(:search, if(search_filter && search_filter != "", do: search_filter))
+        |> maybe_add_opt(:type, if(type_filter && type_filter != "", do: type_filter))
+        |> maybe_add_opt(:strength, strength_filter)
+
+      relationships = GraphStore.list_relationships(opts)
+
+      total =
+        count_relationships(repo, collection_id, search_filter, type_filter, strength_filter)
+
+      relationship_types = load_relationship_types(repo, collection_id)
+
+      assign(socket,
+        relationships: relationships,
+        relationships_total: total,
+        relationship_types: relationship_types
+      )
+    end
+
+    defp count_relationships(repo, collection_id, search_filter, type_filter, strength_filter) do
+      query =
+        from(r in Relationship,
+          join: source in Entity,
+          on: source.id == r.source_id,
+          select: count(r.id)
+        )
+
+      query =
+        if collection_id,
+          do: where(query, [r, source], source.collection_id == ^collection_id),
+          else: query
+
+      query =
+        if search_filter && search_filter != "" do
+          search_pattern = "%#{search_filter}%"
+
+          from([r, source] in query,
+            join: target in Entity,
+            on: target.id == r.target_id,
+            where:
+              ilike(source.name, ^search_pattern) or
+                ilike(target.name, ^search_pattern) or
+                ilike(r.type, ^search_pattern)
+          )
+        else
+          query
+        end
+
+      query =
+        if type_filter && type_filter != "",
+          do: where(query, [r], r.type == ^type_filter),
+          else: query
+
+      query =
+        case strength_filter do
+          "strong" -> where(query, [r], r.strength >= 7)
+          "medium" -> where(query, [r], r.strength >= 4 and r.strength < 7)
+          "weak" -> where(query, [r], r.strength < 4)
+          _ -> query
+        end
+
+      repo.one(query) || 0
+    rescue
+      _ -> 0
+    end
+
+    defp load_communities(socket) do
+      repo = socket.assigns.repo
+      collection_id = get_selected_collection_id(socket)
+      search_filter = socket.assigns.community_filter
+      level_filter = socket.assigns.community_level_filter
+      page = socket.assigns.communities_page
+
+      offset = (page - 1) * @page_size
+
+      # Parse level filter to integer if it's a string
+      level = parse_level_filter(level_filter)
+
+      opts =
+        [repo: repo, limit: @page_size, offset: offset]
+        |> maybe_add_opt(:collection_id, collection_id)
+        |> maybe_add_opt(:search, if(search_filter && search_filter != "", do: search_filter))
+        |> maybe_add_opt(:level, level)
+
+      communities = GraphStore.list_communities(opts)
+      total = count_communities(repo, collection_id, search_filter, level)
+
+      assign(socket, communities: communities, communities_total: total)
+    end
+
+    defp parse_level_filter(nil), do: nil
+    defp parse_level_filter(""), do: nil
+    defp parse_level_filter(level) when is_integer(level), do: level
+
+    defp parse_level_filter(level) when is_binary(level) do
+      case Integer.parse(level) do
+        {int, _} -> int
+        :error -> nil
+      end
+    end
+
+    defp count_communities(repo, collection_id, search_filter, level) do
+      query = from(c in Community, select: count(c.id))
+
+      query =
+        if collection_id, do: where(query, [c], c.collection_id == ^collection_id), else: query
+
+      query =
+        if search_filter && search_filter != "",
+          do: where(query, [c], ilike(c.summary, ^"%#{search_filter}%")),
+          else: query
+
+      query = if level, do: where(query, [c], c.level == ^level), else: query
+
+      repo.one(query) || 0
+    rescue
+      _ -> 0
+    end
+
+    @impl true
+    def handle_event("switch_subtab", %{"tab" => tab}, socket) do
+      {:noreply, push_patch(socket, to: build_path(socket, tab: tab))}
+    end
+
+    def handle_event("select_collection", %{"collection" => ""}, socket) do
+      {:noreply, push_patch(socket, to: build_path(socket, collection: nil))}
+    end
+
+    def handle_event("select_collection", %{"collection" => collection}, socket) do
+      {:noreply, push_patch(socket, to: build_path(socket, collection: collection))}
+    end
+
+    def handle_event("filter_entities", params, socket) do
+      name_filter = params["name"] || ""
+      type_filter = params["type"]
+
+      {:noreply,
+       socket
+       |> assign(entity_filter: name_filter, entity_type_filter: type_filter, entities_page: 1)
+       |> load_entities()}
+    end
+
+    def handle_event("select_entity", %{"id" => id}, socket) do
+      details = load_entity_details(socket.assigns.repo, id)
+      {:noreply, assign(socket, selected_entity: id, entity_details: details)}
+    end
+
+    def handle_event("close_entity_detail", _params, socket) do
+      {:noreply, assign(socket, selected_entity: nil, entity_details: nil)}
+    end
+
+    def handle_event("filter_relationships", params, socket) do
+      search_filter = params["search"] || ""
+      type_filter = params["type"]
+      strength_filter = params["strength"]
+
+      {:noreply,
+       socket
+       |> assign(
+         relationship_filter: search_filter,
+         relationship_type_filter: type_filter,
+         relationship_strength_filter: strength_filter,
+         relationships_page: 1
+       )
+       |> load_relationships()}
+    end
+
+    def handle_event("select_relationship", %{"id" => id}, socket) do
+      details = load_relationship_details(socket.assigns.repo, id)
+      {:noreply, assign(socket, selected_relationship: id, relationship_details: details)}
+    end
+
+    def handle_event("close_relationship_detail", _params, socket) do
+      {:noreply, assign(socket, selected_relationship: nil, relationship_details: nil)}
+    end
+
+    def handle_event("filter_communities", params, socket) do
+      search_filter = params["search"] || ""
+      level_filter = params["level"]
+
+      {:noreply,
+       socket
+       |> assign(
+         community_filter: search_filter,
+         community_level_filter: level_filter,
+         communities_page: 1
+       )
+       |> load_communities()}
+    end
+
+    def handle_event("select_community", %{"id" => id}, socket) do
+      details = load_community_details(socket.assigns.repo, id)
+      {:noreply, assign(socket, selected_community: id, community_details: details)}
+    end
+
+    def handle_event("close_community_detail", _params, socket) do
+      {:noreply, assign(socket, selected_community: nil, community_details: nil)}
+    end
+
+    # Pagination handlers
+    def handle_event("entities_page", %{"page" => page}, socket) do
+      page = String.to_integer(page)
+      {:noreply, socket |> assign(entities_page: page) |> load_entities()}
+    end
+
+    def handle_event("relationships_page", %{"page" => page}, socket) do
+      page = String.to_integer(page)
+      {:noreply, socket |> assign(relationships_page: page) |> load_relationships()}
+    end
+
+    def handle_event("communities_page", %{"page" => page}, socket) do
+      page = String.to_integer(page)
+      {:noreply, socket |> assign(communities_page: page) |> load_communities()}
+    end
+
+    defp load_relationship_details(repo, relationship_id) do
+      case GraphStore.get_relationship(relationship_id, repo: repo) do
+        {:ok, relationship} -> %{relationship: relationship}
+        {:error, :not_found} -> %{relationship: nil}
+      end
+    end
+
+    defp load_entity_details(repo, entity_id) do
+      entity =
+        case GraphStore.get_entity(entity_id, repo: repo) do
+          {:ok, e} -> e
+          {:error, :not_found} -> nil
+        end
+
+      relationships = GraphStore.get_relationships(entity_id, repo: repo)
+      mentions = GraphStore.get_mentions(entity_id, repo: repo, limit: 5)
+
+      %{entity: entity, relationships: relationships, mentions: mentions}
+    end
+
+    defp load_community_details(repo, community_id) do
+      case GraphStore.get_community(community_id, repo: repo) do
+        {:ok, community} ->
+          build_community_details(community, repo)
+
+        {:error, :not_found} ->
+          %{community: nil, entities: [], internal_relationships: []}
+      end
+    end
+
+    defp build_community_details(community, repo) do
+      entity_ids = community.entity_ids || []
+
+      entities = load_community_entities(entity_ids, repo)
+      internal_relationships = load_internal_relationships(entity_ids, repo)
+
+      %{community: community, entities: entities, internal_relationships: internal_relationships}
+    end
+
+    defp load_community_entities(entity_ids, repo) do
+      entity_ids
+      |> Enum.map(&fetch_entity_summary(&1, repo))
+      |> Enum.reject(&is_nil/1)
+    end
+
+    defp fetch_entity_summary(id, repo) do
+      case GraphStore.get_entity(id, repo: repo) do
+        {:ok, entity} -> %{id: entity.id, name: entity.name, type: entity.type}
         {:error, :not_found} -> nil
       end
-
-    relationships = GraphStore.get_relationships(entity_id, repo: repo)
-    mentions = GraphStore.get_mentions(entity_id, repo: repo, limit: 5)
-
-    %{entity: entity, relationships: relationships, mentions: mentions}
-  end
-
-  defp load_community_details(repo, community_id) do
-    case GraphStore.get_community(community_id, repo: repo) do
-      {:ok, community} ->
-        build_community_details(community, repo)
-
-      {:error, :not_found} ->
-        %{community: nil, entities: [], internal_relationships: []}
     end
-  end
 
-  defp build_community_details(community, repo) do
-    entity_ids = community.entity_ids || []
+    defp load_internal_relationships(entity_ids, _repo) when length(entity_ids) < 2, do: []
 
-    entities = load_community_entities(entity_ids, repo)
-    internal_relationships = load_internal_relationships(entity_ids, repo)
-
-    %{community: community, entities: entities, internal_relationships: internal_relationships}
-  end
-
-  defp load_community_entities(entity_ids, repo) do
-    entity_ids
-    |> Enum.map(&fetch_entity_summary(&1, repo))
-    |> Enum.reject(&is_nil/1)
-  end
-
-  defp fetch_entity_summary(id, repo) do
-    case GraphStore.get_entity(id, repo: repo) do
-      {:ok, entity} -> %{id: entity.id, name: entity.name, type: entity.type}
-      {:error, :not_found} -> nil
+    defp load_internal_relationships(entity_ids, repo) do
+      entity_ids
+      |> Enum.flat_map(fn id -> GraphStore.get_relationships(id, repo: repo) end)
+      |> Enum.filter(fn rel -> rel.source_id in entity_ids and rel.target_id in entity_ids end)
+      |> Enum.uniq_by(& &1.id)
     end
-  end
 
-  defp load_internal_relationships(entity_ids, _repo) when length(entity_ids) < 2, do: []
+    defp build_path(socket, overrides) do
+      tab = Keyword.get(overrides, :tab, Atom.to_string(socket.assigns.current_subtab))
 
-  defp load_internal_relationships(entity_ids, repo) do
-    entity_ids
-    |> Enum.flat_map(fn id -> GraphStore.get_relationships(id, repo: repo) end)
-    |> Enum.filter(fn rel -> rel.source_id in entity_ids and rel.target_id in entity_ids end)
-    |> Enum.uniq_by(& &1.id)
-  end
+      collection =
+        case Keyword.fetch(overrides, :collection) do
+          {:ok, nil} -> nil
+          {:ok, c} -> c
+          :error -> socket.assigns.selected_collection
+        end
 
-  defp build_path(socket, overrides) do
-    tab = Keyword.get(overrides, :tab, Atom.to_string(socket.assigns.current_subtab))
+      params =
+        [tab: tab, collection: collection]
+        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+        |> Enum.into(%{})
 
-    collection =
-      case Keyword.fetch(overrides, :collection) do
-        {:ok, nil} -> nil
-        {:ok, c} -> c
-        :error -> socket.assigns.selected_collection
+      "#{socket.assigns.prefix}/graph?" <> URI.encode_query(params)
+    end
+
+    defp has_any_graph_data?(collections) do
+      Enum.any?(collections, & &1.graph_enabled)
+    end
+
+    defp get_selected_collection_id(socket) do
+      selected_name = socket.assigns.selected_collection
+
+      if selected_name do
+        socket.assigns.collections
+        |> Enum.find(fn c -> c.name == selected_name end)
+        |> case do
+          nil -> nil
+          collection -> collection.id
+        end
+      else
+        nil
       end
-
-    params =
-      [tab: tab, collection: collection]
-      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-      |> Enum.into(%{})
-
-    "#{socket.assigns.prefix}/graph?" <> URI.encode_query(params)
-  end
-
-  defp has_any_graph_data?(collections) do
-    Enum.any?(collections, & &1.graph_enabled)
-  end
-
-  defp get_selected_collection_id(socket) do
-    selected_name = socket.assigns.selected_collection
-
-    if selected_name do
-      socket.assigns.collections
-      |> Enum.find(fn c -> c.name == selected_name end)
-      |> case do
-        nil -> nil
-        collection -> collection.id
-      end
-    else
-      nil
     end
-  end
 
-  defp maybe_add_opt(opts, _key, nil), do: opts
-  defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+    defp maybe_add_opt(opts, _key, nil), do: opts
+    defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
 
-  defp total_pages(total) do
-    max(1, ceil(total / @page_size))
-  end
+    defp total_pages(total) do
+      max(1, ceil(total / @page_size))
+    end
 
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:graph} prefix={@prefix}>
-      <div class="arcana-graph">
-        <h2>Graph</h2>
-        <p class="arcana-tab-description">
-          Explore entities, relationships, and communities extracted from your documents.
-        </p>
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.dashboard_layout stats={@stats} current_tab={:graph} prefix={@prefix}>
+        <div class="arcana-graph">
+          <h2>Graph</h2>
+          <p class="arcana-tab-description">
+            Explore entities, relationships, and communities extracted from your documents.
+          </p>
 
-        <div class="arcana-collection-selector">
-          <label>Collection:</label>
-          <select phx-change="select_collection" name="collection">
-            <option value="">All Collections</option>
-            <%= for coll <- @collections do %>
-              <option value={coll.name} selected={@selected_collection == coll.name}>
-                <%= coll.name %>
-                <%= if coll.graph_enabled, do: "✓", else: "✗" %>
+          <div class="arcana-collection-selector">
+            <label>Collection:</label>
+            <select phx-change="select_collection" name="collection">
+              <option value="">All Collections</option>
+              <%= for coll <- @collections do %>
+                <option value={coll.name} selected={@selected_collection == coll.name}>
+                  <%= coll.name %>
+                  <%= if coll.graph_enabled, do: "✓", else: "✗" %>
+                </option>
+              <% end %>
+            </select>
+          </div>
+
+          <%= if not has_any_graph_data?(@collections) do %>
+            <div class="arcana-empty-state">
+              <h3>No Graph Data Yet</h3>
+              <p>Enable GraphRAG during document ingestion:</p>
+              <pre><code>Arcana.ingest(text, repo: Repo, graph: true)</code></pre>
+              <p>This extracts entities and relationships to enhance search.</p>
+            </div>
+          <% else %>
+            <div class="arcana-graph-subtabs">
+              <button
+                class={"arcana-subtab-btn #{if @current_subtab == :entities, do: "active", else: ""}"}
+                phx-click="switch_subtab"
+                phx-value-tab="entities"
+              >
+                Entities
+              </button>
+              <button
+                class={"arcana-subtab-btn #{if @current_subtab == :relationships, do: "active", else: ""}"}
+                phx-click="switch_subtab"
+                phx-value-tab="relationships"
+              >
+                Relationships
+              </button>
+              <button
+                class={"arcana-subtab-btn #{if @current_subtab == :communities, do: "active", else: ""}"}
+                phx-click="switch_subtab"
+                phx-value-tab="communities"
+              >
+                Communities
+              </button>
+            </div>
+
+            <%= case @current_subtab do %>
+              <% :entities -> %>
+                <.entities_view
+                  prefix={@prefix}
+                  entities={@entities}
+                  entity_filter={@entity_filter}
+                  entity_type_filter={@entity_type_filter}
+                  entity_types={@entity_types}
+                  selected_entity={@selected_entity}
+                  entity_details={@entity_details}
+                  page={@entities_page}
+                  total={@entities_total}
+                  total_pages={total_pages(@entities_total)}
+                />
+              <% :relationships -> %>
+                <.relationships_view
+                  relationships={@relationships}
+                  relationship_filter={@relationship_filter}
+                  relationship_type_filter={@relationship_type_filter}
+                  relationship_types={@relationship_types}
+                  relationship_strength_filter={@relationship_strength_filter}
+                  selected_relationship={@selected_relationship}
+                  relationship_details={@relationship_details}
+                  page={@relationships_page}
+                  total={@relationships_total}
+                  total_pages={total_pages(@relationships_total)}
+                />
+              <% :communities -> %>
+                <.communities_view
+                  communities={@communities}
+                  community_filter={@community_filter}
+                  community_level_filter={@community_level_filter}
+                  selected_community={@selected_community}
+                  community_details={@community_details}
+                  page={@communities_page}
+                  total={@communities_total}
+                  total_pages={total_pages(@communities_total)}
+                />
+            <% end %>
+          <% end %>
+        </div>
+      </.dashboard_layout>
+      """
+    end
+
+    defp entities_view(assigns) do
+      ~H"""
+      <div class="arcana-entities-view">
+        <form phx-change="filter_entities" class="arcana-filter-bar">
+          <input
+            type="text"
+            name="name"
+            value={@entity_filter}
+            placeholder="Search entities..."
+            class="arcana-input"
+            phx-debounce="300"
+          />
+          <select name="type" class="arcana-input">
+            <option value="">All Types</option>
+            <%= for entity_type <- @entity_types do %>
+              <option value={entity_type} selected={@entity_type_filter == entity_type}>
+                <%= String.capitalize(entity_type) %>
               </option>
             <% end %>
           </select>
-        </div>
+        </form>
 
-        <%= if not has_any_graph_data?(@collections) do %>
-          <div class="arcana-empty-state">
-            <h3>No Graph Data Yet</h3>
-            <p>Enable GraphRAG during document ingestion:</p>
-            <pre><code>Arcana.ingest(text, repo: Repo, graph: true)</code></pre>
-            <p>This extracts entities and relationships to enhance search.</p>
-          </div>
+        <%= if Enum.empty?(@entities) do %>
+          <div class="arcana-empty">No entities found matching your criteria.</div>
         <% else %>
-          <div class="arcana-graph-subtabs">
-            <button
-              class={"arcana-subtab-btn #{if @current_subtab == :entities, do: "active", else: ""}"}
-              phx-click="switch_subtab"
-              phx-value-tab="entities"
-            >
-              Entities
-            </button>
-            <button
-              class={"arcana-subtab-btn #{if @current_subtab == :relationships, do: "active", else: ""}"}
-              phx-click="switch_subtab"
-              phx-value-tab="relationships"
-            >
-              Relationships
-            </button>
-            <button
-              class={"arcana-subtab-btn #{if @current_subtab == :communities, do: "active", else: ""}"}
-              phx-click="switch_subtab"
-              phx-value-tab="communities"
-            >
-              Communities
-            </button>
-          </div>
+          <table class="arcana-table arcana-graph-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Mentions</th>
+                <th>Relationships</th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= for entity <- @entities do %>
+                <tr
+                  id={"entity-#{entity.id}"}
+                  class={"arcana-entity-row #{if @selected_entity == entity.id, do: "selected", else: ""}"}
+                  phx-click="select_entity"
+                  phx-value-id={entity.id}
+                >
+                  <td><%= entity.name %></td>
+                  <td>
+                    <span class={"arcana-entity-type-badge #{entity.type}"}>
+                      <%= entity.type %>
+                    </span>
+                  </td>
+                  <td><%= entity.mention_count %></td>
+                  <td><%= entity.relationship_count %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
 
-          <%= case @current_subtab do %>
-            <% :entities -> %>
-              <.entities_view
-                prefix={@prefix}
-                entities={@entities}
-                entity_filter={@entity_filter}
-                entity_type_filter={@entity_type_filter}
-                entity_types={@entity_types}
-                selected_entity={@selected_entity}
-                entity_details={@entity_details}
-                page={@entities_page}
-                total={@entities_total}
-                total_pages={total_pages(@entities_total)}
-              />
-            <% :relationships -> %>
-              <.relationships_view
-                relationships={@relationships}
-                relationship_filter={@relationship_filter}
-                relationship_type_filter={@relationship_type_filter}
-                relationship_types={@relationship_types}
-                relationship_strength_filter={@relationship_strength_filter}
-                selected_relationship={@selected_relationship}
-                relationship_details={@relationship_details}
-                page={@relationships_page}
-                total={@relationships_total}
-                total_pages={total_pages(@relationships_total)}
-              />
-            <% :communities -> %>
-              <.communities_view
-                communities={@communities}
-                community_filter={@community_filter}
-                community_level_filter={@community_level_filter}
-                selected_community={@selected_community}
-                community_details={@community_details}
-                page={@communities_page}
-                total={@communities_total}
-                total_pages={total_pages(@communities_total)}
-              />
-          <% end %>
+          <.pagination
+            page={@page}
+            total={@total}
+            total_pages={@total_pages}
+            event="entities_page"
+          />
+        <% end %>
+
+        <%= if @entity_details do %>
+          <.entity_detail_panel details={@entity_details} prefix={@prefix} />
         <% end %>
       </div>
-    </.dashboard_layout>
-    """
-  end
+      """
+    end
 
-  defp entities_view(assigns) do
-    ~H"""
-    <div class="arcana-entities-view">
-      <form phx-change="filter_entities" class="arcana-filter-bar">
-        <input
-          type="text"
-          name="name"
-          value={@entity_filter}
-          placeholder="Search entities..."
-          class="arcana-input"
-          phx-debounce="300"
-        />
-        <select name="type" class="arcana-input">
-          <option value="">All Types</option>
-          <%= for entity_type <- @entity_types do %>
-            <option value={entity_type} selected={@entity_type_filter == entity_type}>
-              <%= String.capitalize(entity_type) %>
-            </option>
-          <% end %>
-        </select>
-      </form>
+    defp entity_detail_panel(assigns) do
+      ~H"""
+      <div class="arcana-entity-detail">
+        <div class="arcana-entity-detail-header">
+          <h3><%= @details.entity.name %></h3>
+          <span class={"arcana-entity-type-badge #{@details.entity.type}"}>
+            <%= @details.entity.type %>
+          </span>
+          <button class="arcana-entity-detail-close" phx-click="close_entity_detail">×</button>
+        </div>
 
-      <%= if Enum.empty?(@entities) do %>
-        <div class="arcana-empty">No entities found matching your criteria.</div>
-      <% else %>
-        <table class="arcana-table arcana-graph-table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Type</th>
-              <th>Mentions</th>
-              <th>Relationships</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%= for entity <- @entities do %>
-              <tr
-                id={"entity-#{entity.id}"}
-                class={"arcana-entity-row #{if @selected_entity == entity.id, do: "selected", else: ""}"}
-                phx-click="select_entity"
-                phx-value-id={entity.id}
-              >
-                <td><%= entity.name %></td>
-                <td>
-                  <span class={"arcana-entity-type-badge #{entity.type}"}>
-                    <%= entity.type %>
-                  </span>
-                </td>
-                <td><%= entity.mention_count %></td>
-                <td><%= entity.relationship_count %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+        <%= if @details.entity.description do %>
+          <p class="arcana-entity-description"><%= @details.entity.description %></p>
+        <% end %>
 
-        <.pagination
-          page={@page}
-          total={@total}
-          total_pages={@total_pages}
-          event="entities_page"
-        />
-      <% end %>
+        <%= if Enum.any?(@details.relationships) do %>
+          <div class="arcana-entity-relationships">
+            <h4>Relationships</h4>
+            <div class="arcana-rel-cards">
+              <%= for rel <- @details.relationships do %>
+                <div class="arcana-rel-card">
+                  <%= if rel.source_id == @details.entity.id do %>
+                    <span class="arcana-rel-type"><%= rel.type %></span>
+                    <span class="arcana-rel-arrow">→</span>
+                    <span class="arcana-rel-target"><%= rel.target_name %></span>
+                  <% else %>
+                    <span class="arcana-rel-source"><%= rel.source_name %></span>
+                    <span class="arcana-rel-arrow">→</span>
+                    <span class="arcana-rel-type"><%= rel.type %></span>
+                    <span class="arcana-rel-arrow">→</span>
+                    <span class="arcana-rel-self">(this)</span>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
 
-      <%= if @entity_details do %>
-        <.entity_detail_panel details={@entity_details} prefix={@prefix} />
-      <% end %>
-    </div>
-    """
-  end
-
-  defp entity_detail_panel(assigns) do
-    ~H"""
-    <div class="arcana-entity-detail">
-      <div class="arcana-entity-detail-header">
-        <h3><%= @details.entity.name %></h3>
-        <span class={"arcana-entity-type-badge #{@details.entity.type}"}>
-          <%= @details.entity.type %>
-        </span>
-        <button class="arcana-entity-detail-close" phx-click="close_entity_detail">×</button>
-      </div>
-
-      <%= if @details.entity.description do %>
-        <p class="arcana-entity-description"><%= @details.entity.description %></p>
-      <% end %>
-
-      <%= if Enum.any?(@details.relationships) do %>
-        <div class="arcana-entity-relationships">
-          <h4>Relationships</h4>
-          <div class="arcana-rel-cards">
-            <%= for rel <- @details.relationships do %>
-              <div class="arcana-rel-card">
-                <%= if rel.source_id == @details.entity.id do %>
-                  <span class="arcana-rel-type"><%= rel.type %></span>
-                  <span class="arcana-rel-arrow">→</span>
-                  <span class="arcana-rel-target"><%= rel.target_name %></span>
-                <% else %>
-                  <span class="arcana-rel-source"><%= rel.source_name %></span>
-                  <span class="arcana-rel-arrow">→</span>
-                  <span class="arcana-rel-type"><%= rel.type %></span>
-                  <span class="arcana-rel-arrow">→</span>
-                  <span class="arcana-rel-self">(this)</span>
-                <% end %>
+        <%= if Enum.any?(@details.mentions) do %>
+          <div class="arcana-entity-mentions">
+            <h4>Source Chunks</h4>
+            <%= for mention <- @details.mentions do %>
+              <div class="arcana-mention-preview">
+                <p><%= String.slice(mention.context || mention.chunk_text || "", 0, 200) %></p>
+                <a
+                  href={"#{@prefix}/documents?doc=#{mention.document_id}"}
+                  class="arcana-view-in-docs"
+                >
+                  View in Documents →
+                </a>
               </div>
             <% end %>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
+      """
+    end
 
-      <%= if Enum.any?(@details.mentions) do %>
-        <div class="arcana-entity-mentions">
-          <h4>Source Chunks</h4>
-          <%= for mention <- @details.mentions do %>
-            <div class="arcana-mention-preview">
-              <p><%= String.slice(mention.context || mention.chunk_text || "", 0, 200) %></p>
-              <a
-                href={"#{@prefix}/documents?doc=#{mention.document_id}"}
-                class="arcana-view-in-docs"
-              >
-                View in Documents →
-              </a>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-    """
-  end
-
-  defp relationships_view(assigns) do
-    ~H"""
-    <div class="arcana-relationships-view">
-      <form phx-change="filter_relationships" class="arcana-filter-bar">
-        <input
-          type="text"
-          name="search"
-          value={@relationship_filter}
-          placeholder="Search relationships..."
-          class="arcana-input"
-          phx-debounce="300"
-        />
-        <select name="type" class="arcana-input">
-          <option value="">All Types</option>
-          <%= for relationship_type <- @relationship_types do %>
-            <option value={relationship_type} selected={@relationship_type_filter == relationship_type}>
-              <%= relationship_type %>
+    defp relationships_view(assigns) do
+      ~H"""
+      <div class="arcana-relationships-view">
+        <form phx-change="filter_relationships" class="arcana-filter-bar">
+          <input
+            type="text"
+            name="search"
+            value={@relationship_filter}
+            placeholder="Search relationships..."
+            class="arcana-input"
+            phx-debounce="300"
+          />
+          <select name="type" class="arcana-input">
+            <option value="">All Types</option>
+            <%= for relationship_type <- @relationship_types do %>
+              <option value={relationship_type} selected={@relationship_type_filter == relationship_type}>
+                <%= relationship_type %>
+              </option>
+            <% end %>
+          </select>
+          <select name="strength" class="arcana-input">
+            <option value="">Any Strength</option>
+            <option value="strong" selected={@relationship_strength_filter == "strong"}>
+              Strong (7-10)
             </option>
-          <% end %>
-        </select>
-        <select name="strength" class="arcana-input">
-          <option value="">Any Strength</option>
-          <option value="strong" selected={@relationship_strength_filter == "strong"}>
-            Strong (7-10)
-          </option>
-          <option value="medium" selected={@relationship_strength_filter == "medium"}>
-            Medium (4-6)
-          </option>
-          <option value="weak" selected={@relationship_strength_filter == "weak"}>Weak (1-3)</option>
-        </select>
-      </form>
+            <option value="medium" selected={@relationship_strength_filter == "medium"}>
+              Medium (4-6)
+            </option>
+            <option value="weak" selected={@relationship_strength_filter == "weak"}>Weak (1-3)</option>
+          </select>
+        </form>
 
-      <%= if Enum.empty?(@relationships) do %>
-        <div class="arcana-empty">No relationships found matching your criteria.</div>
-      <% else %>
-        <table class="arcana-table arcana-graph-table">
-          <thead>
-            <tr>
-              <th>Source</th>
-              <th>Relationship</th>
-              <th>Target</th>
-              <th>Strength</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%= for rel <- @relationships do %>
-              <tr
-                id={"relationship-#{rel.id}"}
-                class={"arcana-relationship-row #{if @selected_relationship == rel.id, do: "selected", else: ""}"}
-                phx-click="select_relationship"
-                phx-value-id={rel.id}
-              >
-                <td><%= rel.source_name %></td>
-                <td><code><%= rel.type %></code></td>
-                <td><%= rel.target_name %></td>
-                <td><.strength_meter value={rel.strength || 5} /></td>
+        <%= if Enum.empty?(@relationships) do %>
+          <div class="arcana-empty">No relationships found matching your criteria.</div>
+        <% else %>
+          <table class="arcana-table arcana-graph-table">
+            <thead>
+              <tr>
+                <th>Source</th>
+                <th>Relationship</th>
+                <th>Target</th>
+                <th>Strength</th>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              <%= for rel <- @relationships do %>
+                <tr
+                  id={"relationship-#{rel.id}"}
+                  class={"arcana-relationship-row #{if @selected_relationship == rel.id, do: "selected", else: ""}"}
+                  phx-click="select_relationship"
+                  phx-value-id={rel.id}
+                >
+                  <td><%= rel.source_name %></td>
+                  <td><code><%= rel.type %></code></td>
+                  <td><%= rel.target_name %></td>
+                  <td><.strength_meter value={rel.strength || 5} /></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
 
-        <.pagination
-          page={@page}
-          total={@total}
-          total_pages={@total_pages}
-          event="relationships_page"
-        />
-      <% end %>
+          <.pagination
+            page={@page}
+            total={@total}
+            total_pages={@total_pages}
+            event="relationships_page"
+          />
+        <% end %>
 
-      <%= if @relationship_details do %>
-        <.relationship_detail_panel details={@relationship_details} />
-      <% end %>
-    </div>
-    """
-  end
-
-  defp relationship_detail_panel(assigns) do
-    ~H"""
-    <div class="arcana-relationship-detail">
-      <div class="arcana-relationship-detail-header">
-        <div class="arcana-relationship-visual">
-          <span class="arcana-relationship-source"><%= @details.relationship.source_name %></span>
-          <span class="arcana-relationship-arrow">→</span>
-          <code class="arcana-relationship-type"><%= @details.relationship.type %></code>
-          <span class="arcana-relationship-arrow">→</span>
-          <span class="arcana-relationship-target"><%= @details.relationship.target_name %></span>
-        </div>
-        <button class="arcana-relationship-detail-close" phx-click="close_relationship_detail">
-          ×
-        </button>
+        <%= if @relationship_details do %>
+          <.relationship_detail_panel details={@relationship_details} />
+        <% end %>
       </div>
+      """
+    end
 
-      <div class="arcana-relationship-strength">
-        <strong>Strength:</strong> <%= @details.relationship.strength || 5 %>/10
-      </div>
-
-      <%= if @details.relationship.description do %>
-        <p class="arcana-relationship-description"><%= @details.relationship.description %></p>
-      <% end %>
-    </div>
-    """
-  end
-
-  defp communities_view(assigns) do
-    ~H"""
-    <div class="arcana-communities-view">
-      <form phx-change="filter_communities" class="arcana-filter-bar">
-        <input
-          type="text"
-          name="search"
-          value={@community_filter}
-          placeholder="Search communities..."
-          class="arcana-input"
-          phx-debounce="300"
-        />
-        <select name="level" class="arcana-input">
-          <option value="">All Levels</option>
-          <option value="0" selected={@community_level_filter == "0"}>Level 0</option>
-          <option value="1" selected={@community_level_filter == "1"}>Level 1</option>
-          <option value="2" selected={@community_level_filter == "2"}>Level 2</option>
-        </select>
-      </form>
-
-      <%= if Enum.empty?(@communities) do %>
-        <div class="arcana-empty">
-          <p>No Communities Detected</p>
-          <p class="arcana-empty-hint">
-            Communities are generated when there are enough entities
-            and relationships to form meaningful clusters.
-          </p>
+    defp relationship_detail_panel(assigns) do
+      ~H"""
+      <div class="arcana-relationship-detail">
+        <div class="arcana-relationship-detail-header">
+          <div class="arcana-relationship-visual">
+            <span class="arcana-relationship-source"><%= @details.relationship.source_name %></span>
+            <span class="arcana-relationship-arrow">→</span>
+            <code class="arcana-relationship-type"><%= @details.relationship.type %></code>
+            <span class="arcana-relationship-arrow">→</span>
+            <span class="arcana-relationship-target"><%= @details.relationship.target_name %></span>
+          </div>
+          <button class="arcana-relationship-detail-close" phx-click="close_relationship_detail">
+            ×
+          </button>
         </div>
-      <% else %>
-        <table class="arcana-table arcana-graph-table">
-          <thead>
-            <tr>
-              <th>Community</th>
-              <th>Level</th>
-              <th>Entities</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%= for community <- @communities do %>
-              <tr
-                id={"community-#{community.id}"}
-                class={"arcana-community-row #{if @selected_community == community.id, do: "selected", else: ""}"}
-                phx-click="select_community"
-                phx-value-id={community.id}
-              >
-                <td>
-                  <%= if community.summary do %>
-                    <%= String.slice(community.summary, 0, 50) %><%= if String.length(community.summary) > 50, do: "...", else: "" %>
-                  <% else %>
-                    <span class="arcana-no-summary">No summary</span>
-                  <% end %>
-                </td>
-                <td><%= community.level %></td>
-                <td><%= community.entity_count %></td>
-                <td>
-                  <%= cond do %>
-                    <% community.dirty -> %>
-                      <span class="arcana-status-pending" title="Pending regeneration">⟳</span>
-                    <% community.summary -> %>
-                      <span class="arcana-status-ready" title="Summary ready">✓</span>
-                    <% true -> %>
-                      <span class="arcana-status-empty" title="No summary">○</span>
-                  <% end %>
-                </td>
+
+        <div class="arcana-relationship-strength">
+          <strong>Strength:</strong> <%= @details.relationship.strength || 5 %>/10
+        </div>
+
+        <%= if @details.relationship.description do %>
+          <p class="arcana-relationship-description"><%= @details.relationship.description %></p>
+        <% end %>
+      </div>
+      """
+    end
+
+    defp communities_view(assigns) do
+      ~H"""
+      <div class="arcana-communities-view">
+        <form phx-change="filter_communities" class="arcana-filter-bar">
+          <input
+            type="text"
+            name="search"
+            value={@community_filter}
+            placeholder="Search communities..."
+            class="arcana-input"
+            phx-debounce="300"
+          />
+          <select name="level" class="arcana-input">
+            <option value="">All Levels</option>
+            <option value="0" selected={@community_level_filter == "0"}>Level 0</option>
+            <option value="1" selected={@community_level_filter == "1"}>Level 1</option>
+            <option value="2" selected={@community_level_filter == "2"}>Level 2</option>
+          </select>
+        </form>
+
+        <%= if Enum.empty?(@communities) do %>
+          <div class="arcana-empty">
+            <p>No Communities Detected</p>
+            <p class="arcana-empty-hint">
+              Communities are generated when there are enough entities
+              and relationships to form meaningful clusters.
+            </p>
+          </div>
+        <% else %>
+          <table class="arcana-table arcana-graph-table">
+            <thead>
+              <tr>
+                <th>Community</th>
+                <th>Level</th>
+                <th>Entities</th>
+                <th>Status</th>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              <%= for community <- @communities do %>
+                <tr
+                  id={"community-#{community.id}"}
+                  class={"arcana-community-row #{if @selected_community == community.id, do: "selected", else: ""}"}
+                  phx-click="select_community"
+                  phx-value-id={community.id}
+                >
+                  <td>
+                    <%= if community.summary do %>
+                      <%= String.slice(community.summary, 0, 50) %><%= if String.length(community.summary) > 50, do: "...", else: "" %>
+                    <% else %>
+                      <span class="arcana-no-summary">No summary</span>
+                    <% end %>
+                  </td>
+                  <td><%= community.level %></td>
+                  <td><%= community.entity_count %></td>
+                  <td>
+                    <%= cond do %>
+                      <% community.dirty -> %>
+                        <span class="arcana-status-pending" title="Pending regeneration">⟳</span>
+                      <% community.summary -> %>
+                        <span class="arcana-status-ready" title="Summary ready">✓</span>
+                      <% true -> %>
+                        <span class="arcana-status-empty" title="No summary">○</span>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
 
-        <.pagination
-          page={@page}
-          total={@total}
-          total_pages={@total_pages}
-          event="communities_page"
-        />
-      <% end %>
+          <.pagination
+            page={@page}
+            total={@total}
+            total_pages={@total_pages}
+            event="communities_page"
+          />
+        <% end %>
 
-      <%= if @community_details do %>
-        <.community_detail_panel details={@community_details} />
-      <% end %>
-    </div>
-    """
-  end
-
-  defp community_detail_panel(assigns) do
-    ~H"""
-    <div class="arcana-community-detail">
-      <div class="arcana-community-detail-header">
-        <h3>Community</h3>
-        <span class="arcana-community-level-badge">Level <%= @details.community.level %></span>
-        <button class="arcana-community-detail-close" phx-click="close_community_detail">×</button>
+        <%= if @community_details do %>
+          <.community_detail_panel details={@community_details} />
+        <% end %>
       </div>
+      """
+    end
 
-      <%= if @details.community.summary do %>
-        <div class="arcana-community-summary">
-          <h4>Summary</h4>
-          <p><%= @details.community.summary %></p>
+    defp community_detail_panel(assigns) do
+      ~H"""
+      <div class="arcana-community-detail">
+        <div class="arcana-community-detail-header">
+          <h3>Community</h3>
+          <span class="arcana-community-level-badge">Level <%= @details.community.level %></span>
+          <button class="arcana-community-detail-close" phx-click="close_community_detail">×</button>
         </div>
-      <% else %>
-        <div class="arcana-community-no-summary">
-          <p>No summary generated yet.</p>
-        </div>
-      <% end %>
 
-      <%= if Enum.any?(@details.entities) do %>
-        <div class="arcana-community-entities">
-          <h4>Member Entities</h4>
-          <ul>
-            <%= for entity <- @details.entities do %>
-              <li>
-                <span class={"arcana-entity-type-badge #{entity.type}"}><%= entity.type %></span>
-                <%= entity.name %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
+        <%= if @details.community.summary do %>
+          <div class="arcana-community-summary">
+            <h4>Summary</h4>
+            <p><%= @details.community.summary %></p>
+          </div>
+        <% else %>
+          <div class="arcana-community-no-summary">
+            <p>No summary generated yet.</p>
+          </div>
+        <% end %>
 
-      <%= if Enum.any?(@details.internal_relationships) do %>
-        <div class="arcana-community-relationships">
-          <h4>Internal Relationships</h4>
-          <ul>
-            <%= for rel <- @details.internal_relationships do %>
-              <li>
-                <%= rel.source_name %> <code><%= rel.type %></code> <%= rel.target_name %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-    </div>
-    """
-  end
+        <%= if Enum.any?(@details.entities) do %>
+          <div class="arcana-community-entities">
+            <h4>Member Entities</h4>
+            <ul>
+              <%= for entity <- @details.entities do %>
+                <li>
+                  <span class={"arcana-entity-type-badge #{entity.type}"}><%= entity.type %></span>
+                  <%= entity.name %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
 
-  defp strength_meter(assigns) do
-    value = assigns.value || 5
-    filled = min(max(round(value), 0), 10)
+        <%= if Enum.any?(@details.internal_relationships) do %>
+          <div class="arcana-community-relationships">
+            <h4>Internal Relationships</h4>
+            <ul>
+              <%= for rel <- @details.internal_relationships do %>
+                <li>
+                  <%= rel.source_name %> <code><%= rel.type %></code> <%= rel.target_name %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+      </div>
+      """
+    end
 
-    assigns = assign(assigns, filled: filled)
+    defp strength_meter(assigns) do
+      value = assigns.value || 5
+      filled = min(max(round(value), 0), 10)
 
-    ~H"""
-    <span class="arcana-strength-meter" title={"Strength: #{@value}/10"}>
-      <%= for i <- 1..10 do %>
-        <span class={"arcana-strength-dot #{if i <= @filled, do: "filled", else: ""}"}></span>
-      <% end %>
-    </span>
-    """
-  end
+      assigns = assign(assigns, filled: filled)
 
-  defp pagination(assigns) do
-    ~H"""
-    <div class="arcana-pagination">
-      <span class="arcana-pagination-info">
-        Page <%= @page %> of <%= @total_pages %> (<%= @total %> items)
+      ~H"""
+      <span class="arcana-strength-meter" title={"Strength: #{@value}/10"}>
+        <%= for i <- 1..10 do %>
+          <span class={"arcana-strength-dot #{if i <= @filled, do: "filled", else: ""}"}></span>
+        <% end %>
       </span>
-      <div class="arcana-pagination-buttons">
-        <button
-          type="button"
-          class="arcana-btn"
-          phx-click={@event}
-          phx-value-page={@page - 1}
-          disabled={@page <= 1}
-        >
-          ← Prev
-        </button>
-        <button
-          type="button"
-          class="arcana-btn"
-          phx-click={@event}
-          phx-value-page={@page + 1}
-          disabled={@page >= @total_pages}
-        >
-          Next →
-        </button>
+      """
+    end
+
+    defp pagination(assigns) do
+      ~H"""
+      <div class="arcana-pagination">
+        <span class="arcana-pagination-info">
+          Page <%= @page %> of <%= @total_pages %> (<%= @total %> items)
+        </span>
+        <div class="arcana-pagination-buttons">
+          <button
+            type="button"
+            class="arcana-btn"
+            phx-click={@event}
+            phx-value-page={@page - 1}
+            disabled={@page <= 1}
+          >
+            ← Prev
+          </button>
+          <button
+            type="button"
+            class="arcana-btn"
+            phx-click={@event}
+            phx-value-page={@page + 1}
+            disabled={@page >= @total_pages}
+          >
+            Next →
+          </button>
+        </div>
       </div>
-    </div>
-    """
+      """
+    end
   end
 end

--- a/lib/arcana_web/live/info_live.ex
+++ b/lib/arcana_web/live/info_live.ex
@@ -1,544 +1,550 @@
-defmodule ArcanaWeb.InfoLive do
-  @moduledoc """
-  LiveView for displaying Arcana configuration info.
-  """
-  use Phoenix.LiveView
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  import ArcanaWeb.DashboardComponents
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.InfoLive do
+    @moduledoc """
+    LiveView for displaying Arcana configuration info.
+    """
+    use Phoenix.LiveView
 
-  @impl true
-  def mount(_params, session, socket) do
-    repo = get_repo_from_session(session)
+    import ArcanaWeb.DashboardComponents
 
-    {:ok,
-     socket
-     |> assign(repo: repo)
-     |> assign(config_info: get_config_info())
-     |> assign(stats: nil)}
-  end
+    @impl true
+    def mount(_params, session, socket) do
+      repo = get_repo_from_session(session)
 
-  @impl true
-  def handle_params(_params, _uri, socket) do
-    {:noreply, load_data(socket)}
-  end
-
-  defp load_data(socket) do
-    repo = socket.assigns.repo
-
-    socket
-    |> assign(stats: load_stats(repo))
-  end
-
-  defp get_config_info do
-    %{
-      repo: Arcana.Config.get_env(:repo),
-      llm: format_llm_config(Arcana.Config.get_env(:llm)),
-      embedding: format_embedding_config(Arcana.Config.get_env(:embedder, :local)),
-      chunker: format_chunker_config(Arcana.Config.get_env(:chunker, :default)),
-      reranker: format_reranker_config(Arcana.Config.get_env(:reranker)),
-      grounder: format_grounder_config(),
-      loop: format_loop_config(Arcana.Config.get_env(:loop, [])),
-      vector_store: format_vector_store_config(),
-      graph: format_graph_config(),
-      raw: %{
-        embedder: Arcana.Config.redact(Arcana.Config.get_env(:embedder, :local)),
-        llm: Arcana.Config.redact(Arcana.Config.get_env(:llm)),
-        reranker: Arcana.Config.redact(Arcana.Config.get_env(:reranker)),
-        chunker: Arcana.Config.redact(Arcana.Config.get_env(:chunker, :default)),
-        loop: Arcana.Config.redact(Arcana.Config.get_env(:loop, [])),
-        graph: Arcana.Config.redact(Arcana.Config.get_env(:graph, [])),
-        vector_store: Arcana.Config.get_env(:vector_store, :pgvector)
-      }
-    }
-  end
-
-  # Loop config lives under `config :arcana, :loop, [...]`. The values are
-  # merged with per-call options inside Arcana.Loop.run/2 via
-  # Arcana.Config.merge_app_opts/2. We surface the effective defaults so
-  # users can see what their app config sets.
-  defp format_loop_config(loop_opts) do
-    %{
-      max_iterations: Keyword.get(loop_opts, :max_iterations, 10),
-      chunk_cap: Keyword.get(loop_opts, :chunk_cap, 30),
-      controller_llm: format_loop_controller_llm(loop_opts),
-      configured: loop_opts != []
-    }
-  end
-
-  defp format_loop_controller_llm(loop_opts) do
-    case Keyword.get(loop_opts, :controller_llm) do
-      nil -> nil
-      llm -> Arcana.Config.redact(llm)
+      {:ok,
+       socket
+       |> assign(repo: repo)
+       |> assign(config_info: get_config_info())
+       |> assign(stats: nil)}
     end
-  end
 
-  # Grounder doesn't live in app config — it's resolved per-call by
-  # Pipeline.ground/2 and Loop.ground/2 with a default of
-  # Arcana.Grounder.Hallmark. Surface that as the "default" so users
-  # know which grounder ships out of the box.
-  defp format_grounder_config do
-    %{
-      default: Arcana.Grounder.Hallmark,
-      description:
-        "Local Vectara HHEM via Bumblebee. Override per-call with the :grounder option."
-    }
-  end
+    @impl true
+    def handle_params(_params, _uri, socket) do
+      {:noreply, load_data(socket)}
+    end
 
-  defp format_llm_config(nil), do: %{configured: false}
+    defp load_data(socket) do
+      repo = socket.assigns.repo
 
-  defp format_llm_config(llm) when is_function(llm) do
-    %{configured: true, type: "Function"}
-  end
+      socket
+      |> assign(stats: load_stats(repo))
+    end
 
-  defp format_llm_config(llm) do
-    case llm do
-      %{__struct__: module} = struct ->
-        %{
-          configured: true,
-          type: module |> Module.split() |> List.last(),
-          model: Map.get(struct, :model, "unknown")
+    defp get_config_info do
+      %{
+        repo: Arcana.Config.get_env(:repo),
+        llm: format_llm_config(Arcana.Config.get_env(:llm)),
+        embedding: format_embedding_config(Arcana.Config.get_env(:embedder, :local)),
+        chunker: format_chunker_config(Arcana.Config.get_env(:chunker, :default)),
+        reranker: format_reranker_config(Arcana.Config.get_env(:reranker)),
+        grounder: format_grounder_config(),
+        loop: format_loop_config(Arcana.Config.get_env(:loop, [])),
+        vector_store: format_vector_store_config(),
+        graph: format_graph_config(),
+        raw: %{
+          embedder: Arcana.Config.redact(Arcana.Config.get_env(:embedder, :local)),
+          llm: Arcana.Config.redact(Arcana.Config.get_env(:llm)),
+          reranker: Arcana.Config.redact(Arcana.Config.get_env(:reranker)),
+          chunker: Arcana.Config.redact(Arcana.Config.get_env(:chunker, :default)),
+          loop: Arcana.Config.redact(Arcana.Config.get_env(:loop, [])),
+          graph: Arcana.Config.redact(Arcana.Config.get_env(:graph, [])),
+          vector_store: Arcana.Config.get_env(:vector_store, :pgvector)
         }
-
-      {model, _opts} when is_binary(model) ->
-        %{configured: true, type: "Req.LLM", model: model}
-
-      {model, _opts} when is_atom(model) ->
-        %{configured: true, type: "Req.LLM", model: Atom.to_string(model)}
-
-      model when is_binary(model) ->
-        %{configured: true, type: "Req.LLM", model: model}
-
-      model when is_atom(model) ->
-        %{configured: true, type: "Req.LLM", model: Atom.to_string(model)}
-
-      _ ->
-        %{configured: true, type: "Custom"}
+      }
     end
-  end
 
-  defp format_embedding_config(:local), do: %{type: :local, model: "BAAI/bge-small-en-v1.5"}
-  defp format_embedding_config(:openai), do: %{type: :openai, model: "text-embedding-3-small"}
-
-  defp format_embedding_config({:local, opts}) do
-    %{type: :local, model: Keyword.get(opts, :model, "BAAI/bge-small-en-v1.5")}
-  end
-
-  defp format_embedding_config({:openai, opts}) do
-    %{type: :openai, model: Keyword.get(opts, :model, "text-embedding-3-small")}
-  end
-
-  defp format_embedding_config({:custom, _fun}), do: %{type: :custom}
-  defp format_embedding_config({:custom, _fun, _opts}), do: %{type: :custom}
-
-  defp format_embedding_config({module, opts}) when is_atom(module) and is_list(opts) do
-    %{type: :custom_module, module: module, opts: Arcana.Config.do_redact(opts)}
-  end
-
-  defp format_embedding_config(module) when is_atom(module) do
-    %{type: :custom_module, module: module}
-  end
-
-  defp format_embedding_config(other), do: %{type: :unknown, raw: inspect(other)}
-
-  defp format_reranker_config(nil), do: %{module: Arcana.Reranker.LLM, configured: false}
-
-  defp format_reranker_config(module) when is_atom(module),
-    do: %{module: module, configured: true}
-
-  defp format_reranker_config({module, opts}) when is_atom(module) and is_list(opts) do
-    %{module: module, opts: Arcana.Config.do_redact(opts), configured: true}
-  end
-
-  defp format_reranker_config(fun) when is_function(fun) do
-    %{type: :function, configured: true}
-  end
-
-  defp format_reranker_config(other),
-    do: %{type: :unknown, raw: Arcana.Config.do_redact(other), configured: true}
-
-  defp format_chunker_config(:default), do: %{type: :default, chunk_size: 512, chunk_overlap: 100}
-
-  defp format_chunker_config({:default, opts}) do
-    %{
-      type: :default,
-      chunk_size: Keyword.get(opts, :chunk_size, 512),
-      chunk_overlap: Keyword.get(opts, :chunk_overlap, 100)
-    }
-  end
-
-  defp format_chunker_config(fun) when is_function(fun), do: %{type: :function}
-
-  defp format_chunker_config({module, opts}) when is_atom(module) and is_list(opts) do
-    %{type: :custom, module: module, opts: Arcana.Config.do_redact(opts)}
-  end
-
-  defp format_chunker_config(module) when is_atom(module), do: %{type: :custom, module: module}
-  defp format_chunker_config(_other), do: %{type: :unknown}
-
-  defp format_vector_store_config do
-    store = Arcana.Config.get_env(:vector_store, :pgvector)
-
-    case store do
-      :pgvector -> %{type: :pgvector, description: "PostgreSQL with pgvector extension"}
-      :memory -> %{type: :memory, description: "In-memory vector store"}
-      module when is_atom(module) -> %{type: :custom, module: module}
-      _ -> %{type: :unknown}
+    # Loop config lives under `config :arcana, :loop, [...]`. The values are
+    # merged with per-call options inside Arcana.Loop.run/2 via
+    # Arcana.Config.merge_app_opts/2. We surface the effective defaults so
+    # users can see what their app config sets.
+    defp format_loop_config(loop_opts) do
+      %{
+        max_iterations: Keyword.get(loop_opts, :max_iterations, 10),
+        chunk_cap: Keyword.get(loop_opts, :chunk_cap, 30),
+        controller_llm: format_loop_controller_llm(loop_opts),
+        configured: loop_opts != []
+      }
     end
-  end
 
-  defp format_graph_config do
-    config = Arcana.Graph.config()
-    graph_opts = Arcana.Config.get_env(:graph, [])
-
-    extractor =
-      cond do
-        config[:extractor] -> format_extractor(config[:extractor])
-        graph_opts[:extractor] -> format_extractor(graph_opts[:extractor])
-        true -> nil
+    defp format_loop_controller_llm(loop_opts) do
+      case Keyword.get(loop_opts, :controller_llm) do
+        nil -> nil
+        llm -> Arcana.Config.redact(llm)
       end
+    end
 
-    entity_extractor =
-      cond do
-        config[:entity_extractor] -> format_extractor(config[:entity_extractor])
-        graph_opts[:entity_extractor] -> format_extractor(graph_opts[:entity_extractor])
-        true -> %{type: :ner, description: "Built-in NER (default)"}
+    # Grounder doesn't live in app config — it's resolved per-call by
+    # Pipeline.ground/2 and Loop.ground/2 with a default of
+    # Arcana.Grounder.Hallmark. Surface that as the "default" so users
+    # know which grounder ships out of the box.
+    defp format_grounder_config do
+      %{
+        default: Arcana.Grounder.Hallmark,
+        description:
+          "Local Vectara HHEM via Bumblebee. Override per-call with the :grounder option."
+      }
+    end
+
+    defp format_llm_config(nil), do: %{configured: false}
+
+    defp format_llm_config(llm) when is_function(llm) do
+      %{configured: true, type: "Function"}
+    end
+
+    defp format_llm_config(llm) do
+      case llm do
+        %{__struct__: module} = struct ->
+          %{
+            configured: true,
+            type: module |> Module.split() |> List.last(),
+            model: Map.get(struct, :model, "unknown")
+          }
+
+        {model, _opts} when is_binary(model) ->
+          %{configured: true, type: "Req.LLM", model: model}
+
+        {model, _opts} when is_atom(model) ->
+          %{configured: true, type: "Req.LLM", model: Atom.to_string(model)}
+
+        model when is_binary(model) ->
+          %{configured: true, type: "Req.LLM", model: model}
+
+        model when is_atom(model) ->
+          %{configured: true, type: "Req.LLM", model: Atom.to_string(model)}
+
+        _ ->
+          %{configured: true, type: "Custom"}
       end
+    end
 
-    relationship_extractor =
-      cond do
-        config[:relationship_extractor] ->
-          format_extractor(config[:relationship_extractor])
+    defp format_embedding_config(:local), do: %{type: :local, model: "BAAI/bge-small-en-v1.5"}
+    defp format_embedding_config(:openai), do: %{type: :openai, model: "text-embedding-3-small"}
 
-        graph_opts[:relationship_extractor] ->
-          format_extractor(graph_opts[:relationship_extractor])
+    defp format_embedding_config({:local, opts}) do
+      %{type: :local, model: Keyword.get(opts, :model, "BAAI/bge-small-en-v1.5")}
+    end
 
-        true ->
-          nil
+    defp format_embedding_config({:openai, opts}) do
+      %{type: :openai, model: Keyword.get(opts, :model, "text-embedding-3-small")}
+    end
+
+    defp format_embedding_config({:custom, _fun}), do: %{type: :custom}
+    defp format_embedding_config({:custom, _fun, _opts}), do: %{type: :custom}
+
+    defp format_embedding_config({module, opts}) when is_atom(module) and is_list(opts) do
+      %{type: :custom_module, module: module, opts: Arcana.Config.do_redact(opts)}
+    end
+
+    defp format_embedding_config(module) when is_atom(module) do
+      %{type: :custom_module, module: module}
+    end
+
+    defp format_embedding_config(other), do: %{type: :unknown, raw: inspect(other)}
+
+    defp format_reranker_config(nil), do: %{module: Arcana.Reranker.LLM, configured: false}
+
+    defp format_reranker_config(module) when is_atom(module),
+      do: %{module: module, configured: true}
+
+    defp format_reranker_config({module, opts}) when is_atom(module) and is_list(opts) do
+      %{module: module, opts: Arcana.Config.do_redact(opts), configured: true}
+    end
+
+    defp format_reranker_config(fun) when is_function(fun) do
+      %{type: :function, configured: true}
+    end
+
+    defp format_reranker_config(other),
+      do: %{type: :unknown, raw: Arcana.Config.do_redact(other), configured: true}
+
+    defp format_chunker_config(:default),
+      do: %{type: :default, chunk_size: 512, chunk_overlap: 100}
+
+    defp format_chunker_config({:default, opts}) do
+      %{
+        type: :default,
+        chunk_size: Keyword.get(opts, :chunk_size, 512),
+        chunk_overlap: Keyword.get(opts, :chunk_overlap, 100)
+      }
+    end
+
+    defp format_chunker_config(fun) when is_function(fun), do: %{type: :function}
+
+    defp format_chunker_config({module, opts}) when is_atom(module) and is_list(opts) do
+      %{type: :custom, module: module, opts: Arcana.Config.do_redact(opts)}
+    end
+
+    defp format_chunker_config(module) when is_atom(module), do: %{type: :custom, module: module}
+    defp format_chunker_config(_other), do: %{type: :unknown}
+
+    defp format_vector_store_config do
+      store = Arcana.Config.get_env(:vector_store, :pgvector)
+
+      case store do
+        :pgvector -> %{type: :pgvector, description: "PostgreSQL with pgvector extension"}
+        :memory -> %{type: :memory, description: "In-memory vector store"}
+        module when is_atom(module) -> %{type: :custom, module: module}
+        _ -> %{type: :unknown}
       end
+    end
 
-    community_detector =
-      cond do
-        config[:community_detector] ->
-          format_community_detector(config[:community_detector])
+    defp format_graph_config do
+      config = Arcana.Graph.config()
+      graph_opts = Arcana.Config.get_env(:graph, [])
 
-        graph_opts[:community_detector] ->
-          format_community_detector(graph_opts[:community_detector])
+      extractor =
+        cond do
+          config[:extractor] -> format_extractor(config[:extractor])
+          graph_opts[:extractor] -> format_extractor(graph_opts[:extractor])
+          true -> nil
+        end
 
-        true ->
-          %{type: :leiden, description: "Leiden (default)"}
-      end
+      entity_extractor =
+        cond do
+          config[:entity_extractor] -> format_extractor(config[:entity_extractor])
+          graph_opts[:entity_extractor] -> format_extractor(graph_opts[:entity_extractor])
+          true -> %{type: :ner, description: "Built-in NER (default)"}
+        end
 
-    %{
-      enabled: config.enabled,
-      community_levels: config.community_levels,
-      resolution: config.resolution,
-      store: Arcana.Config.get_env(:graph_store, :ecto),
-      extractor: extractor,
-      entity_extractor: entity_extractor,
-      relationship_extractor: relationship_extractor,
-      community_detector: community_detector
-    }
-  end
+      relationship_extractor =
+        cond do
+          config[:relationship_extractor] ->
+            format_extractor(config[:relationship_extractor])
 
-  defp format_extractor(nil), do: nil
-  defp format_extractor(:ner), do: %{type: :ner, description: "Built-in NER"}
-  defp format_extractor(:llm), do: %{type: :llm, description: "LLM-based extraction"}
+          graph_opts[:relationship_extractor] ->
+            format_extractor(graph_opts[:relationship_extractor])
 
-  defp format_extractor({module, opts}) when is_atom(module) and is_list(opts) do
-    module_name = module |> Module.split() |> List.last()
-    %{type: :custom, module: module_name, opts: Arcana.Config.do_redact(opts)}
-  end
+          true ->
+            nil
+        end
 
-  defp format_extractor(module) when is_atom(module) do
-    module_name = module |> Module.split() |> List.last()
-    %{type: :module, module: module_name}
-  end
+      community_detector =
+        cond do
+          config[:community_detector] ->
+            format_community_detector(config[:community_detector])
 
-  defp format_extractor(_other), do: %{type: :unknown}
+          graph_opts[:community_detector] ->
+            format_community_detector(graph_opts[:community_detector])
 
-  defp format_community_detector(nil), do: nil
-  defp format_community_detector(:leiden), do: %{type: :leiden, description: "Leiden"}
+          true ->
+            %{type: :leiden, description: "Leiden (default)"}
+        end
 
-  defp format_community_detector({module, opts}) when is_atom(module) and is_list(opts) do
-    module_name = module |> Module.split() |> List.last()
-    %{type: :custom, module: module_name, opts: Arcana.Config.do_redact(opts)}
-  end
+      %{
+        enabled: config.enabled,
+        community_levels: config.community_levels,
+        resolution: config.resolution,
+        store: Arcana.Config.get_env(:graph_store, :ecto),
+        extractor: extractor,
+        entity_extractor: entity_extractor,
+        relationship_extractor: relationship_extractor,
+        community_detector: community_detector
+      }
+    end
 
-  defp format_community_detector(module) when is_atom(module) do
-    module_name = module |> Module.split() |> List.last()
-    %{type: :module, module: module_name}
-  end
+    defp format_extractor(nil), do: nil
+    defp format_extractor(:ner), do: %{type: :ner, description: "Built-in NER"}
+    defp format_extractor(:llm), do: %{type: :llm, description: "LLM-based extraction"}
 
-  defp format_community_detector(_other), do: %{type: :unknown}
+    defp format_extractor({module, opts}) when is_atom(module) and is_list(opts) do
+      module_name = module |> Module.split() |> List.last()
+      %{type: :custom, module: module_name, opts: Arcana.Config.do_redact(opts)}
+    end
 
-  defp raw_config_section(assigns) do
-    config_text = """
-    config :arcana,
-      repo: #{inspect(assigns.config_info.repo)},
-      embedder: #{inspect(assigns.config_info.raw.embedder)},
-      llm: #{inspect(assigns.config_info.raw.llm)},
-      chunker: #{inspect(assigns.config_info.raw.chunker)},
-      reranker: #{if assigns.config_info.raw.reranker, do: inspect(assigns.config_info.raw.reranker), else: "nil # defaults to Arcana.Reranker.LLM"},
-      loop: #{inspect(assigns.config_info.raw.loop)},
-      vector_store: #{inspect(assigns.config_info.raw.vector_store)},
-      graph: #{inspect(assigns.config_info.raw.graph)}
-    """
+    defp format_extractor(module) when is_atom(module) do
+      module_name = module |> Module.split() |> List.last()
+      %{type: :module, module: module_name}
+    end
 
-    assigns = assign(assigns, :config_text, config_text)
+    defp format_extractor(_other), do: %{type: :unknown}
 
-    ~H"""
-    <div class="arcana-info-section arcana-info-full">
-      <h3>Raw Configuration</h3>
-      <pre class="arcana-doc-content" style="font-size: 0.75rem; line-height: 1.5; overflow-x: auto;"><%= @config_text %></pre>
-    </div>
-    """
-  end
+    defp format_community_detector(nil), do: nil
+    defp format_community_detector(:leiden), do: %{type: :leiden, description: "Leiden"}
 
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:info} prefix={@prefix}>
-      <div class="arcana-info">
-        <h2>Info</h2>
-        <p class="arcana-tab-description">
-          View current Arcana configuration including embedding, LLM, and chunking settings.
-        </p>
+    defp format_community_detector({module, opts}) when is_atom(module) and is_list(opts) do
+      module_name = module |> Module.split() |> List.last()
+      %{type: :custom, module: module_name, opts: Arcana.Config.do_redact(opts)}
+    end
 
-        <div class="arcana-info-grid">
-          <div class="arcana-info-section">
-            <h3>Embedding</h3>
-            <div class="arcana-doc-info">
-              <div class="arcana-doc-field">
-                <label>Type</label>
-                <span><%= @config_info.embedding.type %></span>
-              </div>
-              <%= if @config_info.embedding[:model] do %>
-                <div class="arcana-doc-field">
-                  <label>Model</label>
-                  <span><%= @config_info.embedding.model %></span>
-                </div>
-              <% end %>
-              <%= if @config_info.embedding[:module] do %>
-                <div class="arcana-doc-field">
-                  <label>Module</label>
-                  <code><%= inspect(@config_info.embedding.module) %></code>
-                </div>
-              <% end %>
-            </div>
-          </div>
+    defp format_community_detector(module) when is_atom(module) do
+      module_name = module |> Module.split() |> List.last()
+      %{type: :module, module: module_name}
+    end
 
-          <div class="arcana-info-section">
-            <h3>LLM</h3>
-            <div class="arcana-doc-info">
-              <%= if @config_info.llm.configured do %>
+    defp format_community_detector(_other), do: %{type: :unknown}
+
+    defp raw_config_section(assigns) do
+      config_text = """
+      config :arcana,
+        repo: #{inspect(assigns.config_info.repo)},
+        embedder: #{inspect(assigns.config_info.raw.embedder)},
+        llm: #{inspect(assigns.config_info.raw.llm)},
+        chunker: #{inspect(assigns.config_info.raw.chunker)},
+        reranker: #{if assigns.config_info.raw.reranker, do: inspect(assigns.config_info.raw.reranker), else: "nil # defaults to Arcana.Reranker.LLM"},
+        loop: #{inspect(assigns.config_info.raw.loop)},
+        vector_store: #{inspect(assigns.config_info.raw.vector_store)},
+        graph: #{inspect(assigns.config_info.raw.graph)}
+      """
+
+      assigns = assign(assigns, :config_text, config_text)
+
+      ~H"""
+      <div class="arcana-info-section arcana-info-full">
+        <h3>Raw Configuration</h3>
+        <pre class="arcana-doc-content" style="font-size: 0.75rem; line-height: 1.5; overflow-x: auto;"><%= @config_text %></pre>
+      </div>
+      """
+    end
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.dashboard_layout stats={@stats} current_tab={:info} prefix={@prefix}>
+        <div class="arcana-info">
+          <h2>Info</h2>
+          <p class="arcana-tab-description">
+            View current Arcana configuration including embedding, LLM, and chunking settings.
+          </p>
+
+          <div class="arcana-info-grid">
+            <div class="arcana-info-section">
+              <h3>Embedding</h3>
+              <div class="arcana-doc-info">
                 <div class="arcana-doc-field">
                   <label>Type</label>
-                  <span><%= @config_info.llm.type %></span>
+                  <span><%= @config_info.embedding.type %></span>
                 </div>
-                <%= if @config_info.llm[:model] do %>
+                <%= if @config_info.embedding[:model] do %>
                   <div class="arcana-doc-field">
                     <label>Model</label>
-                    <span><%= @config_info.llm.model %></span>
+                    <span><%= @config_info.embedding.model %></span>
                   </div>
                 <% end %>
-              <% else %>
+                <%= if @config_info.embedding[:module] do %>
+                  <div class="arcana-doc-field">
+                    <label>Module</label>
+                    <code><%= inspect(@config_info.embedding.module) %></code>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="arcana-info-section">
+              <h3>LLM</h3>
+              <div class="arcana-doc-info">
+                <%= if @config_info.llm.configured do %>
+                  <div class="arcana-doc-field">
+                    <label>Type</label>
+                    <span><%= @config_info.llm.type %></span>
+                  </div>
+                  <%= if @config_info.llm[:model] do %>
+                    <div class="arcana-doc-field">
+                      <label>Model</label>
+                      <span><%= @config_info.llm.model %></span>
+                    </div>
+                  <% end %>
+                <% else %>
+                  <div class="arcana-doc-field">
+                    <label>Status</label>
+                    <span class="arcana-not-configured">Not configured</span>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="arcana-info-section">
+              <h3>Chunker</h3>
+              <div class="arcana-doc-info">
+                <div class="arcana-doc-field">
+                  <label>Type</label>
+                  <span><%= @config_info.chunker.type %></span>
+                </div>
+                <%= if @config_info.chunker[:chunk_size] do %>
+                  <div class="arcana-doc-field">
+                    <label>Chunk Size</label>
+                    <span><%= @config_info.chunker.chunk_size %> tokens</span>
+                  </div>
+                <% end %>
+                <%= if @config_info.chunker[:chunk_overlap] do %>
+                  <div class="arcana-doc-field">
+                    <label>Overlap</label>
+                    <span><%= @config_info.chunker.chunk_overlap %> tokens</span>
+                  </div>
+                <% end %>
+                <%= if @config_info.chunker[:module] do %>
+                  <div class="arcana-doc-field">
+                    <label>Module</label>
+                    <code><%= inspect(@config_info.chunker.module) %></code>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="arcana-info-section">
+              <h3>Reranker</h3>
+              <div class="arcana-doc-info">
+                <div class="arcana-doc-field">
+                  <label>Module</label>
+                  <code><%= inspect(@config_info.reranker[:module] || @config_info.reranker[:type]) %></code>
+                </div>
+                <%= if @config_info.reranker[:opts] do %>
+                  <div class="arcana-doc-field">
+                    <label>Options</label>
+                    <span><%= inspect(@config_info.reranker.opts) %></span>
+                  </div>
+                <% end %>
                 <div class="arcana-doc-field">
                   <label>Status</label>
-                  <span class="arcana-not-configured">Not configured</span>
+                  <span><%= if @config_info.reranker.configured, do: "Configured", else: "Default" %></span>
                 </div>
-              <% end %>
-            </div>
-          </div>
-
-          <div class="arcana-info-section">
-            <h3>Chunker</h3>
-            <div class="arcana-doc-info">
-              <div class="arcana-doc-field">
-                <label>Type</label>
-                <span><%= @config_info.chunker.type %></span>
-              </div>
-              <%= if @config_info.chunker[:chunk_size] do %>
-                <div class="arcana-doc-field">
-                  <label>Chunk Size</label>
-                  <span><%= @config_info.chunker.chunk_size %> tokens</span>
-                </div>
-              <% end %>
-              <%= if @config_info.chunker[:chunk_overlap] do %>
-                <div class="arcana-doc-field">
-                  <label>Overlap</label>
-                  <span><%= @config_info.chunker.chunk_overlap %> tokens</span>
-                </div>
-              <% end %>
-              <%= if @config_info.chunker[:module] do %>
-                <div class="arcana-doc-field">
-                  <label>Module</label>
-                  <code><%= inspect(@config_info.chunker.module) %></code>
-                </div>
-              <% end %>
-            </div>
-          </div>
-
-          <div class="arcana-info-section">
-            <h3>Reranker</h3>
-            <div class="arcana-doc-info">
-              <div class="arcana-doc-field">
-                <label>Module</label>
-                <code><%= inspect(@config_info.reranker[:module] || @config_info.reranker[:type]) %></code>
-              </div>
-              <%= if @config_info.reranker[:opts] do %>
-                <div class="arcana-doc-field">
-                  <label>Options</label>
-                  <span><%= inspect(@config_info.reranker.opts) %></span>
-                </div>
-              <% end %>
-              <div class="arcana-doc-field">
-                <label>Status</label>
-                <span><%= if @config_info.reranker.configured, do: "Configured", else: "Default" %></span>
               </div>
             </div>
-          </div>
 
-          <div class="arcana-info-section">
-            <h3>Grounder</h3>
-            <div class="arcana-doc-info">
-              <div class="arcana-doc-field">
-                <label>Default</label>
-                <code><%= inspect(@config_info.grounder.default) %></code>
-              </div>
-              <div class="arcana-doc-field">
-                <label>Description</label>
-                <span><%= @config_info.grounder.description %></span>
-              </div>
-              <div class="arcana-doc-field">
-                <label>Used by</label>
-                <span><code>Pipeline.ground/2</code> and <code>Loop.ground/2</code></span>
-              </div>
-            </div>
-          </div>
-
-          <div class="arcana-info-section">
-            <h3>Loop</h3>
-            <div class="arcana-doc-info">
-              <div class="arcana-doc-field">
-                <label>Status</label>
-                <span class={"arcana-status-badge #{if @config_info.loop.configured, do: "enabled", else: "disabled"}"}>
-                  <%= if @config_info.loop.configured, do: "Configured", else: "Defaults" %>
-                </span>
-              </div>
-              <div class="arcana-doc-field">
-                <label>Max Iterations</label>
-                <span><%= @config_info.loop.max_iterations %></span>
-              </div>
-              <div class="arcana-doc-field">
-                <label>Chunk Cap</label>
-                <span><%= @config_info.loop.chunk_cap %></span>
-              </div>
-              <%= if @config_info.loop.controller_llm do %>
+            <div class="arcana-info-section">
+              <h3>Grounder</h3>
+              <div class="arcana-doc-info">
                 <div class="arcana-doc-field">
-                  <label>Controller LLM</label>
-                  <span><%= inspect(@config_info.loop.controller_llm) %></span>
+                  <label>Default</label>
+                  <code><%= inspect(@config_info.grounder.default) %></code>
                 </div>
-              <% else %>
-                <div class="arcana-doc-field">
-                  <label>Controller LLM</label>
-                  <span style="color: #6b7280;">inherited from <code>config :arcana, :llm</code></span>
-                </div>
-              <% end %>
-              <div class="arcana-doc-field">
-                <label>Default Tools</label>
-                <span><code>search</code>, <code>answer</code>, <code>give_up</code></span>
-              </div>
-            </div>
-          </div>
-
-          <div class="arcana-info-section">
-            <h3>Vector Store</h3>
-            <div class="arcana-doc-info">
-              <div class="arcana-doc-field">
-                <label>Type</label>
-                <span><%= @config_info.vector_store.type %></span>
-              </div>
-              <%= if @config_info.vector_store[:description] do %>
                 <div class="arcana-doc-field">
                   <label>Description</label>
-                  <span><%= @config_info.vector_store.description %></span>
+                  <span><%= @config_info.grounder.description %></span>
                 </div>
-              <% end %>
-              <%= if @config_info.vector_store[:module] do %>
                 <div class="arcana-doc-field">
-                  <label>Module</label>
-                  <code><%= inspect(@config_info.vector_store.module) %></code>
+                  <label>Used by</label>
+                  <span><code>Pipeline.ground/2</code> and <code>Loop.ground/2</code></span>
                 </div>
-              <% end %>
-            </div>
-          </div>
-
-          <div class="arcana-info-section">
-            <h3>GraphRAG</h3>
-            <div class="arcana-doc-info">
-              <div class="arcana-doc-field">
-                <label>Status</label>
-                <span class={"arcana-status-badge #{if @config_info.graph.enabled, do: "enabled", else: "disabled"}"}>
-                  <%= if @config_info.graph.enabled, do: "Enabled", else: "Disabled" %>
-                </span>
               </div>
-              <%= if @config_info.graph.extractor do %>
+            </div>
+
+            <div class="arcana-info-section">
+              <h3>Loop</h3>
+              <div class="arcana-doc-info">
                 <div class="arcana-doc-field">
-                  <label>Extractor</label>
-                  <span>
-                    <%= @config_info.graph.extractor[:module] || @config_info.graph.extractor[:description] || @config_info.graph.extractor[:type] %>
-                    <span style="color: #6b7280; font-size: 0.75rem;">(combined)</span>
+                  <label>Status</label>
+                  <span class={"arcana-status-badge #{if @config_info.loop.configured, do: "enabled", else: "disabled"}"}>
+                    <%= if @config_info.loop.configured, do: "Configured", else: "Defaults" %>
                   </span>
                 </div>
-              <% else %>
-                <%= if @config_info.graph.entity_extractor do %>
-                  <div class="arcana-doc-field">
-                    <label>Entity Extractor</label>
-                    <span><%= @config_info.graph.entity_extractor[:module] || @config_info.graph.entity_extractor[:description] || @config_info.graph.entity_extractor[:type] %></span>
-                  </div>
-                <% end %>
-                <%= if @config_info.graph.relationship_extractor do %>
-                  <div class="arcana-doc-field">
-                    <label>Relationship Extractor</label>
-                    <span><%= @config_info.graph.relationship_extractor[:module] || @config_info.graph.relationship_extractor[:description] || @config_info.graph.relationship_extractor[:type] %></span>
-                  </div>
-                <% end %>
-              <% end %>
-              <div class="arcana-doc-field">
-                <label>Community Levels</label>
-                <span><%= @config_info.graph.community_levels %></span>
-              </div>
-              <div class="arcana-doc-field">
-                <label>Resolution</label>
-                <span><%= @config_info.graph.resolution %></span>
-              </div>
-              <div class="arcana-doc-field">
-                <label>Store</label>
-                <span><%= @config_info.graph.store %></span>
-              </div>
-              <%= if @config_info.graph.community_detector do %>
                 <div class="arcana-doc-field">
-                  <label>Community Detector</label>
-                  <span><%= @config_info.graph.community_detector[:module] || @config_info.graph.community_detector[:description] || @config_info.graph.community_detector[:type] %></span>
+                  <label>Max Iterations</label>
+                  <span><%= @config_info.loop.max_iterations %></span>
                 </div>
-              <% end %>
+                <div class="arcana-doc-field">
+                  <label>Chunk Cap</label>
+                  <span><%= @config_info.loop.chunk_cap %></span>
+                </div>
+                <%= if @config_info.loop.controller_llm do %>
+                  <div class="arcana-doc-field">
+                    <label>Controller LLM</label>
+                    <span><%= inspect(@config_info.loop.controller_llm) %></span>
+                  </div>
+                <% else %>
+                  <div class="arcana-doc-field">
+                    <label>Controller LLM</label>
+                    <span style="color: #6b7280;">inherited from <code>config :arcana, :llm</code></span>
+                  </div>
+                <% end %>
+                <div class="arcana-doc-field">
+                  <label>Default Tools</label>
+                  <span><code>search</code>, <code>answer</code>, <code>give_up</code></span>
+                </div>
+              </div>
             </div>
-          </div>
 
-          <div class="arcana-info-section">
-            <h3>Repository</h3>
-            <div class="arcana-doc-info">
-              <div class="arcana-doc-field">
-                <label>Module</label>
-                <code><%= inspect(@config_info.repo) %></code>
+            <div class="arcana-info-section">
+              <h3>Vector Store</h3>
+              <div class="arcana-doc-info">
+                <div class="arcana-doc-field">
+                  <label>Type</label>
+                  <span><%= @config_info.vector_store.type %></span>
+                </div>
+                <%= if @config_info.vector_store[:description] do %>
+                  <div class="arcana-doc-field">
+                    <label>Description</label>
+                    <span><%= @config_info.vector_store.description %></span>
+                  </div>
+                <% end %>
+                <%= if @config_info.vector_store[:module] do %>
+                  <div class="arcana-doc-field">
+                    <label>Module</label>
+                    <code><%= inspect(@config_info.vector_store.module) %></code>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="arcana-info-section">
+              <h3>GraphRAG</h3>
+              <div class="arcana-doc-info">
+                <div class="arcana-doc-field">
+                  <label>Status</label>
+                  <span class={"arcana-status-badge #{if @config_info.graph.enabled, do: "enabled", else: "disabled"}"}>
+                    <%= if @config_info.graph.enabled, do: "Enabled", else: "Disabled" %>
+                  </span>
+                </div>
+                <%= if @config_info.graph.extractor do %>
+                  <div class="arcana-doc-field">
+                    <label>Extractor</label>
+                    <span>
+                      <%= @config_info.graph.extractor[:module] || @config_info.graph.extractor[:description] || @config_info.graph.extractor[:type] %>
+                      <span style="color: #6b7280; font-size: 0.75rem;">(combined)</span>
+                    </span>
+                  </div>
+                <% else %>
+                  <%= if @config_info.graph.entity_extractor do %>
+                    <div class="arcana-doc-field">
+                      <label>Entity Extractor</label>
+                      <span><%= @config_info.graph.entity_extractor[:module] || @config_info.graph.entity_extractor[:description] || @config_info.graph.entity_extractor[:type] %></span>
+                    </div>
+                  <% end %>
+                  <%= if @config_info.graph.relationship_extractor do %>
+                    <div class="arcana-doc-field">
+                      <label>Relationship Extractor</label>
+                      <span><%= @config_info.graph.relationship_extractor[:module] || @config_info.graph.relationship_extractor[:description] || @config_info.graph.relationship_extractor[:type] %></span>
+                    </div>
+                  <% end %>
+                <% end %>
+                <div class="arcana-doc-field">
+                  <label>Community Levels</label>
+                  <span><%= @config_info.graph.community_levels %></span>
+                </div>
+                <div class="arcana-doc-field">
+                  <label>Resolution</label>
+                  <span><%= @config_info.graph.resolution %></span>
+                </div>
+                <div class="arcana-doc-field">
+                  <label>Store</label>
+                  <span><%= @config_info.graph.store %></span>
+                </div>
+                <%= if @config_info.graph.community_detector do %>
+                  <div class="arcana-doc-field">
+                    <label>Community Detector</label>
+                    <span><%= @config_info.graph.community_detector[:module] || @config_info.graph.community_detector[:description] || @config_info.graph.community_detector[:type] %></span>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="arcana-info-section">
+              <h3>Repository</h3>
+              <div class="arcana-doc-info">
+                <div class="arcana-doc-field">
+                  <label>Module</label>
+                  <code><%= inspect(@config_info.repo) %></code>
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <.raw_config_section config_info={@config_info} />
-      </div>
-    </.dashboard_layout>
-    """
+          <.raw_config_section config_info={@config_info} />
+        </div>
+      </.dashboard_layout>
+      """
+    end
   end
 end

--- a/lib/arcana_web/live/info_live.ex
+++ b/lib/arcana_web/live/info_live.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.InfoLive do

--- a/lib/arcana_web/live/maintenance_live.ex
+++ b/lib/arcana_web/live/maintenance_live.ex
@@ -1,576 +1,588 @@
-defmodule ArcanaWeb.MaintenanceLive do
-  @moduledoc """
-  LiveView for maintenance operations in Arcana.
-  """
-  use Phoenix.LiveView
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs).
 
-  import Ecto.Query
-  import ArcanaWeb.DashboardComponents
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.MaintenanceLive do
+    @moduledoc """
+    LiveView for maintenance operations in Arcana.
+    """
+    use Phoenix.LiveView
 
-  @impl true
-  def mount(_params, session, socket) do
-    repo = get_repo_from_session(session)
+    import Ecto.Query
+    import ArcanaWeb.DashboardComponents
 
-    {:ok,
-     socket
-     |> assign(repo: repo)
-     |> assign(
-       reembed_running: false,
-       reembed_progress: nil,
-       reembed_collection: nil,
-       embedding_info: get_embedding_info(),
-       rebuild_graph_running: false,
-       rebuild_graph_progress: nil,
-       rebuild_graph_collection: nil,
-       graph_info: get_graph_info(),
-       detect_communities_running: false,
-       detect_communities_progress: nil,
-       detect_communities_collection: nil,
-       collections: [],
-       collections_for_assign: [],
-       orphaned_stats: %{entities: 0, relationships: 0},
-       assign_orphans_collection: nil,
-       stats: nil
-     )}
-  end
+    @impl true
+    def mount(_params, session, socket) do
+      repo = get_repo_from_session(session)
 
-  @impl true
-  def handle_params(_params, _uri, socket) do
-    {:noreply, load_data(socket)}
-  end
-
-  defp load_data(socket) do
-    repo = socket.assigns.repo
-    collections = fetch_collections(repo)
-
-    socket
-    |> assign(stats: load_stats(repo))
-    |> assign(collections: Enum.map(collections, & &1.name))
-    |> assign(collections_for_assign: collections)
-    |> assign(orphaned_stats: count_orphaned_graph_data(repo))
-  end
-
-  defp fetch_collections(repo) do
-    repo.all(from(c in Arcana.Collection, select: %{id: c.id, name: c.name}, order_by: c.name))
-  rescue
-    _ -> []
-  end
-
-  defp count_orphaned_graph_data(repo) do
-    entities =
-      repo.one(
-        from(e in Arcana.Graph.Entity, where: is_nil(e.collection_id), select: count(e.id))
-      ) ||
-        0
-
-    # Relationships don't have collection_id - count those connected to orphaned entities
-    relationships =
-      repo.one(
-        from(r in Arcana.Graph.Relationship,
-          join: source in Arcana.Graph.Entity,
-          on: r.source_id == source.id,
-          where: is_nil(source.collection_id),
-          select: count(r.id)
-        )
-      ) || 0
-
-    %{entities: entities, relationships: relationships}
-  rescue
-    _ -> %{entities: 0, relationships: 0}
-  end
-
-  defp get_embedding_info do
-    Arcana.Maintenance.embedding_info()
-  rescue
-    _ -> %{type: :unknown, dimensions: nil}
-  end
-
-  defp get_graph_info do
-    Arcana.Maintenance.graph_info()
-  rescue
-    _ -> %{enabled: false, extractor_type: :unknown}
-  end
-
-  @impl true
-  def handle_event("select_reembed_collection", %{"collection" => collection}, socket) do
-    collection = if collection == "", do: nil, else: collection
-    {:noreply, assign(socket, reembed_collection: collection)}
-  end
-
-  def handle_event("reembed", _params, socket) do
-    repo = socket.assigns.repo
-    collection = socket.assigns.reembed_collection
-    parent = self()
-
-    socket = assign(socket, reembed_running: true, reembed_progress: %{current: 0, total: 0})
-
-    ArcanaWeb.TaskSupervisor.start_child(fn ->
-      progress_fn = fn current, total ->
-        send(parent, {:reembed_progress, current, total})
-      end
-
-      opts = [batch_size: 50, progress: progress_fn]
-      opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
-      result = Arcana.Maintenance.reembed(repo, opts)
-      send(parent, {:reembed_complete, result})
-    end)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("select_rebuild_collection", %{"collection" => collection}, socket) do
-    collection = if collection == "", do: nil, else: collection
-    {:noreply, assign(socket, rebuild_graph_collection: collection)}
-  end
-
-  def handle_event("rebuild_graph", _params, socket) do
-    repo = socket.assigns.repo
-    collection = socket.assigns.rebuild_graph_collection
-    parent = self()
-
-    socket =
-      assign(socket, rebuild_graph_running: true, rebuild_graph_progress: %{current: 0, total: 0})
-
-    ArcanaWeb.TaskSupervisor.start_child(fn ->
-      progress_fn = fn current, total ->
-        send(parent, {:rebuild_graph_progress, current, total})
-      end
-
-      opts = [progress: progress_fn]
-      opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
-      result = Arcana.Maintenance.rebuild_graph(repo, opts)
-      send(parent, {:rebuild_graph_complete, result})
-    end)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("select_detect_communities_collection", %{"collection" => collection}, socket) do
-    collection = if collection == "", do: nil, else: collection
-    {:noreply, assign(socket, detect_communities_collection: collection)}
-  end
-
-  def handle_event("detect_communities", _params, socket) do
-    repo = socket.assigns.repo
-    collection = socket.assigns.detect_communities_collection
-    parent = self()
-
-    socket =
-      assign(socket,
-        detect_communities_running: true,
-        detect_communities_progress: %{current: 0, total: 0}
-      )
-
-    ArcanaWeb.TaskSupervisor.start_child(fn ->
-      progress_fn = fn current, total ->
-        send(parent, {:detect_communities_progress, current, total})
-      end
-
-      opts = [progress: progress_fn]
-      opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
-      result = Arcana.Maintenance.detect_communities(repo, opts)
-      send(parent, {:detect_communities_complete, result})
-    end)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("select_assign_collection", %{"collection" => collection}, socket) do
-    collection = if collection == "", do: nil, else: collection
-    {:noreply, assign(socket, assign_orphans_collection: collection)}
-  end
-
-  def handle_event("assign_orphans", _params, socket) do
-    repo = socket.assigns.repo
-    collection_name = socket.assigns.assign_orphans_collection
-
-    if collection_name do
-      collection =
-        Enum.find(socket.assigns.collections_for_assign, &(&1.name == collection_name))
-
-      if collection do
-        assign_orphaned_to_collection(repo, collection.id)
-
-        socket =
-          socket
-          |> load_data()
-          |> put_flash(:info, "Assigned orphaned graph data to #{collection_name}")
-
-        {:noreply, socket}
-      else
-        {:noreply, put_flash(socket, :error, "Collection not found")}
-      end
-    else
-      {:noreply, put_flash(socket, :error, "Please select a collection")}
+      {:ok,
+       socket
+       |> assign(repo: repo)
+       |> assign(
+         reembed_running: false,
+         reembed_progress: nil,
+         reembed_collection: nil,
+         embedding_info: get_embedding_info(),
+         rebuild_graph_running: false,
+         rebuild_graph_progress: nil,
+         rebuild_graph_collection: nil,
+         graph_info: get_graph_info(),
+         detect_communities_running: false,
+         detect_communities_progress: nil,
+         detect_communities_collection: nil,
+         collections: [],
+         collections_for_assign: [],
+         orphaned_stats: %{entities: 0, relationships: 0},
+         assign_orphans_collection: nil,
+         stats: nil
+       )}
     end
-  end
 
-  def handle_event("delete_orphans", _params, socket) do
-    repo = socket.assigns.repo
-    {entities_deleted, relationships_deleted} = delete_orphaned_graph_data(repo)
+    @impl true
+    def handle_params(_params, _uri, socket) do
+      {:noreply, load_data(socket)}
+    end
 
-    socket =
+    defp load_data(socket) do
+      repo = socket.assigns.repo
+      collections = fetch_collections(repo)
+
       socket
-      |> load_data()
-      |> put_flash(
-        :info,
-        "Deleted #{entities_deleted} orphaned entities and #{relationships_deleted} orphaned relationships"
-      )
+      |> assign(stats: load_stats(repo))
+      |> assign(collections: Enum.map(collections, & &1.name))
+      |> assign(collections_for_assign: collections)
+      |> assign(orphaned_stats: count_orphaned_graph_data(repo))
+    end
 
-    {:noreply, socket}
-  end
+    defp fetch_collections(repo) do
+      repo.all(from(c in Arcana.Collection, select: %{id: c.id, name: c.name}, order_by: c.name))
+    rescue
+      _ -> []
+    end
 
-  defp assign_orphaned_to_collection(repo, collection_id) do
-    # Only entities have collection_id - relationships reference entities
-    repo.update_all(
-      from(e in Arcana.Graph.Entity, where: is_nil(e.collection_id)),
-      set: [collection_id: collection_id]
-    )
-  end
+    defp count_orphaned_graph_data(repo) do
+      entities =
+        repo.one(
+          from(e in Arcana.Graph.Entity, where: is_nil(e.collection_id), select: count(e.id))
+        ) ||
+          0
 
-  defp delete_orphaned_graph_data(repo) do
-    # Get orphaned entity IDs first
-    orphaned_entity_ids =
-      repo.all(
-        from(e in Arcana.Graph.Entity,
-          where: is_nil(e.collection_id),
-          select: e.id
-        )
-      )
-
-    # Delete relationships connected to orphaned entities (must be done first)
-    {rel_count, _} =
-      if orphaned_entity_ids != [] do
-        repo.delete_all(
+      # Relationships don't have collection_id - count those connected to orphaned entities
+      relationships =
+        repo.one(
           from(r in Arcana.Graph.Relationship,
-            where: r.source_id in ^orphaned_entity_ids or r.target_id in ^orphaned_entity_ids
+            join: source in Arcana.Graph.Entity,
+            on: r.source_id == source.id,
+            where: is_nil(source.collection_id),
+            select: count(r.id)
+          )
+        ) || 0
+
+      %{entities: entities, relationships: relationships}
+    rescue
+      _ -> %{entities: 0, relationships: 0}
+    end
+
+    defp get_embedding_info do
+      Arcana.Maintenance.embedding_info()
+    rescue
+      _ -> %{type: :unknown, dimensions: nil}
+    end
+
+    defp get_graph_info do
+      Arcana.Maintenance.graph_info()
+    rescue
+      _ -> %{enabled: false, extractor_type: :unknown}
+    end
+
+    @impl true
+    def handle_event("select_reembed_collection", %{"collection" => collection}, socket) do
+      collection = if collection == "", do: nil, else: collection
+      {:noreply, assign(socket, reembed_collection: collection)}
+    end
+
+    def handle_event("reembed", _params, socket) do
+      repo = socket.assigns.repo
+      collection = socket.assigns.reembed_collection
+      parent = self()
+
+      socket = assign(socket, reembed_running: true, reembed_progress: %{current: 0, total: 0})
+
+      ArcanaWeb.TaskSupervisor.start_child(fn ->
+        progress_fn = fn current, total ->
+          send(parent, {:reembed_progress, current, total})
+        end
+
+        opts = [batch_size: 50, progress: progress_fn]
+        opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
+        result = Arcana.Maintenance.reembed(repo, opts)
+        send(parent, {:reembed_complete, result})
+      end)
+
+      {:noreply, socket}
+    end
+
+    def handle_event("select_rebuild_collection", %{"collection" => collection}, socket) do
+      collection = if collection == "", do: nil, else: collection
+      {:noreply, assign(socket, rebuild_graph_collection: collection)}
+    end
+
+    def handle_event("rebuild_graph", _params, socket) do
+      repo = socket.assigns.repo
+      collection = socket.assigns.rebuild_graph_collection
+      parent = self()
+
+      socket =
+        assign(socket,
+          rebuild_graph_running: true,
+          rebuild_graph_progress: %{current: 0, total: 0}
+        )
+
+      ArcanaWeb.TaskSupervisor.start_child(fn ->
+        progress_fn = fn current, total ->
+          send(parent, {:rebuild_graph_progress, current, total})
+        end
+
+        opts = [progress: progress_fn]
+        opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
+        result = Arcana.Maintenance.rebuild_graph(repo, opts)
+        send(parent, {:rebuild_graph_complete, result})
+      end)
+
+      {:noreply, socket}
+    end
+
+    def handle_event(
+          "select_detect_communities_collection",
+          %{"collection" => collection},
+          socket
+        ) do
+      collection = if collection == "", do: nil, else: collection
+      {:noreply, assign(socket, detect_communities_collection: collection)}
+    end
+
+    def handle_event("detect_communities", _params, socket) do
+      repo = socket.assigns.repo
+      collection = socket.assigns.detect_communities_collection
+      parent = self()
+
+      socket =
+        assign(socket,
+          detect_communities_running: true,
+          detect_communities_progress: %{current: 0, total: 0}
+        )
+
+      ArcanaWeb.TaskSupervisor.start_child(fn ->
+        progress_fn = fn current, total ->
+          send(parent, {:detect_communities_progress, current, total})
+        end
+
+        opts = [progress: progress_fn]
+        opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
+        result = Arcana.Maintenance.detect_communities(repo, opts)
+        send(parent, {:detect_communities_complete, result})
+      end)
+
+      {:noreply, socket}
+    end
+
+    def handle_event("select_assign_collection", %{"collection" => collection}, socket) do
+      collection = if collection == "", do: nil, else: collection
+      {:noreply, assign(socket, assign_orphans_collection: collection)}
+    end
+
+    def handle_event("assign_orphans", _params, socket) do
+      repo = socket.assigns.repo
+      collection_name = socket.assigns.assign_orphans_collection
+
+      if collection_name do
+        collection =
+          Enum.find(socket.assigns.collections_for_assign, &(&1.name == collection_name))
+
+        if collection do
+          assign_orphaned_to_collection(repo, collection.id)
+
+          socket =
+            socket
+            |> load_data()
+            |> put_flash(:info, "Assigned orphaned graph data to #{collection_name}")
+
+          {:noreply, socket}
+        else
+          {:noreply, put_flash(socket, :error, "Collection not found")}
+        end
+      else
+        {:noreply, put_flash(socket, :error, "Please select a collection")}
+      end
+    end
+
+    def handle_event("delete_orphans", _params, socket) do
+      repo = socket.assigns.repo
+      {entities_deleted, relationships_deleted} = delete_orphaned_graph_data(repo)
+
+      socket =
+        socket
+        |> load_data()
+        |> put_flash(
+          :info,
+          "Deleted #{entities_deleted} orphaned entities and #{relationships_deleted} orphaned relationships"
+        )
+
+      {:noreply, socket}
+    end
+
+    defp assign_orphaned_to_collection(repo, collection_id) do
+      # Only entities have collection_id - relationships reference entities
+      repo.update_all(
+        from(e in Arcana.Graph.Entity, where: is_nil(e.collection_id)),
+        set: [collection_id: collection_id]
+      )
+    end
+
+    defp delete_orphaned_graph_data(repo) do
+      # Get orphaned entity IDs first
+      orphaned_entity_ids =
+        repo.all(
+          from(e in Arcana.Graph.Entity,
+            where: is_nil(e.collection_id),
+            select: e.id
           )
         )
-      else
-        {0, nil}
-      end
 
-    # Then delete orphaned entities
-    {entity_count, _} =
-      repo.delete_all(from(e in Arcana.Graph.Entity, where: is_nil(e.collection_id)))
-
-    {entity_count, rel_count}
-  end
-
-  @impl true
-  def handle_info({:reembed_progress, current, total}, socket) do
-    {:noreply, assign(socket, reembed_progress: %{current: current, total: total})}
-  end
-
-  def handle_info({:reembed_complete, result}, socket) do
-    socket =
-      case result do
-        {:ok, %{reembedded: count}} ->
-          socket
-          |> assign(reembed_running: false, reembed_progress: nil)
-          |> put_flash(:info, "Re-embedded #{count} chunks successfully!")
-
-        {:error, reason} ->
-          socket
-          |> assign(reembed_running: false, reembed_progress: nil)
-          |> put_flash(:error, "Re-embedding failed: #{inspect(reason)}")
-      end
-
-    {:noreply, socket}
-  end
-
-  def handle_info({:rebuild_graph_progress, current, total}, socket) do
-    {:noreply, assign(socket, rebuild_graph_progress: %{current: current, total: total})}
-  end
-
-  def handle_info({:rebuild_graph_complete, result}, socket) do
-    socket =
-      case result do
-        {:ok, %{entities: entities, relationships: relationships}} ->
-          socket
-          |> assign(rebuild_graph_running: false, rebuild_graph_progress: nil)
-          |> load_data()
-          |> put_flash(
-            :info,
-            "Rebuilt graph: #{entities} entities, #{relationships} relationships"
+      # Delete relationships connected to orphaned entities (must be done first)
+      {rel_count, _} =
+        if orphaned_entity_ids != [] do
+          repo.delete_all(
+            from(r in Arcana.Graph.Relationship,
+              where: r.source_id in ^orphaned_entity_ids or r.target_id in ^orphaned_entity_ids
+            )
           )
+        else
+          {0, nil}
+        end
 
-        {:error, reason} ->
-          socket
-          |> assign(rebuild_graph_running: false, rebuild_graph_progress: nil)
-          |> put_flash(:error, "Rebuild graph failed: #{inspect(reason)}")
-      end
+      # Then delete orphaned entities
+      {entity_count, _} =
+        repo.delete_all(from(e in Arcana.Graph.Entity, where: is_nil(e.collection_id)))
 
-    {:noreply, socket}
-  end
+      {entity_count, rel_count}
+    end
 
-  def handle_info({:detect_communities_progress, current, total}, socket) do
-    {:noreply, assign(socket, detect_communities_progress: %{current: current, total: total})}
-  end
+    @impl true
+    def handle_info({:reembed_progress, current, total}, socket) do
+      {:noreply, assign(socket, reembed_progress: %{current: current, total: total})}
+    end
 
-  def handle_info({:detect_communities_complete, result}, socket) do
-    socket =
-      case result do
-        {:ok, %{communities: communities}} ->
-          socket
-          |> assign(detect_communities_running: false, detect_communities_progress: nil)
-          |> load_data()
-          |> put_flash(:info, "Detected #{communities} communities successfully!")
+    def handle_info({:reembed_complete, result}, socket) do
+      socket =
+        case result do
+          {:ok, %{reembedded: count}} ->
+            socket
+            |> assign(reembed_running: false, reembed_progress: nil)
+            |> put_flash(:info, "Re-embedded #{count} chunks successfully!")
 
-        {:error, reason} ->
-          socket
-          |> assign(detect_communities_running: false, detect_communities_progress: nil)
-          |> put_flash(:error, "Community detection failed: #{inspect(reason)}")
-      end
+          {:error, reason} ->
+            socket
+            |> assign(reembed_running: false, reembed_progress: nil)
+            |> put_flash(:error, "Re-embedding failed: #{inspect(reason)}")
+        end
 
-    {:noreply, socket}
-  end
+      {:noreply, socket}
+    end
 
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:maintenance} prefix={@prefix}>
-      <div class="arcana-maintenance">
-        <h2>Maintenance</h2>
-        <p class="arcana-tab-description">
-          View embedding configuration and re-embed documents if settings change.
-        </p>
+    def handle_info({:rebuild_graph_progress, current, total}, socket) do
+      {:noreply, assign(socket, rebuild_graph_progress: %{current: current, total: total})}
+    end
 
-        <div class="arcana-maintenance-section">
-          <h3>Embedding Configuration</h3>
-          <div class="arcana-doc-info">
-            <div class="arcana-doc-field">
-              <label>Type</label>
-              <span><%= @embedding_info.type %></span>
-            </div>
-            <%= if @embedding_info[:model] do %>
+    def handle_info({:rebuild_graph_complete, result}, socket) do
+      socket =
+        case result do
+          {:ok, %{entities: entities, relationships: relationships}} ->
+            socket
+            |> assign(rebuild_graph_running: false, rebuild_graph_progress: nil)
+            |> load_data()
+            |> put_flash(
+              :info,
+              "Rebuilt graph: #{entities} entities, #{relationships} relationships"
+            )
+
+          {:error, reason} ->
+            socket
+            |> assign(rebuild_graph_running: false, rebuild_graph_progress: nil)
+            |> put_flash(:error, "Rebuild graph failed: #{inspect(reason)}")
+        end
+
+      {:noreply, socket}
+    end
+
+    def handle_info({:detect_communities_progress, current, total}, socket) do
+      {:noreply, assign(socket, detect_communities_progress: %{current: current, total: total})}
+    end
+
+    def handle_info({:detect_communities_complete, result}, socket) do
+      socket =
+        case result do
+          {:ok, %{communities: communities}} ->
+            socket
+            |> assign(detect_communities_running: false, detect_communities_progress: nil)
+            |> load_data()
+            |> put_flash(:info, "Detected #{communities} communities successfully!")
+
+          {:error, reason} ->
+            socket
+            |> assign(detect_communities_running: false, detect_communities_progress: nil)
+            |> put_flash(:error, "Community detection failed: #{inspect(reason)}")
+        end
+
+      {:noreply, socket}
+    end
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.dashboard_layout stats={@stats} current_tab={:maintenance} prefix={@prefix}>
+        <div class="arcana-maintenance">
+          <h2>Maintenance</h2>
+          <p class="arcana-tab-description">
+            View embedding configuration and re-embed documents if settings change.
+          </p>
+
+          <div class="arcana-maintenance-section">
+            <h3>Embedding Configuration</h3>
+            <div class="arcana-doc-info">
               <div class="arcana-doc-field">
-                <label>Model</label>
-                <span><%= @embedding_info.model %></span>
+                <label>Type</label>
+                <span><%= @embedding_info.type %></span>
               </div>
-            <% end %>
-            <div class="arcana-doc-field">
-              <label>Dimensions</label>
-              <span><%= @embedding_info.dimensions || "Unknown" %></span>
+              <%= if @embedding_info[:model] do %>
+                <div class="arcana-doc-field">
+                  <label>Model</label>
+                  <span><%= @embedding_info.model %></span>
+                </div>
+              <% end %>
+              <div class="arcana-doc-field">
+                <label>Dimensions</label>
+                <span><%= @embedding_info.dimensions || "Unknown" %></span>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="arcana-maintenance-section">
-          <h3>Re-embed Chunks</h3>
-          <p style="color: #6b7280; margin-bottom: 1rem; font-size: 0.875rem;">
-            Re-embed chunks using the current embedding configuration.
-            Use this after changing embedding models.
-          </p>
-
-          <%= if @reembed_running do %>
-            <div class="arcana-progress">
-              <div class="arcana-progress-text">
-                Re-embedding... <%= @reembed_progress.current %>/<%= @reembed_progress.total %>
-              </div>
-              <%= if @reembed_progress.total > 0 do %>
-                <progress
-                  value={@reembed_progress.current}
-                  max={@reembed_progress.total}
-                  style="width: 100%; height: 1rem;"
-                >
-                  <%= round(@reembed_progress.current / @reembed_progress.total * 100) %>%
-                </progress>
-              <% end %>
-            </div>
-          <% else %>
-            <div style="display: flex; gap: 0.75rem; align-items: stretch;">
-              <select
-                phx-change="select_reembed_collection"
-                name="collection"
-                style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
-              >
-                <option value="">All Collections</option>
-                <%= for collection <- @collections do %>
-                  <option value={collection} selected={@reembed_collection == collection}>
-                    <%= collection %>
-                  </option>
-                <% end %>
-              </select>
-              <button
-                phx-click="reembed"
-                style="background: #7c3aed; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap;"
-              >
-                Re-embed
-              </button>
-            </div>
-          <% end %>
-        </div>
-
-        <div class="arcana-maintenance-section">
-          <h3>Graph Configuration</h3>
-          <div class="arcana-doc-info">
-            <div class="arcana-doc-field">
-              <label>Status</label>
-              <span class={"arcana-status-badge #{if @graph_info.enabled, do: "enabled", else: "disabled"}"}>
-                <%= if @graph_info.enabled, do: "Enabled", else: "Disabled" %>
-              </span>
-            </div>
-            <div class="arcana-doc-field">
-              <label>Extractor</label>
-              <span>
-                <%= @graph_info.extractor_name || @graph_info.extractor_type %>
-                <%= if @graph_info.extractor_type == :combined do %>
-                  <span style="color: #6b7280; font-size: 0.75rem;">(combined)</span>
-                <% end %>
-              </span>
-            </div>
-            <div class="arcana-doc-field">
-              <label>Community Levels</label>
-              <span><%= @graph_info.community_levels %></span>
-            </div>
-          </div>
-        </div>
-
-        <div class="arcana-maintenance-section">
-          <h3>Rebuild Knowledge Graph</h3>
-          <p style="color: #6b7280; margin-bottom: 1rem; font-size: 0.875rem;">
-            Clear and rebuild the knowledge graph.
-            Use this after changing graph extractor configuration or enabling relationship extraction.
-          </p>
-
-          <%= if @rebuild_graph_running do %>
-            <div class="arcana-progress">
-              <div class="arcana-progress-text">
-                Rebuilding graph... <%= @rebuild_graph_progress.current %>/<%= @rebuild_graph_progress.total %> collections
-              </div>
-              <%= if @rebuild_graph_progress.total > 0 do %>
-                <progress
-                  value={@rebuild_graph_progress.current}
-                  max={@rebuild_graph_progress.total}
-                  style="width: 100%; height: 1rem;"
-                >
-                  <%= round(@rebuild_graph_progress.current / @rebuild_graph_progress.total * 100) %>%
-                </progress>
-              <% end %>
-            </div>
-          <% else %>
-            <div style="display: flex; gap: 0.75rem; align-items: stretch;">
-              <select
-                phx-change="select_rebuild_collection"
-                name="collection"
-                style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
-              >
-                <option value="">All Collections</option>
-                <%= for collection <- @collections do %>
-                  <option value={collection} selected={@rebuild_graph_collection == collection}>
-                    <%= collection %>
-                  </option>
-                <% end %>
-              </select>
-              <button
-                phx-click="rebuild_graph"
-                style="background: #10b981; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap;"
-              >
-                Rebuild Graph
-              </button>
-            </div>
-          <% end %>
-        </div>
-
-        <div class="arcana-maintenance-section">
-          <h3>Detect Communities</h3>
-          <p style="color: #6b7280; margin-bottom: 1rem; font-size: 0.875rem;">
-            Run Leiden community detection on the knowledge graph.
-            Communities enable global queries by grouping related entities.
-          </p>
-
-          <%= if @detect_communities_running do %>
-            <div class="arcana-progress">
-              <div class="arcana-progress-text">
-                Detecting communities... <%= @detect_communities_progress.current %>/<%= @detect_communities_progress.total %> collections
-              </div>
-              <%= if @detect_communities_progress.total > 0 do %>
-                <progress
-                  value={@detect_communities_progress.current}
-                  max={@detect_communities_progress.total}
-                  style="width: 100%; height: 1rem;"
-                >
-                  <%= round(@detect_communities_progress.current / @detect_communities_progress.total * 100) %>%
-                </progress>
-              <% end %>
-            </div>
-          <% else %>
-            <div style="display: flex; gap: 0.75rem; align-items: stretch;">
-              <select
-                phx-change="select_detect_communities_collection"
-                name="collection"
-                style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
-              >
-                <option value="">All Collections</option>
-                <%= for collection <- @collections do %>
-                  <option value={collection} selected={@detect_communities_collection == collection}>
-                    <%= collection %>
-                  </option>
-                <% end %>
-              </select>
-              <button
-                phx-click="detect_communities"
-                style="background: #8b5cf6; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap;"
-              >
-                Detect Communities
-              </button>
-            </div>
-          <% end %>
-        </div>
-
-        <%= if @orphaned_stats.entities > 0 or @orphaned_stats.relationships > 0 do %>
-          <div class="arcana-maintenance-section arcana-orphan-section">
-            <h3>Orphaned Graph Data</h3>
+          <div class="arcana-maintenance-section">
+            <h3>Re-embed Chunks</h3>
             <p style="color: #6b7280; margin-bottom: 1rem; font-size: 0.875rem;">
-              These entities and relationships don't belong to any collection.
-              Assign them to a collection or delete them.
+              Re-embed chunks using the current embedding configuration.
+              Use this after changing embedding models.
             </p>
 
-            <div class="arcana-doc-info" style="margin-bottom: 1rem;">
-              <div class="arcana-doc-field">
-                <label>Orphaned Entities</label>
-                <span class="arcana-orphan-count"><%= @orphaned_stats.entities %></span>
-              </div>
-              <div class="arcana-doc-field">
-                <label>Orphaned Relationships</label>
-                <span class="arcana-orphan-count"><%= @orphaned_stats.relationships %></span>
-              </div>
-            </div>
-
-            <div style="display: flex; gap: 0.75rem; align-items: stretch; flex-wrap: wrap;">
-              <select
-                phx-change="select_assign_collection"
-                name="collection"
-                style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
-              >
-                <option value="">Select collection...</option>
-                <%= for collection <- @collections do %>
-                  <option value={collection} selected={@assign_orphans_collection == collection}>
-                    <%= collection %>
-                  </option>
+            <%= if @reembed_running do %>
+              <div class="arcana-progress">
+                <div class="arcana-progress-text">
+                  Re-embedding... <%= @reembed_progress.current %>/<%= @reembed_progress.total %>
+                </div>
+                <%= if @reembed_progress.total > 0 do %>
+                  <progress
+                    value={@reembed_progress.current}
+                    max={@reembed_progress.total}
+                    style="width: 100%; height: 1rem;"
+                  >
+                    <%= round(@reembed_progress.current / @reembed_progress.total * 100) %>%
+                  </progress>
                 <% end %>
-              </select>
-              <button
-                phx-click="assign_orphans"
-                disabled={is_nil(@assign_orphans_collection)}
-                class="arcana-assign-btn"
-                style={"background: #3b82f6; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap; opacity: #{if is_nil(@assign_orphans_collection), do: "0.5", else: "1"};"}
-              >
-                Assign to Collection
-              </button>
-              <button
-                phx-click="delete_orphans"
-                data-confirm="Are you sure you want to delete all orphaned entities and relationships? This cannot be undone."
-                style="background: #ef4444; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap;"
-              >
-                Delete All Orphans
-              </button>
+              </div>
+            <% else %>
+              <div style="display: flex; gap: 0.75rem; align-items: stretch;">
+                <select
+                  phx-change="select_reembed_collection"
+                  name="collection"
+                  style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
+                >
+                  <option value="">All Collections</option>
+                  <%= for collection <- @collections do %>
+                    <option value={collection} selected={@reembed_collection == collection}>
+                      <%= collection %>
+                    </option>
+                  <% end %>
+                </select>
+                <button
+                  phx-click="reembed"
+                  style="background: #7c3aed; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap;"
+                >
+                  Re-embed
+                </button>
+              </div>
+            <% end %>
+          </div>
+
+          <div class="arcana-maintenance-section">
+            <h3>Graph Configuration</h3>
+            <div class="arcana-doc-info">
+              <div class="arcana-doc-field">
+                <label>Status</label>
+                <span class={"arcana-status-badge #{if @graph_info.enabled, do: "enabled", else: "disabled"}"}>
+                  <%= if @graph_info.enabled, do: "Enabled", else: "Disabled" %>
+                </span>
+              </div>
+              <div class="arcana-doc-field">
+                <label>Extractor</label>
+                <span>
+                  <%= @graph_info.extractor_name || @graph_info.extractor_type %>
+                  <%= if @graph_info.extractor_type == :combined do %>
+                    <span style="color: #6b7280; font-size: 0.75rem;">(combined)</span>
+                  <% end %>
+                </span>
+              </div>
+              <div class="arcana-doc-field">
+                <label>Community Levels</label>
+                <span><%= @graph_info.community_levels %></span>
+              </div>
             </div>
           </div>
-        <% end %>
-      </div>
-    </.dashboard_layout>
-    """
+
+          <div class="arcana-maintenance-section">
+            <h3>Rebuild Knowledge Graph</h3>
+            <p style="color: #6b7280; margin-bottom: 1rem; font-size: 0.875rem;">
+              Clear and rebuild the knowledge graph.
+              Use this after changing graph extractor configuration or enabling relationship extraction.
+            </p>
+
+            <%= if @rebuild_graph_running do %>
+              <div class="arcana-progress">
+                <div class="arcana-progress-text">
+                  Rebuilding graph... <%= @rebuild_graph_progress.current %>/<%= @rebuild_graph_progress.total %> collections
+                </div>
+                <%= if @rebuild_graph_progress.total > 0 do %>
+                  <progress
+                    value={@rebuild_graph_progress.current}
+                    max={@rebuild_graph_progress.total}
+                    style="width: 100%; height: 1rem;"
+                  >
+                    <%= round(@rebuild_graph_progress.current / @rebuild_graph_progress.total * 100) %>%
+                  </progress>
+                <% end %>
+              </div>
+            <% else %>
+              <div style="display: flex; gap: 0.75rem; align-items: stretch;">
+                <select
+                  phx-change="select_rebuild_collection"
+                  name="collection"
+                  style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
+                >
+                  <option value="">All Collections</option>
+                  <%= for collection <- @collections do %>
+                    <option value={collection} selected={@rebuild_graph_collection == collection}>
+                      <%= collection %>
+                    </option>
+                  <% end %>
+                </select>
+                <button
+                  phx-click="rebuild_graph"
+                  style="background: #10b981; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap;"
+                >
+                  Rebuild Graph
+                </button>
+              </div>
+            <% end %>
+          </div>
+
+          <div class="arcana-maintenance-section">
+            <h3>Detect Communities</h3>
+            <p style="color: #6b7280; margin-bottom: 1rem; font-size: 0.875rem;">
+              Run Leiden community detection on the knowledge graph.
+              Communities enable global queries by grouping related entities.
+            </p>
+
+            <%= if @detect_communities_running do %>
+              <div class="arcana-progress">
+                <div class="arcana-progress-text">
+                  Detecting communities... <%= @detect_communities_progress.current %>/<%= @detect_communities_progress.total %> collections
+                </div>
+                <%= if @detect_communities_progress.total > 0 do %>
+                  <progress
+                    value={@detect_communities_progress.current}
+                    max={@detect_communities_progress.total}
+                    style="width: 100%; height: 1rem;"
+                  >
+                    <%= round(@detect_communities_progress.current / @detect_communities_progress.total * 100) %>%
+                  </progress>
+                <% end %>
+              </div>
+            <% else %>
+              <div style="display: flex; gap: 0.75rem; align-items: stretch;">
+                <select
+                  phx-change="select_detect_communities_collection"
+                  name="collection"
+                  style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
+                >
+                  <option value="">All Collections</option>
+                  <%= for collection <- @collections do %>
+                    <option value={collection} selected={@detect_communities_collection == collection}>
+                      <%= collection %>
+                    </option>
+                  <% end %>
+                </select>
+                <button
+                  phx-click="detect_communities"
+                  style="background: #8b5cf6; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap;"
+                >
+                  Detect Communities
+                </button>
+              </div>
+            <% end %>
+          </div>
+
+          <%= if @orphaned_stats.entities > 0 or @orphaned_stats.relationships > 0 do %>
+            <div class="arcana-maintenance-section arcana-orphan-section">
+              <h3>Orphaned Graph Data</h3>
+              <p style="color: #6b7280; margin-bottom: 1rem; font-size: 0.875rem;">
+                These entities and relationships don't belong to any collection.
+                Assign them to a collection or delete them.
+              </p>
+
+              <div class="arcana-doc-info" style="margin-bottom: 1rem;">
+                <div class="arcana-doc-field">
+                  <label>Orphaned Entities</label>
+                  <span class="arcana-orphan-count"><%= @orphaned_stats.entities %></span>
+                </div>
+                <div class="arcana-doc-field">
+                  <label>Orphaned Relationships</label>
+                  <span class="arcana-orphan-count"><%= @orphaned_stats.relationships %></span>
+                </div>
+              </div>
+
+              <div style="display: flex; gap: 0.75rem; align-items: stretch; flex-wrap: wrap;">
+                <select
+                  phx-change="select_assign_collection"
+                  name="collection"
+                  style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
+                >
+                  <option value="">Select collection...</option>
+                  <%= for collection <- @collections do %>
+                    <option value={collection} selected={@assign_orphans_collection == collection}>
+                      <%= collection %>
+                    </option>
+                  <% end %>
+                </select>
+                <button
+                  phx-click="assign_orphans"
+                  disabled={is_nil(@assign_orphans_collection)}
+                  class="arcana-assign-btn"
+                  style={"background: #3b82f6; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap; opacity: #{if is_nil(@assign_orphans_collection), do: "0.5", else: "1"};"}
+                >
+                  Assign to Collection
+                </button>
+                <button
+                  phx-click="delete_orphans"
+                  data-confirm="Are you sure you want to delete all orphaned entities and relationships? This cannot be undone."
+                  style="background: #ef4444; color: white; padding: 0.5rem 1rem; border: none; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; white-space: nowrap;"
+                >
+                  Delete All Orphans
+                </button>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </.dashboard_layout>
+      """
+    end
   end
 end

--- a/lib/arcana_web/live/maintenance_live.ex
+++ b/lib/arcana_web/live/maintenance_live.ex
@@ -1,5 +1,6 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs).
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.MaintenanceLive do

--- a/lib/arcana_web/live/search_live.ex
+++ b/lib/arcana_web/live/search_live.ex
@@ -1,281 +1,287 @@
-defmodule ArcanaWeb.SearchLive do
-  @moduledoc """
-  LiveView for searching documents in Arcana.
-  """
-  use Phoenix.LiveView
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Only
+# ArcanaWeb.TaskSupervisor is phoenix-free and stays available.
 
-  import ArcanaWeb.DashboardComponents
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.SearchLive do
+    @moduledoc """
+    LiveView for searching documents in Arcana.
+    """
+    use Phoenix.LiveView
 
-  alias Arcana.Document
+    import ArcanaWeb.DashboardComponents
 
-  @impl true
-  def mount(_params, session, socket) do
-    repo = get_repo_from_session(session)
+    alias Arcana.Document
 
-    {:ok,
-     socket
-     |> assign(repo: repo)
-     |> assign(
-       search_results: [],
-       search_query: "",
-       expanded_result_id: nil,
-       viewing_document: nil,
-       stats: nil,
-       collections: [],
-       source_ids: []
-     )}
-  end
+    @impl true
+    def mount(_params, session, socket) do
+      repo = get_repo_from_session(session)
 
-  @impl true
-  def handle_params(_params, _uri, socket) do
-    {:noreply, load_data(socket)}
-  end
-
-  defp load_data(socket) do
-    repo = socket.assigns.repo
-
-    socket
-    |> assign(stats: load_stats(repo))
-    |> assign(collections: load_collections(repo))
-    |> assign(source_ids: load_source_ids(repo))
-  end
-
-  @impl true
-  def handle_event("search", params, socket) do
-    query = params["query"] || ""
-    results = run_search(query, params, socket.assigns.repo)
-
-    {:noreply,
-     assign(socket, search_results: results, search_query: query, expanded_result_id: nil)}
-  end
-
-  def handle_event("toggle_result", %{"id" => id}, socket) do
-    current = socket.assigns.expanded_result_id
-    new_id = if current == id, do: nil, else: id
-    {:noreply, assign(socket, expanded_result_id: new_id)}
-  end
-
-  def handle_event("view_search_document", %{"id" => id}, socket) do
-    repo = socket.assigns.repo
-    import Ecto.Query
-
-    document = repo.get(Document, id)
-
-    chunks =
-      repo.all(
-        from(c in Arcana.Chunk,
-          where: c.document_id == ^id,
-          order_by: c.chunk_index
-        )
-      )
-
-    {:noreply, assign(socket, viewing_document: %{document: document, chunks: chunks})}
-  end
-
-  def handle_event("close_search_document", _params, socket) do
-    {:noreply, assign(socket, viewing_document: nil)}
-  end
-
-  defp run_search("", _params, _repo), do: []
-
-  defp run_search(query, params, repo) do
-    case params |> build_search_opts(repo) |> then(&Arcana.search(query, &1)) do
-      {:ok, results} -> results
-      {:error, _reason} -> []
+      {:ok,
+       socket
+       |> assign(repo: repo)
+       |> assign(
+         search_results: [],
+         search_query: "",
+         expanded_result_id: nil,
+         viewing_document: nil,
+         stats: nil,
+         collections: [],
+         source_ids: []
+       )}
     end
-  end
 
-  defp build_search_opts(params, repo) do
-    [
-      repo: repo,
-      limit: parse_int(params["limit"], 10),
-      threshold: parse_float(params["threshold"], 0.0),
-      mode: parse_mode(params["mode"])
-    ]
-    |> add_source_id_opt(params["source_id"])
-    |> add_collection_opt(normalize_collections(params["collections"]))
-  end
+    @impl true
+    def handle_params(_params, _uri, socket) do
+      {:noreply, load_data(socket)}
+    end
 
-  defp add_source_id_opt(opts, nil), do: opts
-  defp add_source_id_opt(opts, ""), do: opts
-  defp add_source_id_opt(opts, source_id), do: Keyword.put(opts, :source_id, source_id)
+    defp load_data(socket) do
+      repo = socket.assigns.repo
 
-  defp add_collection_opt(opts, []), do: opts
-  defp add_collection_opt(opts, [single]), do: Keyword.put(opts, :collection, single)
-  defp add_collection_opt(opts, multiple), do: Keyword.put(opts, :collections, multiple)
+      socket
+      |> assign(stats: load_stats(repo))
+      |> assign(collections: load_collections(repo))
+      |> assign(source_ids: load_source_ids(repo))
+    end
 
-  defp normalize_collections(nil), do: []
+    @impl true
+    def handle_event("search", params, socket) do
+      query = params["query"] || ""
+      results = run_search(query, params, socket.assigns.repo)
 
-  defp normalize_collections(collections) when is_list(collections),
-    do: Enum.filter(collections, &(&1 != ""))
+      {:noreply,
+       assign(socket, search_results: results, search_query: query, expanded_result_id: nil)}
+    end
 
-  defp normalize_collections(collection), do: [collection]
+    def handle_event("toggle_result", %{"id" => id}, socket) do
+      current = socket.assigns.expanded_result_id
+      new_id = if current == id, do: nil, else: id
+      {:noreply, assign(socket, expanded_result_id: new_id)}
+    end
 
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <.dashboard_layout stats={@stats} current_tab={:search} prefix={@prefix}>
-      <div class="arcana-search">
-        <%= if @viewing_document do %>
-          <.search_document_detail viewing={@viewing_document} />
-        <% else %>
-          <h2>Search</h2>
-          <p class="arcana-tab-description">
-            Perform vector similarity search to retrieve relevant document chunks from your knowledge base.
-          </p>
+    def handle_event("view_search_document", %{"id" => id}, socket) do
+      repo = socket.assigns.repo
+      import Ecto.Query
 
-          <form id="search-form" phx-submit="search" class="arcana-search-form">
-            <div class="arcana-search-inputs">
-              <input type="text" name="query" placeholder="Enter search query..." value={@search_query} />
+      document = repo.get(Document, id)
 
-              <div class="arcana-search-options">
-                <label>
-                  Mode
-                  <select name="mode">
-                    <option value="vector">Vector</option>
-                    <option value="keyword">Keyword</option>
-                    <option value="hybrid">Hybrid</option>
-                  </select>
-                  <small class="arcana-search-mode-hint">
-                    Vector: embedding similarity. Keyword: exact terms via Postgres full-text.
-                    Hybrid: both fused by Reciprocal Rank Fusion.
-                  </small>
-                </label>
+      chunks =
+        repo.all(
+          from(c in Arcana.Chunk,
+            where: c.document_id == ^id,
+            order_by: c.chunk_index
+          )
+        )
 
-                <label>
-                  Limit
-                  <select name="limit">
-                    <option value="5">5</option>
-                    <option value="10" selected>10</option>
-                    <option value="20">20</option>
-                    <option value="50">50</option>
-                  </select>
-                </label>
+      {:noreply, assign(socket, viewing_document: %{document: document, chunks: chunks})}
+    end
 
-                <label>
-                  Threshold
-                  <input type="number" name="threshold" min="0" max="1" step="0.1" value="0" />
-                </label>
+    def handle_event("close_search_document", _params, socket) do
+      {:noreply, assign(socket, viewing_document: nil)}
+    end
 
-                <label>
-                  Source
-                  <select name="source_id">
-                    <option value="">All sources</option>
-                    <%= for source_id <- @source_ids do %>
-                      <option value={source_id}><%= source_id %></option>
+    defp run_search("", _params, _repo), do: []
+
+    defp run_search(query, params, repo) do
+      case params |> build_search_opts(repo) |> then(&Arcana.search(query, &1)) do
+        {:ok, results} -> results
+        {:error, _reason} -> []
+      end
+    end
+
+    defp build_search_opts(params, repo) do
+      [
+        repo: repo,
+        limit: parse_int(params["limit"], 10),
+        threshold: parse_float(params["threshold"], 0.0),
+        mode: parse_mode(params["mode"])
+      ]
+      |> add_source_id_opt(params["source_id"])
+      |> add_collection_opt(normalize_collections(params["collections"]))
+    end
+
+    defp add_source_id_opt(opts, nil), do: opts
+    defp add_source_id_opt(opts, ""), do: opts
+    defp add_source_id_opt(opts, source_id), do: Keyword.put(opts, :source_id, source_id)
+
+    defp add_collection_opt(opts, []), do: opts
+    defp add_collection_opt(opts, [single]), do: Keyword.put(opts, :collection, single)
+    defp add_collection_opt(opts, multiple), do: Keyword.put(opts, :collections, multiple)
+
+    defp normalize_collections(nil), do: []
+
+    defp normalize_collections(collections) when is_list(collections),
+      do: Enum.filter(collections, &(&1 != ""))
+
+    defp normalize_collections(collection), do: [collection]
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.dashboard_layout stats={@stats} current_tab={:search} prefix={@prefix}>
+        <div class="arcana-search">
+          <%= if @viewing_document do %>
+            <.search_document_detail viewing={@viewing_document} />
+          <% else %>
+            <h2>Search</h2>
+            <p class="arcana-tab-description">
+              Perform vector similarity search to retrieve relevant document chunks from your knowledge base.
+            </p>
+
+            <form id="search-form" phx-submit="search" class="arcana-search-form">
+              <div class="arcana-search-inputs">
+                <input type="text" name="query" placeholder="Enter search query..." value={@search_query} />
+
+                <div class="arcana-search-options">
+                  <label>
+                    Mode
+                    <select name="mode">
+                      <option value="vector">Vector</option>
+                      <option value="keyword">Keyword</option>
+                      <option value="hybrid">Hybrid</option>
+                    </select>
+                    <small class="arcana-search-mode-hint">
+                      Vector: embedding similarity. Keyword: exact terms via Postgres full-text.
+                      Hybrid: both fused by Reciprocal Rank Fusion.
+                    </small>
+                  </label>
+
+                  <label>
+                    Limit
+                    <select name="limit">
+                      <option value="5">5</option>
+                      <option value="10" selected>10</option>
+                      <option value="20">20</option>
+                      <option value="50">50</option>
+                    </select>
+                  </label>
+
+                  <label>
+                    Threshold
+                    <input type="number" name="threshold" min="0" max="1" step="0.1" value="0" />
+                  </label>
+
+                  <label>
+                    Source
+                    <select name="source_id">
+                      <option value="">All sources</option>
+                      <%= for source_id <- @source_ids do %>
+                        <option value={source_id}><%= source_id %></option>
+                      <% end %>
+                    </select>
+                  </label>
+                </div>
+
+                <div class="arcana-ask-collections">
+                  <label>Collections</label>
+                  <div class="arcana-collection-checkboxes">
+                    <%= for collection <- @collections do %>
+                      <label class="arcana-collection-check">
+                        <input type="checkbox" name="collections[]" value={collection.name} />
+                        <span><%= collection.name %></span>
+                      </label>
                     <% end %>
-                  </select>
-                </label>
-              </div>
-
-              <div class="arcana-ask-collections">
-                <label>Collections</label>
-                <div class="arcana-collection-checkboxes">
-                  <%= for collection <- @collections do %>
-                    <label class="arcana-collection-check">
-                      <input type="checkbox" name="collections[]" value={collection.name} />
-                      <span><%= collection.name %></span>
-                    </label>
-                  <% end %>
-                </div>
-                <small class="arcana-collection-hint">Select none for all collections</small>
-              </div>
-            </div>
-
-            <button type="submit">Search</button>
-          </form>
-
-          <%= if Enum.empty?(@search_results) and @search_query != "" do %>
-            <p class="arcana-empty">No results found for "<%= @search_query %>"</p>
-          <% end %>
-
-          <%= if not Enum.empty?(@search_results) do %>
-            <div class="arcana-search-results">
-              <%= for result <- @search_results do %>
-                <div class="arcana-search-result">
-                  <div class="arcana-result-header">
-                    <div class="arcana-result-score">
-                      <span class="score-value"><%= Float.round(result.score, 4) %></span>
-                    </div>
-                    <div class="arcana-result-meta">
-                      <code><%= result.document_id %></code>
-                      <span class="arcana-chunk-badge">Chunk <%= result.chunk_index %></span>
-                    </div>
-                    <div class="arcana-result-actions">
-                      <button
-                        class="arcana-result-btn"
-                        phx-click="toggle_result"
-                        phx-value-id={result.id}
-                      >
-                        <%= if @expanded_result_id == result.id, do: "Collapse", else: "Expand" %>
-                      </button>
-                      <button
-                        class="arcana-result-btn arcana-result-btn-primary"
-                        phx-click="view_search_document"
-                        phx-value-id={result.document_id}
-                      >
-                        View Doc
-                      </button>
-                    </div>
                   </div>
-                  <div class={"arcana-result-text #{if @expanded_result_id == result.id, do: "expanded", else: ""}"}><%= if @expanded_result_id == result.id, do: result.text, else: String.slice(result.text, 0, 200) <> if(String.length(result.text) > 200, do: "...", else: "") %></div>
+                  <small class="arcana-collection-hint">Select none for all collections</small>
                 </div>
-              <% end %>
-            </div>
-          <% end %>
-        <% end %>
-      </div>
-    </.dashboard_layout>
-    """
-  end
-
-  defp search_document_detail(assigns) do
-    ~H"""
-    <div class="arcana-doc-detail">
-      <div class="arcana-doc-header">
-        <h2>Document Details</h2>
-        <button class="arcana-close-btn" phx-click="close_search_document">← Back to search</button>
-      </div>
-
-      <div class="arcana-doc-info">
-        <div class="arcana-doc-field">
-          <label>ID</label>
-          <code><%= @viewing.document.id %></code>
-        </div>
-        <div class="arcana-doc-field">
-          <label>Source</label>
-          <span><%= @viewing.document.source_id || "-" %></span>
-        </div>
-        <div class="arcana-doc-field">
-          <label>Metadata</label>
-          <span><%= format_metadata(@viewing.document.metadata) %></span>
-        </div>
-        <div class="arcana-doc-field">
-          <label>Created</label>
-          <span><%= @viewing.document.inserted_at %></span>
-        </div>
-      </div>
-
-      <div class="arcana-doc-section">
-        <h3>Full Content</h3>
-        <pre class="arcana-doc-content"><%= @viewing.document.content %></pre>
-      </div>
-
-      <div class="arcana-doc-section">
-        <h3>Chunks (<%= length(@viewing.chunks) %>)</h3>
-        <div class="arcana-chunks-list">
-          <%= for chunk <- @viewing.chunks do %>
-            <div class="arcana-chunk">
-              <div class="arcana-chunk-header">
-                <span class="arcana-chunk-index">Chunk <%= chunk.chunk_index %></span>
-                <span class="arcana-chunk-tokens"><%= chunk.token_count %> tokens</span>
               </div>
-              <pre class="arcana-chunk-text"><%= chunk.text %></pre>
-            </div>
+
+              <button type="submit">Search</button>
+            </form>
+
+            <%= if Enum.empty?(@search_results) and @search_query != "" do %>
+              <p class="arcana-empty">No results found for "<%= @search_query %>"</p>
+            <% end %>
+
+            <%= if not Enum.empty?(@search_results) do %>
+              <div class="arcana-search-results">
+                <%= for result <- @search_results do %>
+                  <div class="arcana-search-result">
+                    <div class="arcana-result-header">
+                      <div class="arcana-result-score">
+                        <span class="score-value"><%= Float.round(result.score, 4) %></span>
+                      </div>
+                      <div class="arcana-result-meta">
+                        <code><%= result.document_id %></code>
+                        <span class="arcana-chunk-badge">Chunk <%= result.chunk_index %></span>
+                      </div>
+                      <div class="arcana-result-actions">
+                        <button
+                          class="arcana-result-btn"
+                          phx-click="toggle_result"
+                          phx-value-id={result.id}
+                        >
+                          <%= if @expanded_result_id == result.id, do: "Collapse", else: "Expand" %>
+                        </button>
+                        <button
+                          class="arcana-result-btn arcana-result-btn-primary"
+                          phx-click="view_search_document"
+                          phx-value-id={result.document_id}
+                        >
+                          View Doc
+                        </button>
+                      </div>
+                    </div>
+                    <div class={"arcana-result-text #{if @expanded_result_id == result.id, do: "expanded", else: ""}"}><%= if @expanded_result_id == result.id, do: result.text, else: String.slice(result.text, 0, 200) <> if(String.length(result.text) > 200, do: "...", else: "") %></div>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           <% end %>
         </div>
+      </.dashboard_layout>
+      """
+    end
+
+    defp search_document_detail(assigns) do
+      ~H"""
+      <div class="arcana-doc-detail">
+        <div class="arcana-doc-header">
+          <h2>Document Details</h2>
+          <button class="arcana-close-btn" phx-click="close_search_document">← Back to search</button>
+        </div>
+
+        <div class="arcana-doc-info">
+          <div class="arcana-doc-field">
+            <label>ID</label>
+            <code><%= @viewing.document.id %></code>
+          </div>
+          <div class="arcana-doc-field">
+            <label>Source</label>
+            <span><%= @viewing.document.source_id || "-" %></span>
+          </div>
+          <div class="arcana-doc-field">
+            <label>Metadata</label>
+            <span><%= format_metadata(@viewing.document.metadata) %></span>
+          </div>
+          <div class="arcana-doc-field">
+            <label>Created</label>
+            <span><%= @viewing.document.inserted_at %></span>
+          </div>
+        </div>
+
+        <div class="arcana-doc-section">
+          <h3>Full Content</h3>
+          <pre class="arcana-doc-content"><%= @viewing.document.content %></pre>
+        </div>
+
+        <div class="arcana-doc-section">
+          <h3>Chunks (<%= length(@viewing.chunks) %>)</h3>
+          <div class="arcana-chunks-list">
+            <%= for chunk <- @viewing.chunks do %>
+              <div class="arcana-chunk">
+                <div class="arcana-chunk-header">
+                  <span class="arcana-chunk-index">Chunk <%= chunk.chunk_index %></span>
+                  <span class="arcana-chunk-tokens"><%= chunk.token_count %> tokens</span>
+                </div>
+                <pre class="arcana-chunk-text"><%= chunk.text %></pre>
+              </div>
+            <% end %>
+          </div>
+        </div>
       </div>
-    </div>
-    """
+      """
+    end
   end
 end

--- a/lib/arcana_web/router.ex
+++ b/lib/arcana_web/router.ex
@@ -1,6 +1,7 @@
-# The dashboard is optional: everything under ArcanaWeb only compiles when
-# Phoenix LiveView is available (see the optional deps in mix.exs). Without
-# it, a stub arcana_dashboard/2 raises with instructions at compile time.
+# The dashboard is optional: this module only compiles when Phoenix
+# LiveView is available (see the optional deps in mix.exs). Without
+# phoenix, a stub arcana_dashboard/2 raises with instructions at
+# compile time.
 if Code.ensure_loaded?(Phoenix.LiveView) do
   defmodule ArcanaWeb.Router do
     @moduledoc """

--- a/lib/arcana_web/router.ex
+++ b/lib/arcana_web/router.ex
@@ -1,131 +1,164 @@
-defmodule ArcanaWeb.Router do
-  @moduledoc """
-  Provides LiveView routing for the Arcana dashboard.
+# The dashboard is optional: everything under ArcanaWeb only compiles when
+# Phoenix LiveView is available (see the optional deps in mix.exs). Without
+# it, a stub arcana_dashboard/2 raises with instructions at compile time.
+if Code.ensure_loaded?(Phoenix.LiveView) do
+  defmodule ArcanaWeb.Router do
+    @moduledoc """
+    Provides LiveView routing for the Arcana dashboard.
 
-  ## Usage
+    ## Usage
 
-  Add to your router:
+    Add to your router:
 
-      import ArcanaWeb.Router
+        import ArcanaWeb.Router
 
-      scope "/" do
-        pipe_through :browser
+        scope "/" do
+          pipe_through :browser
 
-        arcana_dashboard "/arcana"
-      end
+          arcana_dashboard "/arcana"
+        end
 
-  ## Options
+    ## Options
 
-    * `:live_socket_path` - The path to the LiveView socket. Defaults to `"/live"`.
+      * `:live_socket_path` - The path to the LiveView socket. Defaults to `"/live"`.
 
-    * `:repo` - The Ecto repo to use for Arcana operations. If not provided,
-      falls back to `Application.get_env(:arcana, :repo)`.
+      * `:repo` - The Ecto repo to use for Arcana operations. If not provided,
+        falls back to `Application.get_env(:arcana, :repo)`.
 
-    * `:on_mount` - Optional list of `Phoenix.LiveView.on_mount/1` callbacks
-      to add to the dashboard's live_session.
+      * `:on_mount` - Optional list of `Phoenix.LiveView.on_mount/1` callbacks
+        to add to the dashboard's live_session.
 
-  ## Example with options
+    ## Example with options
 
-      arcana_dashboard "/arcana",
-        repo: MyApp.Repo,
-        on_mount: [MyAppWeb.Auth]
+        arcana_dashboard "/arcana",
+          repo: MyApp.Repo,
+          on_mount: [MyAppWeb.Auth]
 
-  """
+    """
 
-  @doc """
-  Defines an Arcana dashboard route.
+    @doc """
+    Defines an Arcana dashboard route.
 
-  It expects the `path` the dashboard will be mounted at
-  and a set of options.
-  """
-  defmacro arcana_dashboard(path, opts \\ []) do
-    opts =
-      if Macro.quoted_literal?(opts) do
-        Macro.prewalk(opts, &expand_alias(&1, __CALLER__))
-      else
-        opts
-      end
+    It expects the `path` the dashboard will be mounted at
+    and a set of options.
+    """
+    defmacro arcana_dashboard(path, opts \\ []) do
+      opts =
+        if Macro.quoted_literal?(opts) do
+          Macro.prewalk(opts, &expand_alias(&1, __CALLER__))
+        else
+          opts
+        end
 
-    quote bind_quoted: binding() do
-      # Full mount prefix including enclosing scopes, e.g. "/admin/arcana"
-      # for `scope "/admin" do arcana_dashboard "/arcana" end`. Captured
-      # here so links and asset hrefs don't assume a "/arcana" mount. The
-      # trailing slash is trimmed so a root mount ("/") yields an empty
-      # prefix instead of turning hrefs into protocol-relative "//..." URLs.
-      prefix = String.trim_trailing(Phoenix.Router.scoped_path(__MODULE__, path), "/")
+      quote bind_quoted: binding() do
+        # Full mount prefix including enclosing scopes, e.g. "/admin/arcana"
+        # for `scope "/admin" do arcana_dashboard "/arcana" end`. Captured
+        # here so links and asset hrefs don't assume a "/arcana" mount. The
+        # trailing slash is trimmed so a root mount ("/") yields an empty
+        # prefix instead of turning hrefs into protocol-relative "//..." URLs.
+        prefix = String.trim_trailing(Phoenix.Router.scoped_path(__MODULE__, path), "/")
 
-      scope path, alias: false, as: false do
-        {session_name, session_opts, route_opts} =
-          ArcanaWeb.Router.__options__(opts, prefix)
+        scope path, alias: false, as: false do
+          {session_name, session_opts, route_opts} =
+            ArcanaWeb.Router.__options__(opts, prefix)
 
-        import Phoenix.Router, only: [get: 4]
-        import Phoenix.LiveView.Router, only: [live: 4, live_session: 3]
+          import Phoenix.Router, only: [get: 4]
+          import Phoenix.LiveView.Router, only: [live: 4, live_session: 3]
 
-        live_session session_name, session_opts do
-          # Arcana assets
-          get("/js-:hash", ArcanaWeb.Assets, :js, as: :arcana_asset)
-          get("/css-:hash", ArcanaWeb.Assets, :css, as: :arcana_asset)
+          live_session session_name, session_opts do
+            # Arcana assets
+            get("/js-:hash", ArcanaWeb.Assets, :js, as: :arcana_asset)
+            get("/css-:hash", ArcanaWeb.Assets, :css, as: :arcana_asset)
 
-          # Main dashboard (redirects to documents)
-          live("/", ArcanaWeb.DashboardLive, :index, route_opts)
+            # Main dashboard (redirects to documents)
+            live("/", ArcanaWeb.DashboardLive, :index, route_opts)
 
-          # Separate pages for each tab
-          live("/documents", ArcanaWeb.DocumentsLive, :index, route_opts)
-          live("/collections", ArcanaWeb.CollectionsLive, :index, route_opts)
-          live("/graph", ArcanaWeb.GraphLive, :index, route_opts)
-          live("/search", ArcanaWeb.SearchLive, :index, route_opts)
-          live("/ask", ArcanaWeb.AskLive, :index, route_opts)
-          live("/ask/:sub_tab", ArcanaWeb.AskLive, :index, route_opts)
-          live("/evaluation", ArcanaWeb.EvaluationLive, :index, route_opts)
-          live("/maintenance", ArcanaWeb.MaintenanceLive, :index, route_opts)
-          live("/info", ArcanaWeb.InfoLive, :index, route_opts)
+            # Separate pages for each tab
+            live("/documents", ArcanaWeb.DocumentsLive, :index, route_opts)
+            live("/collections", ArcanaWeb.CollectionsLive, :index, route_opts)
+            live("/graph", ArcanaWeb.GraphLive, :index, route_opts)
+            live("/search", ArcanaWeb.SearchLive, :index, route_opts)
+            live("/ask", ArcanaWeb.AskLive, :index, route_opts)
+            live("/ask/:sub_tab", ArcanaWeb.AskLive, :index, route_opts)
+            live("/evaluation", ArcanaWeb.EvaluationLive, :index, route_opts)
+            live("/maintenance", ArcanaWeb.MaintenanceLive, :index, route_opts)
+            live("/info", ArcanaWeb.InfoLive, :index, route_opts)
+          end
         end
       end
     end
+
+    defp expand_alias({:__aliases__, _, _} = alias, env),
+      do: Macro.expand(alias, %{env | function: {:arcana_dashboard, 2}})
+
+    defp expand_alias(other, _env), do: other
+
+    @doc false
+    def __options__(options, prefix) do
+      live_socket_path = Keyword.get(options, :live_socket_path, "/live")
+      repo = Keyword.get(options, :repo)
+
+      session_args = [repo, prefix]
+
+      {
+        :arcana_dashboard,
+        [
+          session: {__MODULE__, :__session__, session_args},
+          root_layout: {ArcanaWeb.Layouts, :root},
+          on_mount: [ArcanaWeb.Router.Prefix | List.wrap(options[:on_mount])]
+        ],
+        [
+          private: %{live_socket_path: live_socket_path},
+          as: :arcana_dashboard
+        ]
+      }
+    end
+
+    @doc false
+    def __session__(_conn, repo, prefix) do
+      %{
+        "repo" => repo || Arcana.Config.get_env(:repo),
+        "prefix" => prefix
+      }
+    end
   end
 
-  defp expand_alias({:__aliases__, _, _} = alias, env),
-    do: Macro.expand(alias, %{env | function: {:arcana_dashboard, 2}})
+  defmodule ArcanaWeb.Router.Prefix do
+    @moduledoc false
 
-  defp expand_alias(other, _env), do: other
-
-  @doc false
-  def __options__(options, prefix) do
-    live_socket_path = Keyword.get(options, :live_socket_path, "/live")
-    repo = Keyword.get(options, :repo)
-
-    session_args = [repo, prefix]
-
-    {
-      :arcana_dashboard,
-      [
-        session: {__MODULE__, :__session__, session_args},
-        root_layout: {ArcanaWeb.Layouts, :root},
-        on_mount: [ArcanaWeb.Router.Prefix | List.wrap(options[:on_mount])]
-      ],
-      [
-        private: %{live_socket_path: live_socket_path},
-        as: :arcana_dashboard
-      ]
-    }
+    # Assigns the dashboard's mount prefix (e.g. "/admin/arcana") to every
+    # dashboard LiveView so links and asset hrefs are built from the actual
+    # mount point instead of assuming "/arcana".
+    def on_mount(:default, _params, session, socket) do
+      {:cont, Phoenix.Component.assign(socket, :prefix, session["prefix"] || "/arcana")}
+    end
   end
+else
+  defmodule ArcanaWeb.Router do
+    @moduledoc """
+    Stub for when Phoenix LiveView is not available.
 
-  @doc false
-  def __session__(_conn, repo, prefix) do
-    %{
-      "repo" => repo || Arcana.Config.get_env(:repo),
-      "prefix" => prefix
-    }
-  end
-end
+    The Arcana dashboard is optional; mounting it requires the phoenix
+    dependencies. See `arcana_dashboard/2` for the requirements.
+    """
 
-defmodule ArcanaWeb.Router.Prefix do
-  @moduledoc false
+    @doc """
+    Raises at compile time: the dashboard requires Phoenix LiveView.
+    """
+    defmacro arcana_dashboard(_path, _opts \\ []) do
+      raise """
+      arcana_dashboard/2 requires Phoenix LiveView, which is an optional
+      dependency of arcana.
 
-  # Assigns the dashboard's mount prefix (e.g. "/admin/arcana") to every
-  # dashboard LiveView so links and asset hrefs are built from the actual
-  # mount point instead of assuming "/arcana".
-  def on_mount(:default, _params, session, socket) do
-    {:cont, Phoenix.Component.assign(socket, :prefix, session["prefix"] || "/arcana")}
+      Add it to your dependencies to use the dashboard:
+
+          {:phoenix_live_view, "~> 1.0"},
+          {:phoenix_html, "~> 4.1"}
+
+      Then recompile arcana:
+
+          mix deps.compile arcana --force
+      """
+    end
   end
 end


### PR DESCRIPTION
`phoenix_live_view`/`phoenix_html` were already marked optional in mix.exs, but a host without them couldn't compile arcana at all: `assets.ex` read their static files at compile time (`** (ArgumentError) unknown application: :phoenix`) and every ArcanaWeb module `use`d Phoenix.LiveView unguarded.

every module under `lib/arcana_web` now compiles only when `Phoenix.LiveView` is available, the same pattern `llm.ex` uses for ReqLLM. `ArcanaWeb.TaskSupervisor` stays ungated (it's phoenix-free and the deprecated `Arcana.TaskSupervisor` shim delegates to it). Without phoenix, a stub `ArcanaWeb.Router` raises a clear compile-time error from `arcana_dashboard/2` listing the deps to add and the `mix deps.compile arcana --force` gotcha. The dashboard guide gained a step 0 documenting this.

the diff looks big but it's almost all the reindent from wrapping each module: `git diff -w` shows the real change.

**verified in a fresh host app** with arcana as the only dep and no phoenix anywhere: compiles clean (zero Phoenix/ArcanaWeb warnings), `{ArcanaWeb.SearchLive, ArcanaWeb.Router, ArcanaWeb.TaskSupervisor, Arcana.Search}` load as `{false, true, true, true}`, invoking `arcana_dashboard` raises the friendly compile-time message, and the core (`Arcana.Config`, app startup) works without phoenix or a DB. With phoenix present the full suite is green (824 tests).

based on `dashboard-fixes` (#104) because it rewrites the same arcana_web files: retarget to main after #104 merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles without Phoenix by gating the dashboard behind `Phoenix.LiveView`. Previously, hosts without Phoenix failed at compile time due to `assets.ex` reading Phoenix assets and unguarded `ArcanaWeb` LiveViews; now dashboard modules compile only when `Phoenix.LiveView` is present, `ArcanaWeb.TaskSupervisor` stays available, and a stub `ArcanaWeb.Router` makes `arcana_dashboard/2` raise a clear compile-time error with install steps. Core RAG behavior and Phoenix-on behavior are unchanged.

- Applies `Code.ensure_loaded?(Phoenix.LiveView)` guards across `lib/arcana_web/*`; `assets.ex` no longer reads Phoenix apps at compile time.
- Updates the dashboard guide with an optional Phoenix step and a recompile note; guard comments explicitly note `ArcanaWeb.TaskSupervisor` remains ungated.
- To enable the dashboard in non-Phoenix hosts, add:
  - `{:phoenix_live_view, "~> 1.0"}`
  - `{:phoenix_html, "~> 4.1"}`
  - If Arcana was compiled before adding these, run: mix deps.compile arcana --force.

<sup>Written for commit 9f8cc6b4006693611743e9823e23f44069445d34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

