### PR TITLE
docs: Oban ingestion recipe

### DIFF
--- a/guides/oban-ingestion.md
+++ b/guides/oban-ingestion.md
@@ -6,8 +6,8 @@ recipe wraps `Arcana.ingest/2` in an [Oban](https://hexdocs.pm/oban) worker
 with the properties a multi-tenant ingestion pipeline needs:
 
 - a dedicated queue so ingestion can't starve your other workers
-- uniqueness on the document identity, including while a job is executing,
-  so the same document is never ingested twice concurrently
+- uniqueness on the document identity while jobs wait in the queue, so
+  redundant work collapses before it starts
 - replace-args-while-queued, so when content changes faster than the queue
   drains, the latest version wins
 - `replace: true` so re-ingesting an identity supersedes the previous

--- a/guides/oban-ingestion.md
+++ b/guides/oban-ingestion.md
@@ -1,0 +1,94 @@
+# Ingestion with Oban
+
+Ingestion is CPU- and IO-heavy (chunking, embedding, optional graph
+extraction), so production apps usually run it in the background. This
+recipe wraps `Arcana.ingest/2` in an [Oban](https://hexdocs.pm/oban) worker
+with the properties a multi-tenant ingestion pipeline needs:
+
+- a dedicated queue so ingestion can't starve your other workers
+- uniqueness on the document identity, including while a job is executing,
+  so the same document is never ingested twice concurrently
+- replace-args-while-queued, so when content changes faster than the queue
+  drains, the latest version wins
+- `replace: true` so re-ingesting an identity supersedes the previous
+  document atomically (old chunks stay searchable until the new ingest
+  completes)
+
+## The worker
+
+```elixir
+defmodule MyApp.IngestWorker do
+  use Oban.Worker,
+    queue: :ingest,
+    max_attempts: 3,
+    unique: [
+      # One job per document identity, across queued AND running jobs.
+      # :executing matters: without it a queued duplicate can start
+      # while the first is mid-ingest.
+      fields: [:worker, :args],
+      keys: [:collection, :source_id],
+      states: [:available, :scheduled, :retryable, :executing],
+      # When a duplicate arrives while a job is still queued, keep the
+      # job but swap in the newest args, so the latest content wins.
+      on_conflict: {:replace, [:args]}
+    ]
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    %{"collection" => collection, "source_id" => source_id, "content" => content} = args
+
+    case Arcana.ingest(content,
+           repo: MyApp.Repo,
+           collection: collection,
+           source_id: source_id,
+           replace: true,
+           metadata: Map.get(args, "metadata", %{})
+         ) do
+      {:ok, _document} -> :ok
+      # A concurrent ingest for the same identity finished first and
+      # superseded this one: the newest content already won, so don't retry.
+      {:error, :replaced_by_concurrent_ingest} -> {:cancel, :superseded}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end
+```
+
+Enqueue from wherever content arrives:
+
+```elixir
+%{collection: "tenant-#{tenant.id}", source_id: "doc-#{doc.id}", content: text}
+|> MyApp.IngestWorker.new()
+|> Oban.insert()
+```
+
+## Queue configuration
+
+Give ingestion its own queue with a limit matched to your embedder. The
+local Bumblebee embedder batches on the serving, so a few concurrent jobs
+keep the batch full without oversubscribing:
+
+```elixir
+# config/config.exs
+config :my_app, Oban,
+  repo: MyApp.Repo,
+  queues: [default: 10, ingest: 4]
+```
+
+For API-based embedders, size the limit against the provider's rate limit
+instead.
+
+## Notes
+
+- `replace: true` requires a `:source_id`; treat it as the document's
+  stable identity per collection. Without `replace`, re-enqueuing the same
+  identity accumulates duplicate documents.
+- With `config :arcana, strict_collections: true`, create the collection
+  before the first job runs (`Arcana.Collection.get_or_create/3`), or
+  ingest returns `{:error, {:unknown_collection, name}}` and the job
+  retries pointlessly.
+- Files work the same way through `Arcana.ingest_file/2`; for uploads that
+  live in object storage, download to a tmp path in the worker first.
+- The Oban uniqueness lock and Arcana's replace advisory lock are
+  complementary: uniqueness collapses redundant work before it starts,
+  the advisory lock makes whatever does run correct under races.

--- a/guides/oban-ingestion.md
+++ b/guides/oban-ingestion.md
@@ -22,12 +22,15 @@ defmodule MyApp.IngestWorker do
     queue: :ingest,
     max_attempts: 3,
     unique: [
-      # One job per document identity, across queued AND running jobs.
-      # :executing matters: without it a queued duplicate can start
-      # while the first is mid-ingest.
+      # One job per document identity while it waits in the queue.
+      # Deliberately NOT including :executing: replacing args on a job
+      # that is already running does nothing (the worker read its args
+      # at start), so the new content would be silently lost. A
+      # duplicate arriving mid-execution becomes a fresh job instead,
+      # which runs afterwards and supersedes via replace: true.
       fields: [:worker, :args],
       keys: [:collection, :source_id],
-      states: [:available, :scheduled, :retryable, :executing],
+      states: [:available, :scheduled, :retryable],
       # When a duplicate arrives while a job is still queued, keep the
       # job but swap in the newest args, so the latest content wins.
       on_conflict: {:replace, [:args]}
@@ -92,3 +95,10 @@ instead.
 - The Oban uniqueness lock and Arcana's replace advisory lock are
   complementary: uniqueness collapses redundant work before it starts,
   the advisory lock makes whatever does run correct under races.
+- Ordering caveat: if two jobs for the same identity ever execute
+  concurrently (the second enqueued after the first started), Arcana's
+  swap is first-to-complete-wins, not latest-wins. If your content
+  churns faster than ingestion completes and strict latest-wins
+  matters, run the ingest queue with `limit: 1`, or have the worker
+  `{:snooze, n}` when an earlier job for the same identity is still
+  executing.

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule Arcana.MixProject do
         "README.md",
         "guides/getting-started.md",
         "guides/llm-integration.md",
+        "guides/oban-ingestion.md",
         "guides/pipeline.md",
         "guides/loop.md",
         "guides/graphrag.md",


### PR DESCRIPTION
the in-repo guide/recipe for #94 item 2: an Oban worker around `Arcana.ingest/2` with a dedicated queue, uniqueness on the `(collection, source_id)` identity including the `:executing` state, replace-args-while-queued so the latest content wins, and `replace: true` for atomic supersession.

note: references `replace: true` and `{:error, :replaced_by_concurrent_ingest}` from #106, so merge that one first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Oban ingestion guide that uses a dedicated `ingest` queue, uniqueness only while queued (not `:executing`), replace-args-while-queued, and `replace: true` for atomic supersession. This corrects the earlier latest-wins claim, prevents losing mid-execution updates, and keeps search uninterrupted.

- Adds `guides/oban-ingestion.md`; includes it in `mix.exs`.
- Clarifies uniqueness excludes `:executing` and documents first-to-complete-wins ordering with mitigations (`limit: 1` or `{:snooze, n}`); intro bullet aligned accordingly.
- Merge #106 first; relies on `replace: true` and `{:error, :replaced_by_concurrent_ingest}`.
- No runtime or API changes.

<sup>Written for commit 489f64076b40b74282a010b6e8f5a6f125b1ed36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

