### PR TITLE
fix: Drop duplicate hierarchy levels once community detection converges

### DIFF
--- a/lib/arcana/graph/community_detector/leiden.ex
+++ b/lib/arcana/graph/community_detector/leiden.ex
@@ -134,11 +134,28 @@ if Code.ensure_loaded?(Leidenfold) do
       end)
     end
 
-    # Convert hierarchical levels from leidenfold to community maps
+    # Convert hierarchical levels from leidenfold to community maps.
+    #
+    # On small or naturally flat graphs the hierarchy converges before
+    # max_level and the remaining levels are byte-identical partitions;
+    # keep only the first level of each identical run so max_level acts
+    # as a ceiling, not a multiplier (every duplicate row would otherwise
+    # cost an LLM call in summarize_communities).
     defp format_hierarchical_levels(levels, index_to_id, min_size) do
-      Enum.flat_map(levels, fn %{level: level, membership: membership} ->
+      levels
+      |> Enum.map(fn %{level: level, membership: membership} ->
         format_communities(membership, index_to_id, level, min_size)
       end)
+      |> Enum.dedup_by(&partition_signature/1)
+      |> List.flatten()
+    end
+
+    # A level's identity is its set of entity-id sets, independent of
+    # level number and ordering.
+    defp partition_signature(communities) do
+      communities
+      |> Enum.map(fn %{entity_ids: ids} -> Enum.sort(ids) end)
+      |> Enum.sort()
     end
 
     # Convert membership list to community maps

--- a/test/arcana/graph/community_detector_test.exs
+++ b/test/arcana/graph/community_detector_test.exs
@@ -75,6 +75,35 @@ defmodule Arcana.Graph.CommunityDetectorTest do
       assert Enum.all?(levels, &(&1 <= 1))
     end
 
+    test "drops duplicate levels once the hierarchy converges" do
+      # A tiny flat graph converges immediately: with max_level: 5 the
+      # detector used to store five identical copies of the same
+      # partition (issue #115). Consecutive identical partitions must
+      # collapse to one.
+      entities = Enum.map(1..6, &%{id: "#{&1}", name: "Entity #{&1}"})
+
+      relationships = [
+        %{source_id: "1", target_id: "2", strength: 10},
+        %{source_id: "2", target_id: "3", strength: 10},
+        %{source_id: "4", target_id: "5", strength: 10},
+        %{source_id: "5", target_id: "6", strength: 10}
+      ]
+
+      detector = {Leiden, max_level: 5, seed: 42}
+      {:ok, communities} = CommunityDetector.detect(detector, entities, relationships)
+
+      partitions_by_level =
+        communities
+        |> Enum.group_by(& &1.level)
+        |> Enum.sort_by(&elem(&1, 0))
+        |> Enum.map(fn {_level, comms} ->
+          comms |> Enum.map(&Enum.sort(&1.entity_ids)) |> Enum.sort()
+        end)
+
+      # No two consecutive stored levels carry the same partition
+      assert partitions_by_level == Enum.dedup(partitions_by_level)
+    end
+
     test "respects resolution parameter" do
       entities = Enum.map(1..6, &%{id: "#{&1}", name: "Entity #{&1}"})
 


### PR DESCRIPTION
on small or naturally flat graphs the Leiden hierarchy converges after a level or two, and `format_hierarchical_levels` stored every remaining level as a byte-identical copy of the same partition. On the ~24-entity graph from the issue that meant 30 community rows that were 5 copies of the same 6 communities, and `summarize_communities` then paid one LLM call per duplicate row.

levels now collapse consecutive identical partitions (compared as the set of sorted entity-id sets, ignoring level number), so `max_level` is a ceiling instead of a multiplier. Genuinely hierarchical graphs keep every distinct level.

Fixes #115

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops duplicate hierarchy levels once `Leidenfold` community detection converges, preventing redundant community rows and extra LLM calls in summarize_communities. Previously we stored identical partitions up to max_level; now we keep only the first identical level so max_level acts as a ceiling.

- Uses a partition signature (sorted entity-id sets, independent of level number and ordering) to deduplicate levels.
- Adds a test that asserts no consecutive levels carry the same partition on a flat graph.

<sup>Written for commit 5c11a33a253ab740f678da84e11bf81be130e946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

