### PR TITLE
fix: Installer and migration generator fixes

### DIFF
--- a/lib/arcana/config.ex
+++ b/lib/arcana/config.ex
@@ -264,6 +264,8 @@ defmodule Arcana.Config do
     opts[key] || get_env(key)
   end
 
+  @repo_unset :__arcana_repo_unset__
+
   @repo_config_shapes """
   Configure the repo with:
 
@@ -290,6 +292,10 @@ defmodule Arcana.Config do
   `ArgumentError` when no repo can be resolved, or when several per-repo
   entries exist without an explicit `:repo` key to disambiguate.
 
+  `repo: nil` means "not set" and falls through to the per-repo scan.
+  `repo: false` is an explicit "no repo", so it raises the same "no Ecto
+  repo configured" error instead of quietly picking a per-repo entry.
+
   Called without arguments, the `:repo` key is read through `get_env/2` so
   process-scoped overrides installed via `install_env_reader/1` are honored.
   Pass an explicit env keyword list to resolve against it directly.
@@ -298,17 +304,32 @@ defmodule Arcana.Config do
 
   def repo!(nil) do
     # The `:repo` read goes through get_env/2 so test overrides shadow it.
+    # A sentinel default separates "unset" from a configured `nil`/`false`.
     # The per-repo fallback has to enumerate keys, which the reader seam
     # can't express (it resolves one key at a time), so it reads the raw
     # app env.
-    get_env(:repo) || repo_from_module_keys(Application.get_all_env(:arcana))
+    case get_env(:repo, @repo_unset) do
+      false -> raise_repo_disabled()
+      repo when repo in [@repo_unset, nil] -> repo_from_module_keys(all_env())
+      repo -> repo
+    end
   end
 
   def repo!(env) when is_list(env) do
-    case Keyword.get(env, :repo) do
-      nil -> repo_from_module_keys(env)
-      repo -> repo
+    case Keyword.fetch(env, :repo) do
+      {:ok, false} -> raise_repo_disabled()
+      {:ok, nil} -> repo_from_module_keys(env)
+      {:ok, repo} -> repo
+      :error -> repo_from_module_keys(env)
     end
+  end
+
+  defp all_env, do: Application.get_all_env(:arcana)
+
+  defp raise_repo_disabled do
+    raise ArgumentError,
+          "no Ecto repo configured for :arcana: `repo: false` disables repo " <>
+            "resolution.\n\n" <> @repo_config_shapes
   end
 
   defp repo_from_module_keys(env) do

--- a/lib/arcana/config.ex
+++ b/lib/arcana/config.ex
@@ -289,8 +289,22 @@ defmodule Arcana.Config do
   configured, that repo is used (with a note printed to stderr). Raises
   `ArgumentError` when no repo can be resolved, or when several per-repo
   entries exist without an explicit `:repo` key to disambiguate.
+
+  Called without arguments, the `:repo` key is read through `get_env/2` so
+  process-scoped overrides installed via `install_env_reader/1` are honored.
+  Pass an explicit env keyword list to resolve against it directly.
   """
-  def repo!(env \\ Application.get_all_env(:arcana)) do
+  def repo!(env \\ nil)
+
+  def repo!(nil) do
+    # The `:repo` read goes through get_env/2 so test overrides shadow it.
+    # The per-repo fallback has to enumerate keys, which the reader seam
+    # can't express (it resolves one key at a time), so it reads the raw
+    # app env.
+    get_env(:repo) || repo_from_module_keys(Application.get_all_env(:arcana))
+  end
+
+  def repo!(env) when is_list(env) do
     case Keyword.get(env, :repo) do
       nil -> repo_from_module_keys(env)
       repo -> repo

--- a/lib/arcana/config.ex
+++ b/lib/arcana/config.ex
@@ -264,6 +264,69 @@ defmodule Arcana.Config do
     opts[key] || get_env(key)
   end
 
+  @repo_config_shapes """
+  Configure the repo with:
+
+      config :arcana, repo: MyApp.Repo
+
+  or with the per-repo shape:
+
+      config :arcana, MyApp.Repo, priv: "priv/my_repo"
+  """
+
+  @doc """
+  Resolves the Ecto repo configured for Arcana's mix tasks.
+
+  Accepts either configuration shape:
+
+      # Explicit repo key
+      config :arcana, repo: MyApp.Repo
+
+      # Per-repo configuration (e.g. custom priv directory)
+      config :arcana, MyApp.Repo, priv: "priv/my_repo"
+
+  When only the per-repo shape is present and exactly one repo is
+  configured, that repo is used (with a note printed to stderr). Raises
+  `ArgumentError` when no repo can be resolved, or when several per-repo
+  entries exist without an explicit `:repo` key to disambiguate.
+  """
+  def repo!(env \\ Application.get_all_env(:arcana)) do
+    case Keyword.get(env, :repo) do
+      nil -> repo_from_module_keys(env)
+      repo -> repo
+    end
+  end
+
+  defp repo_from_module_keys(env) do
+    env
+    |> Keyword.keys()
+    |> Enum.filter(&ecto_repo_key?/1)
+    |> case do
+      [repo] ->
+        IO.puts(
+          :stderr,
+          "Arcana: using #{inspect(repo)} from `config :arcana, #{inspect(repo)}, ...`. " <>
+            "Set `config :arcana, repo: #{inspect(repo)}` to make this explicit."
+        )
+
+        repo
+
+      [] ->
+        raise ArgumentError, "no Ecto repo configured for :arcana.\n\n" <> @repo_config_shapes
+
+      repos ->
+        raise ArgumentError,
+              "several Ecto repos configured for :arcana " <>
+                "(#{Enum.map_join(repos, ", ", &inspect/1)}) and no `:repo` key to " <>
+                "disambiguate.\n\n" <> @repo_config_shapes
+    end
+  end
+
+  defp ecto_repo_key?(key) do
+    is_atom(key) and String.starts_with?(Atom.to_string(key), "Elixir.") and
+      Code.ensure_loaded?(key) and function_exported?(key, :__adapter__, 0)
+  end
+
   @doc """
   Merges global keyword-list config under `app_key` with per-call opts.
 

--- a/lib/arcana/mix_helpers.ex
+++ b/lib/arcana/mix_helpers.ex
@@ -6,6 +6,8 @@ defmodule Arcana.MixHelpers do
   # into `Mix.raise/1` so the CLI prints a single clean line instead of a
   # stacktrace.
 
+  defguardp is_valid_dimensions(value) when is_integer(value) and value > 0
+
   @doc """
   Resolves the configured repo, converting `Arcana.Config.repo!/1`'s
   `ArgumentError` into a clean `Mix.raise`.
@@ -24,11 +26,16 @@ defmodule Arcana.MixHelpers do
 
   Loads the host application's config first, since the embedder is read
   from app env. Raises a `Mix.Error` with a `--dimensions` hint when the
-  embedder can't be probed.
+  embedder can't be probed, or when it reports something that isn't a
+  positive integer.
   """
   def detect_dimensions! do
     Mix.Task.run("app.config")
-    Arcana.Embedder.dimensions(Arcana.embedder())
+    {module, _opts} = embedder = Arcana.embedder()
+
+    embedder
+    |> Arcana.Embedder.dimensions()
+    |> validate_detected_dimensions!(module)
   rescue
     e in Mix.Error ->
       reraise e, __STACKTRACE__
@@ -50,9 +57,23 @@ defmodule Arcana.MixHelpers do
   """
   def validate_dimensions!(value, flag \\ "--dimensions")
 
-  def validate_dimensions!(value, _flag) when is_integer(value) and value > 0, do: value
+  def validate_dimensions!(value, _flag) when is_valid_dimensions(value), do: value
 
   def validate_dimensions!(value, flag) do
     Mix.raise("#{flag} must be a positive integer, got: #{inspect(value)}")
+  end
+
+  # Same check as validate_dimensions!/2, but the value came from the
+  # embedder rather than the command line, so the flag is the workaround
+  # instead of the culprit.
+  defp validate_detected_dimensions!(value, _module) when is_valid_dimensions(value), do: value
+
+  defp validate_detected_dimensions!(value, module) do
+    Mix.raise("""
+    The configured embedder #{inspect(module)} reported invalid embedding dimensions: #{inspect(value)}
+
+    Dimensions must be a positive integer. Fix the embedder's dimensions/1
+    callback, or pass them explicitly with --dimensions, e.g.: --dimensions 1024
+    """)
   end
 end

--- a/lib/arcana/mix_helpers.ex
+++ b/lib/arcana/mix_helpers.ex
@@ -1,0 +1,58 @@
+defmodule Arcana.MixHelpers do
+  @moduledoc false
+
+  # Shared helpers for Arcana's mix tasks. Library functions raise regular
+  # exceptions (ArgumentError, RuntimeError); these wrappers translate them
+  # into `Mix.raise/1` so the CLI prints a single clean line instead of a
+  # stacktrace.
+
+  @doc """
+  Resolves the configured repo, converting `Arcana.Config.repo!/1`'s
+  `ArgumentError` into a clean `Mix.raise`.
+
+  `env` defaults to `nil`, which lets `Arcana.Config.repo!/1` read the app
+  env itself. Pass an explicit keyword list to resolve against it.
+  """
+  def repo!(env \\ nil) do
+    Arcana.Config.repo!(env)
+  rescue
+    e in ArgumentError -> Mix.raise(Exception.message(e))
+  end
+
+  @doc """
+  Detects embedding dimensions from the configured embedder.
+
+  Loads the host application's config first, since the embedder is read
+  from app env. Raises a `Mix.Error` with a `--dimensions` hint when the
+  embedder can't be probed.
+  """
+  def detect_dimensions! do
+    Mix.Task.run("app.config")
+    Arcana.Embedder.dimensions(Arcana.embedder())
+  rescue
+    e in Mix.Error ->
+      reraise e, __STACKTRACE__
+
+    e ->
+      Mix.raise("""
+      Could not detect embedding dimensions from the configured embedder: #{Exception.message(e)}
+
+      Pass them explicitly with --dimensions, e.g.: --dimensions 1024
+      """)
+  end
+
+  @doc """
+  Validates a user-supplied vector dimension.
+
+  Returns the value when it is a positive integer, raises a `Mix.Error`
+  otherwise. Postgres rejects `vector(0)` and `vector(-1)`, so catching it
+  here beats generating a migration that fails halfway through.
+  """
+  def validate_dimensions!(value, flag \\ "--dimensions")
+
+  def validate_dimensions!(value, _flag) when is_integer(value) and value > 0, do: value
+
+  def validate_dimensions!(value, flag) do
+    Mix.raise("#{flag} must be a positive integer, got: #{inspect(value)}")
+  end
+end

--- a/lib/mix/tasks/arcana.eval.generate.ex
+++ b/lib/mix/tasks/arcana.eval.generate.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Arcana.Eval.Generate do
     source_id = Keyword.get(opts, :source_id)
     collection = Keyword.get(opts, :collection)
 
-    repo = Arcana.Config.repo!()
+    repo = Arcana.MixHelpers.repo!()
     llm = Application.get_env(:arcana, :llm) || raise "Missing :arcana, :llm config"
 
     IO.puts("Generating test cases from #{sample_size} chunks...")

--- a/lib/mix/tasks/arcana.eval.generate.ex
+++ b/lib/mix/tasks/arcana.eval.generate.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Arcana.Eval.Generate do
     source_id = Keyword.get(opts, :source_id)
     collection = Keyword.get(opts, :collection)
 
-    repo = Application.get_env(:arcana, :repo) || raise "Missing :arcana, :repo config"
+    repo = Arcana.Config.repo!()
     llm = Application.get_env(:arcana, :llm) || raise "Missing :arcana, :llm config"
 
     IO.puts("Generating test cases from #{sample_size} chunks...")

--- a/lib/mix/tasks/arcana.eval.run.ex
+++ b/lib/mix/tasks/arcana.eval.run.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Arcana.Eval.Run do
         ]
       )
 
-    repo = Application.get_env(:arcana, :repo) || raise "Missing :arcana, :repo config"
+    repo = Arcana.Config.repo!()
 
     mode =
       case Keyword.get(opts, :mode, "vector") do

--- a/lib/mix/tasks/arcana.eval.run.ex
+++ b/lib/mix/tasks/arcana.eval.run.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Arcana.Eval.Run do
         ]
       )
 
-    repo = Arcana.Config.repo!()
+    repo = Arcana.MixHelpers.repo!()
 
     mode =
       case Keyword.get(opts, :mode, "vector") do

--- a/lib/mix/tasks/arcana.gen.embedding_migration.ex
+++ b/lib/mix/tasks/arcana.gen.embedding_migration.ex
@@ -11,13 +11,22 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
   2. Show the detected dimensions
   3. Generate a migration to update the vector column
 
+  The `down` migration restores the dimensions the column had *before*
+  this migration. Those are read from the database when it is reachable;
+  otherwise pass `--previous-dimensions`. Without either, the generated
+  `down` raises instead of silently truncating the column.
+
   ## Options
 
     * `--dimensions` - Override auto-detected dimensions
+    * `--previous-dimensions` - Dimensions the `down` migration restores,
+      when they can't be read from the database
 
   """
 
   use Mix.Task
+
+  alias Arcana.MixHelpers
 
   @shortdoc "Generates a migration for embedding dimension changes"
 
@@ -25,45 +34,89 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
   def run(args) do
     {opts, _, _} =
       OptionParser.parse(args,
-        strict: [dimensions: :integer]
+        strict: [dimensions: :integer, previous_dimensions: :integer]
       )
 
     # Start the app to access config
     Mix.Task.run("app.config")
 
+    repo = MixHelpers.repo!()
+    previous = resolve_previous_dimensions(repo, Keyword.get(opts, :previous_dimensions))
+
     dimensions =
       case Keyword.get(opts, :dimensions) do
         nil ->
-          case detect_dimensions() do
-            {:ok, dims} ->
-              Mix.shell().info("Detected embedding dimensions: #{dims}")
-              dims
-
-            {:error, reason} ->
-              Mix.raise("Could not detect dimensions: #{inspect(reason)}")
-          end
+          dims = MixHelpers.detect_dimensions!()
+          Mix.shell().info("Detected embedding dimensions: #{dims}")
+          dims
 
         dims ->
+          dims = MixHelpers.validate_dimensions!(dims)
           Mix.shell().info("Using specified dimensions: #{dims}")
           dims
       end
 
-    generate_migration(dimensions)
+    generate_migration(repo, dimensions, previous)
   end
 
-  defp detect_dimensions do
-    embedder = Arcana.embedder()
-    {:ok, Arcana.Embedder.dimensions(embedder)}
+  defp resolve_previous_dimensions(repo, nil) do
+    case current_column_dimensions(repo) do
+      nil ->
+        Mix.shell().info(
+          "Could not read the current arcana_chunks.embedding size; the generated " <>
+            "down migration will raise. Pass --previous-dimensions to make it reversible."
+        )
+
+        nil
+
+      dims ->
+        Mix.shell().info("Current column dimensions (used for rollback): #{dims}")
+        dims
+    end
+  end
+
+  defp resolve_previous_dimensions(_repo, given),
+    do: MixHelpers.validate_dimensions!(given, "--previous-dimensions")
+
+  # pgvector stores the declared dimension straight in atttypmod, so
+  # vector(384) reads back as 384.
+  @current_dimensions_query """
+  SELECT a.atttypmod
+  FROM pg_attribute a
+  JOIN pg_class c ON c.oid = a.attrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = current_schema()
+    AND c.relname = 'arcana_chunks'
+    AND a.attname = 'embedding'
+    AND NOT a.attisdropped
+  """
+
+  # Best effort: boots just the repo (not the host supervision tree, which
+  # may load embedding models) to read the column's current size.
+  defp current_column_dimensions(repo) do
+    {:ok, _} = Application.ensure_all_started(:ecto_sql)
+    {:ok, pid} = repo.start_link(pool_size: 1, log: false)
+
+    try do
+      case repo.query!(@current_dimensions_query) do
+        %{rows: [[dims]]} when is_integer(dims) and dims > 0 -> dims
+        _ -> nil
+      end
+    after
+      Process.unlink(pid)
+      Supervisor.stop(pid)
+    end
   rescue
-    e -> {:error, e}
+    _ -> nil
+  catch
+    :exit, _ -> nil
   end
 
-  defp generate_migration(dimensions) do
+  defp generate_migration(repo, dimensions, previous) do
     timestamp = Calendar.strftime(DateTime.utc_now(), "%Y%m%d%H%M%S")
     filename = "#{timestamp}_update_embedding_dimensions.exs"
 
     # Find the priv/repo/migrations directory
-    repo = Arcana.Config.repo!()
     repo_config = Application.get_env(:arcana, repo) || []
     priv_dir = Keyword.get(repo_config, :priv, "priv/repo")
     migrations_dir = Path.join(priv_dir, "migrations")
@@ -73,7 +126,7 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
 
     path = Path.join(migrations_dir, filename)
 
-    content = migration_content(dimensions)
+    content = migration_content(dimensions, previous)
 
     File.write!(path, content)
 
@@ -98,7 +151,7 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
   end
 
   @doc false
-  def migration_content(dimensions) do
+  def migration_content(dimensions, previous_dimensions \\ nil) do
     """
     defmodule Arcana.Repo.Migrations.UpdateEmbeddingDimensions do
       use Ecto.Migration
@@ -124,22 +177,50 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
         \"\"\"
       end
 
+    #{down_body(previous_dimensions)}
+    end
+    """
+  end
+
+  defp down_body(nil) do
+    """
       def down do
-        # Note: Down migration requires knowing the previous dimensions
-        # This is a best-effort reversal - you may need to adjust the size
+        # Arcana could not determine the dimensions this column had before
+        # the migration above, and guessing would truncate every embedding.
+        # Fill in the previous size below, then delete this raise.
+        raise "Set the previous vector size in this down migration before rolling back"
+
+        # execute "DROP INDEX IF EXISTS arcana_chunks_embedding_idx"
+        # execute "DROP INDEX IF EXISTS arcana_chunks_embedding_index"
+        #
+        # alter table(:arcana_chunks) do
+        #   modify :embedding, :vector, size: PREVIOUS_DIMENSIONS
+        # end
+        #
+        # execute \"\"\"
+        # CREATE INDEX arcana_chunks_embedding_idx ON arcana_chunks
+        # USING hnsw (embedding vector_cosine_ops)
+        # \"\"\"
+      end\
+    """
+  end
+
+  defp down_body(previous) do
+    """
+      def down do
         execute "DROP INDEX IF EXISTS arcana_chunks_embedding_idx"
         execute "DROP INDEX IF EXISTS arcana_chunks_embedding_index"
 
+        # Restores the size the column had before this migration ran.
         alter table(:arcana_chunks) do
-          modify :embedding, :vector, size: 384
+          modify :embedding, :vector, size: #{previous}
         end
 
         execute \"\"\"
         CREATE INDEX arcana_chunks_embedding_idx ON arcana_chunks
         USING hnsw (embedding vector_cosine_ops)
         \"\"\"
-      end
-    end
+      end\
     """
   end
 end

--- a/lib/mix/tasks/arcana.gen.embedding_migration.ex
+++ b/lib/mix/tasks/arcana.gen.embedding_migration.ex
@@ -63,7 +63,8 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
     filename = "#{timestamp}_update_embedding_dimensions.exs"
 
     # Find the priv/repo/migrations directory
-    repo_config = Application.get_env(:arcana, Application.get_env(:arcana, :repo))
+    repo = Arcana.Config.repo!()
+    repo_config = Application.get_env(:arcana, repo) || []
     priv_dir = Keyword.get(repo_config, :priv, "priv/repo")
     migrations_dir = Path.join(priv_dir, "migrations")
 

--- a/lib/mix/tasks/arcana.gen.embedding_migration.ex
+++ b/lib/mix/tasks/arcana.gen.embedding_migration.ex
@@ -97,40 +97,47 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
     """)
   end
 
-  defp migration_content(dimensions) do
+  @doc false
+  def migration_content(dimensions) do
     """
     defmodule Arcana.Repo.Migrations.UpdateEmbeddingDimensions do
       use Ecto.Migration
 
       def up do
-        # Drop the existing HNSW index
-        drop_if_exists index(:arcana_chunks, [:embedding])
+        # Drop the existing HNSW index. The install migration creates it via
+        # raw SQL as arcana_chunks_embedding_idx; also drop the Ecto-default
+        # name defensively in case it was created under that name instead.
+        execute "DROP INDEX IF EXISTS arcana_chunks_embedding_idx"
+        execute "DROP INDEX IF EXISTS arcana_chunks_embedding_index"
 
         # Alter the embedding column to new dimensions
         alter table(:arcana_chunks) do
           modify :embedding, :vector, size: #{dimensions}
         end
 
-        # Recreate the HNSW index with the new dimensions
-        create index(:arcana_chunks, [:embedding],
-          using: :hnsw,
-          options: "vector_cosine_ops"
-        )
+        # Recreate the HNSW index with the new dimensions. This must be raw
+        # SQL because the operator class (vector_cosine_ops) cannot be
+        # expressed through Ecto's index helper.
+        execute \"\"\"
+        CREATE INDEX arcana_chunks_embedding_idx ON arcana_chunks
+        USING hnsw (embedding vector_cosine_ops)
+        \"\"\"
       end
 
       def down do
         # Note: Down migration requires knowing the previous dimensions
         # This is a best-effort reversal - you may need to adjust the size
-        drop_if_exists index(:arcana_chunks, [:embedding])
+        execute "DROP INDEX IF EXISTS arcana_chunks_embedding_idx"
+        execute "DROP INDEX IF EXISTS arcana_chunks_embedding_index"
 
         alter table(:arcana_chunks) do
           modify :embedding, :vector, size: 384
         end
 
-        create index(:arcana_chunks, [:embedding],
-          using: :hnsw,
-          options: "vector_cosine_ops"
-        )
+        execute \"\"\"
+        CREATE INDEX arcana_chunks_embedding_idx ON arcana_chunks
+        USING hnsw (embedding vector_cosine_ops)
+        \"\"\"
       end
     end
     """

--- a/lib/mix/tasks/arcana.gen.embedding_migration.ex
+++ b/lib/mix/tasks/arcana.gen.embedding_migration.ex
@@ -95,7 +95,14 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
   # may load embedding models) to read the column's current size.
   defp current_column_dimensions(repo) do
     {:ok, _} = Application.ensure_all_started(:ecto_sql)
-    {:ok, pid} = repo.start_link(pool_size: 1, log: false)
+
+    # A composing task may have already started the repo; leave that one
+    # running and only tear down the one we booted.
+    started =
+      case repo.start_link(pool_size: 1, log: false) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, _pid}} -> nil
+      end
 
     try do
       case repo.query!(@current_dimensions_query) do
@@ -103,8 +110,10 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigration do
         _ -> nil
       end
     after
-      Process.unlink(pid)
-      Supervisor.stop(pid)
+      if started do
+        Process.unlink(started)
+        Supervisor.stop(started)
+      end
     end
   rescue
     _ -> nil

--- a/lib/mix/tasks/arcana.graph.detect_communities.ex
+++ b/lib/mix/tasks/arcana.graph.detect_communities.ex
@@ -85,7 +85,7 @@ defmodule Mix.Tasks.Arcana.Graph.DetectCommunities do
     min_size = Keyword.get(opts, :min_size, graph_config[:min_size] || 1)
     max_level = Keyword.get(opts, :max_level, graph_config[:community_levels] || 1)
 
-    repo = Arcana.Config.repo!()
+    repo = Arcana.MixHelpers.repo!()
 
     # Check leidenfold is available
     unless Code.ensure_loaded?(Leidenfold) do

--- a/lib/mix/tasks/arcana.graph.detect_communities.ex
+++ b/lib/mix/tasks/arcana.graph.detect_communities.ex
@@ -85,11 +85,7 @@ defmodule Mix.Tasks.Arcana.Graph.DetectCommunities do
     min_size = Keyword.get(opts, :min_size, graph_config[:min_size] || 1)
     max_level = Keyword.get(opts, :max_level, graph_config[:community_levels] || 1)
 
-    repo = Application.get_env(:arcana, :repo)
-
-    unless repo do
-      Mix.raise("No repo configured. Set config :arcana, repo: YourApp.Repo")
-    end
+    repo = Arcana.Config.repo!()
 
     # Check leidenfold is available
     unless Code.ensure_loaded?(Leidenfold) do

--- a/lib/mix/tasks/arcana.graph.embed_entities.ex
+++ b/lib/mix/tasks/arcana.graph.embed_entities.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Arcana.Graph.EmbedEntities do
 
     Mix.Task.run("app.start")
 
-    repo = Arcana.Config.repo!()
+    repo = Arcana.MixHelpers.repo!()
 
     unless quiet do
       Mix.shell().info(

--- a/lib/mix/tasks/arcana.graph.embed_entities.ex
+++ b/lib/mix/tasks/arcana.graph.embed_entities.ex
@@ -43,11 +43,7 @@ defmodule Mix.Tasks.Arcana.Graph.EmbedEntities do
 
     Mix.Task.run("app.start")
 
-    repo = Application.get_env(:arcana, :repo)
-
-    unless repo do
-      Mix.raise("No repo configured. Set config :arcana, repo: YourApp.Repo")
-    end
+    repo = Arcana.Config.repo!()
 
     unless quiet do
       Mix.shell().info(

--- a/lib/mix/tasks/arcana.graph.install.ex
+++ b/lib/mix/tasks/arcana.graph.install.ex
@@ -15,9 +15,14 @@ if Code.ensure_loaded?(Igniter) do
     GraphRAG is optional. Only run this if you want to use knowledge graph
     features for enhanced retrieval.
 
+    Entity embedding dimensions are detected from the configured embedder
+    (via `Arcana.Embedder.dimensions/1`), so the generated table matches
+    your vectors. Use `--dimensions` to override.
+
     ## Options
 
       * `--repo` - The repo to use (defaults to YourApp.Repo)
+      * `--dimensions` - Override auto-detected embedding dimensions
 
     ## Configuration
 
@@ -43,7 +48,8 @@ if Code.ensure_loaded?(Igniter) do
         group: :arcana,
         example: "mix arcana.graph.install",
         schema: [
-          repo: :string
+          repo: :string,
+          dimensions: :integer
         ],
         defaults: [],
         aliases: []
@@ -63,8 +69,10 @@ if Code.ensure_loaded?(Igniter) do
           Module.concat([app_module, "Repo"])
         end
 
+      dimensions = opts[:dimensions] || detect_dimensions()
+
       igniter
-      |> create_migration(repo_module)
+      |> create_migration(repo_module, dimensions)
       |> Igniter.add_notice("""
 
       GraphRAG migration created!
@@ -96,7 +104,19 @@ if Code.ensure_loaded?(Igniter) do
       """)
     end
 
-    defp create_migration(igniter, repo_module) do
+    defp detect_dimensions do
+      Mix.Task.run("app.config")
+      Arcana.Embedder.dimensions(Arcana.embedder())
+    rescue
+      e ->
+        Mix.raise("""
+        Could not detect embedding dimensions from the configured embedder: #{Exception.message(e)}
+
+        Pass them explicitly, e.g.: mix arcana.graph.install --dimensions 1024
+        """)
+    end
+
+    defp create_migration(igniter, repo_module, dimensions) do
       repo_underscore =
         repo_module
         |> Module.split()
@@ -119,7 +139,7 @@ if Code.ensure_loaded?(Igniter) do
             add :name, :string, null: false
             add :type, :string, null: false
             add :description, :text
-            add :embedding, :vector, size: 384
+            add :embedding, :vector, size: #{dimensions}
             add :metadata, :map, default: %{}
             add :chunk_id, references(:arcana_chunks, type: :binary_id, on_delete: :nilify_all)
             add :collection_id, references(:arcana_collections, type: :binary_id, on_delete: :delete_all)
@@ -220,9 +240,14 @@ else
     GraphRAG is optional. Only run this if you want to use knowledge graph
     features for enhanced retrieval.
 
+    Entity embedding dimensions are detected from the configured embedder
+    (via `Arcana.Embedder.dimensions/1`), so the generated table matches
+    your vectors. Use `--dimensions` to override.
+
     ## Options
 
       * `--repo` - The repo to generate migrations for (defaults to YourApp.Repo)
+      * `--dimensions` - Override auto-detected embedding dimensions
     """
 
     use Mix.Task
@@ -239,7 +264,7 @@ else
           add :name, :string, null: false
           add :type, :string, null: false
           add :description, :text
-          add :embedding, :vector, size: 384
+          add :embedding, :vector, size: <%= @dimensions %>
           add :metadata, :map, default: %{}
           add :chunk_id, references(:arcana_chunks, type: :binary_id, on_delete: :nilify_all)
           add :collection_id, references(:arcana_collections, type: :binary_id, on_delete: :delete_all)
@@ -322,10 +347,11 @@ else
 
     @impl Mix.Task
     def run(args) do
-      {opts, _, _} = OptionParser.parse(args, strict: [repo: :string])
+      {opts, _, _} = OptionParser.parse(args, strict: [repo: :string, dimensions: :integer])
 
       repo = opts[:repo] || infer_repo()
       repo_underscore = Macro.underscore(repo) |> String.replace("/", "_")
+      dimensions = opts[:dimensions] || detect_dimensions()
 
       migrations_path = Path.join(["priv", repo_underscore, "migrations"])
       File.mkdir_p!(migrations_path)
@@ -334,7 +360,8 @@ else
       filename = "#{timestamp}_create_arcana_graph_tables.exs"
       path = Path.join(migrations_path, filename)
 
-      content = EEx.eval_string(@migration_template, assigns: [repo: repo])
+      content =
+        EEx.eval_string(@migration_template, assigns: [repo: repo, dimensions: dimensions])
 
       create_file(path, content)
 
@@ -380,6 +407,18 @@ else
           |> Macro.camelize()
           |> Kernel.<>(".Repo")
       end
+    end
+
+    defp detect_dimensions do
+      Mix.Task.run("app.config")
+      Arcana.Embedder.dimensions(Arcana.embedder())
+    rescue
+      e ->
+        Mix.raise("""
+        Could not detect embedding dimensions from the configured embedder: #{Exception.message(e)}
+
+        Pass them explicitly, e.g.: mix arcana.graph.install --dimensions 1024
+        """)
     end
   end
 end

--- a/lib/mix/tasks/arcana.graph.install.ex
+++ b/lib/mix/tasks/arcana.graph.install.ex
@@ -69,7 +69,7 @@ if Code.ensure_loaded?(Igniter) do
           Module.concat([app_module, "Repo"])
         end
 
-      dimensions = opts[:dimensions] || detect_dimensions()
+      dimensions = resolve_dimensions(opts[:dimensions])
 
       igniter
       |> create_migration(repo_module, dimensions)
@@ -104,17 +104,8 @@ if Code.ensure_loaded?(Igniter) do
       """)
     end
 
-    defp detect_dimensions do
-      Mix.Task.run("app.config")
-      Arcana.Embedder.dimensions(Arcana.embedder())
-    rescue
-      e ->
-        Mix.raise("""
-        Could not detect embedding dimensions from the configured embedder: #{Exception.message(e)}
-
-        Pass them explicitly, e.g.: mix arcana.graph.install --dimensions 1024
-        """)
-    end
+    defp resolve_dimensions(nil), do: Arcana.MixHelpers.detect_dimensions!()
+    defp resolve_dimensions(given), do: Arcana.MixHelpers.validate_dimensions!(given)
 
     defp create_migration(igniter, repo_module, dimensions) do
       repo_underscore =
@@ -351,7 +342,7 @@ else
 
       repo = opts[:repo] || infer_repo()
       repo_underscore = Macro.underscore(repo) |> String.replace("/", "_")
-      dimensions = opts[:dimensions] || detect_dimensions()
+      dimensions = resolve_dimensions(opts[:dimensions])
 
       migrations_path = Path.join(["priv", repo_underscore, "migrations"])
       File.mkdir_p!(migrations_path)
@@ -409,16 +400,7 @@ else
       end
     end
 
-    defp detect_dimensions do
-      Mix.Task.run("app.config")
-      Arcana.Embedder.dimensions(Arcana.embedder())
-    rescue
-      e ->
-        Mix.raise("""
-        Could not detect embedding dimensions from the configured embedder: #{Exception.message(e)}
-
-        Pass them explicitly, e.g.: mix arcana.graph.install --dimensions 1024
-        """)
-    end
+    defp resolve_dimensions(nil), do: Arcana.MixHelpers.detect_dimensions!()
+    defp resolve_dimensions(given), do: Arcana.MixHelpers.validate_dimensions!(given)
   end
 end

--- a/lib/mix/tasks/arcana.graph.rebuild.ex
+++ b/lib/mix/tasks/arcana.graph.rebuild.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Arcana.Graph.Rebuild do
     # Start the host application (which will start the repo)
     Mix.Task.run("app.start")
 
-    repo = Arcana.Config.repo!()
+    repo = Arcana.MixHelpers.repo!()
 
     # Show current graph info
     info = Arcana.Maintenance.graph_info()

--- a/lib/mix/tasks/arcana.graph.rebuild.ex
+++ b/lib/mix/tasks/arcana.graph.rebuild.ex
@@ -52,11 +52,7 @@ defmodule Mix.Tasks.Arcana.Graph.Rebuild do
     # Start the host application (which will start the repo)
     Mix.Task.run("app.start")
 
-    repo = Application.get_env(:arcana, :repo)
-
-    unless repo do
-      Mix.raise("No repo configured. Set config :arcana, repo: YourApp.Repo")
-    end
+    repo = Arcana.Config.repo!()
 
     # Show current graph info
     info = Arcana.Maintenance.graph_info()

--- a/lib/mix/tasks/arcana.graph.summarize_communities.ex
+++ b/lib/mix/tasks/arcana.graph.summarize_communities.ex
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Arcana.Graph.SummarizeCommunities do
     # Start the host application (which will start the repo)
     Mix.Task.run("app.start")
 
-    repo = Arcana.Config.repo!()
+    repo = Arcana.MixHelpers.repo!()
 
     # Check LLM is configured
     unless Application.get_env(:arcana, :llm) do

--- a/lib/mix/tasks/arcana.graph.summarize_communities.ex
+++ b/lib/mix/tasks/arcana.graph.summarize_communities.ex
@@ -67,11 +67,7 @@ defmodule Mix.Tasks.Arcana.Graph.SummarizeCommunities do
     # Start the host application (which will start the repo)
     Mix.Task.run("app.start")
 
-    repo = Application.get_env(:arcana, :repo)
-
-    unless repo do
-      Mix.raise("No repo configured. Set config :arcana, repo: YourApp.Repo")
-    end
+    repo = Arcana.Config.repo!()
 
     # Check LLM is configured
     unless Application.get_env(:arcana, :llm) do

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -29,6 +29,13 @@ if Code.ensure_loaded?(Igniter) do
     alias Igniter.Libs.Phoenix
     alias Igniter.Project.Config
 
+    # Files that can hold `config :app, Repo, types: ...`. config.exs alone
+    # misses env files, which `import_config` pulls in but igniter's config
+    # helpers don't follow.
+    @config_files ["config.exs", "dev.exs", "test.exs", "prod.exs", "runtime.exs"]
+
+    @types_define_marker "Postgrex.Types.define"
+
     @impl Igniter.Mix.Task
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
@@ -59,12 +66,13 @@ if Code.ensure_loaded?(Igniter) do
       web_module = Module.concat([app_module <> "Web"])
       types_module = Module.concat([app_module, "PostgrexTypes"])
 
-      igniter = Igniter.include_glob(igniter, "lib/**/*.ex")
+      {igniter, unparsable} = include_types_candidates(igniter)
       existing_types = existing_types_module(igniter, app_name, repo_module)
 
       igniter
       |> create_migration(repo_module)
       |> setup_postgrex_types(existing_types, app_name, repo_module, types_module)
+      |> maybe_warn_unparsable(unparsable)
       |> maybe_add_dashboard_route(opts[:dashboard], web_module)
       |> Igniter.add_notice("""
 
@@ -213,43 +221,161 @@ if Code.ensure_loaded?(Igniter) do
       Igniter.create_new_file(igniter, path, migration_content)
     end
 
-    # Detects an existing Postgrex types module: either a Postgrex.Types.define/3
-    # call somewhere under lib/, or a :types key already set on the repo config.
-    # Returns the defined module, :unknown when detected but unnamed, or nil.
+    # Pulls only the lib/ files that actually mention Postgrex.Types.define
+    # into the rewrite. Reading a file parses it eagerly, so a lib file with
+    # a syntax error would otherwise abort the whole install; those are
+    # collected and reported instead.
+    defp include_types_candidates(igniter) do
+      {igniter, unparsable} =
+        igniter
+        |> types_candidate_paths()
+        |> Enum.reduce({igniter, []}, fn path, {igniter, unparsable} ->
+          try do
+            {Igniter.include_existing_file(igniter, path), unparsable}
+          rescue
+            _ -> {igniter, [path | unparsable]}
+          end
+        end)
+
+      {igniter, Enum.reverse(unparsable)}
+    end
+
+    defp types_candidate_paths(igniter) do
+      if igniter.assigns[:test_mode?] do
+        igniter.assigns[:test_files]
+        |> Enum.filter(fn {path, content} ->
+          lib_source?(path) and String.contains?(content, @types_define_marker)
+        end)
+        |> Enum.map(fn {path, _content} -> path end)
+      else
+        "lib/**/*.ex"
+        |> Path.wildcard()
+        |> Enum.filter(&mentions_types_define?/1)
+      end
+      |> Enum.sort()
+    end
+
+    defp lib_source?(path) do
+      String.starts_with?(path, "lib/") and String.ends_with?(path, ".ex")
+    end
+
+    defp mentions_types_define?(path) do
+      case File.read(path) do
+        {:ok, content} -> String.contains?(content, @types_define_marker)
+        _ -> false
+      end
+    end
+
+    defp maybe_warn_unparsable(igniter, []), do: igniter
+
+    defp maybe_warn_unparsable(igniter, paths) do
+      Igniter.add_notice(igniter, """
+
+      Arcana could not parse these files while looking for an existing
+      Postgrex types module:
+
+      #{Enum.map_join(paths, "\n", &"    #{&1}")}
+
+      Installation continued as if no types module existed. If one of them
+      does define one, remove the module Arcana just generated and add
+      Pgvector.Extensions.Vector to yours instead.
+      """)
+    end
+
+    # Detects an existing Postgrex types module. The `:types` key on the repo
+    # being configured is authoritative; a Postgrex.Types.define/3 call found
+    # by scanning lib/ is a hint, since it may belong to a different repo.
     defp existing_types_module(igniter, app_name, repo_module) do
-      find_postgrex_types_define(igniter) ||
-        configured_repo_types(igniter, app_name, repo_module)
+      configured_repo_types(igniter, app_name, repo_module) ||
+        find_postgrex_types_define(igniter)
     end
 
     defp find_postgrex_types_define(igniter) do
       igniter.rewrite
       |> Rewrite.sources()
-      |> Enum.filter(&String.ends_with?(&1.path, ".ex"))
+      |> Enum.filter(&types_define_candidate?/1)
       |> Enum.find_value(&postgrex_types_define_in_source/1)
+    end
+
+    defp types_define_candidate?(source) do
+      String.ends_with?(source.path, ".ex") and
+        String.contains?(Rewrite.Source.get(source, :content), @types_define_marker)
+    rescue
+      _ -> false
     end
 
     defp postgrex_types_define_in_source(source) do
       zipper = source |> Rewrite.Source.get(:quoted) |> Sourceror.Zipper.zip()
 
       case Function.move_to_function_call(zipper, {Postgrex.Types, :define}, :any) do
-        {:ok, call} -> defined_types_module(call)
+        {:ok, call} -> {:source, defined_types_module(call), source.path}
         :error -> nil
       end
+    rescue
+      _ -> nil
     end
 
+    # The first argument is usually a plain alias, but `__MODULE__.Types` is a
+    # common idiom (it's the one Postgrex's own docs use). Anything we can't
+    # name confidently degrades to :unknown - a wrong module name in the
+    # notice is worse than none.
     defp defined_types_module(call_zipper) do
       with {:ok, arg} <- Function.move_to_nth_argument(call_zipper, 0),
-           {:__aliases__, _, parts} when is_list(parts) <- Sourceror.Zipper.node(arg) do
-        Module.concat(parts)
+           {:__aliases__, _, parts} when is_list(parts) <- Sourceror.Zipper.node(arg),
+           {:ok, module} <- resolve_alias(parts, arg) do
+        module
       else
         _ -> :unknown
       end
     end
 
-    defp configured_repo_types(igniter, app_name, repo_module) do
-      if Config.configures_key?(igniter, "config.exs", app_name, [repo_module, :types]) do
-        :unknown
+    defp resolve_alias(parts, zipper) do
+      case Enum.split_while(parts, &is_atom/1) do
+        {[_ | _] = atoms, []} -> {:ok, Module.concat(atoms)}
+        {[], [{:__MODULE__, _, _} | rest]} -> resolve_self_alias(rest, zipper)
+        _ -> :error
       end
+    end
+
+    defp resolve_self_alias(rest, zipper) do
+      if Enum.all?(rest, &is_atom/1) do
+        case enclosing_module_parts(zipper, []) do
+          [] -> :error
+          parts -> {:ok, Module.concat(parts ++ rest)}
+        end
+      else
+        :error
+      end
+    end
+
+    # Walks up to collect every enclosing defmodule name. Nested defmodules
+    # concatenate, so `defmodule Foo do defmodule Bar` is Foo.Bar.
+    defp enclosing_module_parts(zipper, acc) do
+      case Sourceror.Zipper.up(zipper) do
+        nil ->
+          acc
+
+        parent ->
+          case Sourceror.Zipper.node(parent) do
+            {:defmodule, _, [{:__aliases__, _, parts} | _]} ->
+              if Enum.all?(parts, &is_atom/1) do
+                enclosing_module_parts(parent, parts ++ acc)
+              else
+                []
+              end
+
+            _ ->
+              enclosing_module_parts(parent, acc)
+          end
+      end
+    end
+
+    defp configured_repo_types(igniter, app_name, repo_module) do
+      Enum.find_value(@config_files, fn file ->
+        if Config.configures_key?(igniter, file, app_name, [repo_module, :types]) do
+          {:config, file}
+        end
+      end)
     end
 
     defp setup_postgrex_types(igniter, nil, app_name, repo_module, types_module) do
@@ -262,17 +388,34 @@ if Code.ensure_loaded?(Igniter) do
       Igniter.add_notice(igniter, existing_types_notice(existing, app_name, repo_module))
     end
 
-    defp existing_types_notice(existing, app_name, repo_module) do
-      module_hint =
-        if existing == :unknown, do: "your existing types module", else: inspect(existing)
+    defp existing_types_notice({:config, file}, _app_name, repo_module) do
+      """
+      #{inspect(repo_module)} already has a `:types` module configured in
+      config/#{file}, so Arcana skipped generating one.
 
-      module_code = if existing == :unknown, do: "MyApp.PostgrexTypes", else: inspect(existing)
+      Make sure that module includes the pgvector extension:
+
+          Postgrex.Types.define(
+            YourApp.PostgrexTypes,
+            [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
+            []
+          )
+      """
+    end
+
+    defp existing_types_notice({:source, existing, path}, app_name, repo_module) do
+      module_hint = if existing == :unknown, do: "a types module", else: inspect(existing)
+      module_code = if existing == :unknown, do: "YourApp.PostgrexTypes", else: inspect(existing)
 
       """
-      An existing Postgrex types module was detected, so Arcana skipped
-      generating one.
+      Arcana found #{module_hint} defined by a Postgrex.Types.define/3 call in
+      #{path}, so it skipped generating one.
 
-      Make sure #{module_hint} includes the pgvector extension:
+      #{inspect(repo_module)} has no `:types` key configured, so Arcana could
+      not confirm this module is the one it should use - in a multi-repo app it
+      may belong to a different repo. Please verify.
+
+      If it is the right module, add the pgvector extension to it:
 
           Postgrex.Types.define(
             #{module_code},
@@ -280,9 +423,12 @@ if Code.ensure_loaded?(Igniter) do
             []
           )
 
-      and that your repo is configured to use it:
+      and point the repo at it:
 
           config :#{app_name}, #{inspect(repo_module)}, types: #{module_code}
+
+      If it belongs to a different repo, define a separate types module for
+      #{inspect(repo_module)} with the same snippet and configure that instead.
       """
     end
 
@@ -326,15 +472,42 @@ if Code.ensure_loaded?(Igniter) do
         arcana_dashboard "/arcana"
       """
 
-      igniter
-      |> Phoenix.add_scope("/", scope_code, router: router_module)
-      |> Igniter.add_notice("""
+      # Router discovery includes (and therefore parses) elixir files across
+      # the project, so a single syntax-broken file aborts the install. The
+      # dashboard route is optional - degrade to instructions instead.
+      case add_dashboard_scope(igniter, router_module, scope_code) do
+        {:ok, igniter} ->
+          Igniter.add_notice(igniter, """
 
-      IMPORTANT: Add this import to the top of your router (#{inspect(router_module)}):
+          IMPORTANT: Add this import to the top of your router (#{inspect(router_module)}):
 
-          import ArcanaWeb.Router
+              import ArcanaWeb.Router
 
-      """)
+          """)
+
+        {:error, message} ->
+          Igniter.add_notice(igniter, """
+
+          Arcana could not add the dashboard route automatically: #{message}
+
+          Add it to #{inspect(router_module)} by hand:
+
+              import ArcanaWeb.Router
+
+              scope "/" do
+                pipe_through [:browser]
+
+                arcana_dashboard "/arcana"
+              end
+
+          """)
+      end
+    end
+
+    defp add_dashboard_scope(igniter, router_module, scope_code) do
+      {:ok, Phoenix.add_scope(igniter, "/", scope_code, router: router_module)}
+    rescue
+      e -> {:error, Exception.message(e)}
     end
   end
 else

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -561,10 +561,21 @@ if Code.ensure_loaded?(Igniter) do
 
     defp types_module_taken?(igniter, candidate, found, found_path) do
       path = types_module_path(candidate)
-      {defined?, igniter} = IgniterModule.module_exists(igniter, candidate)
+      {defined?, igniter} = module_defined?(igniter, candidate)
 
       {candidate == found or path == found_path or defined? or Igniter.exists?(igniter, path),
        igniter}
+    end
+
+    # The search parses the files it looks at, so one unparsable file in lib/
+    # would otherwise abort the whole install with a Sourceror error. An app
+    # with a broken file still deserves a working installer, and the path check
+    # below is enough to keep us off an occupied name: whatever the file
+    # contains, it is there.
+    defp module_defined?(igniter, candidate) do
+      IgniterModule.module_exists(igniter, candidate)
+    rescue
+      _ -> {false, igniter}
     end
 
     defp no_free_types_module_message(candidates) do

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -17,6 +17,14 @@ if Code.ensure_loaded?(Igniter) do
     the installer skips generating one and instead tells you how to add
     the pgvector extension to your existing module.
 
+    Detection reads every `*.exs` file directly inside your config
+    directory, plus every `lib/**/*.ex` file that mentions
+    `Postgrex.Types.define`. It does not evaluate config, so a `:types` key
+    that only exists in a file imported from outside the config directory,
+    or that is built at runtime, is invisible to it - the installer will
+    generate a second types module. If that happens, delete the generated
+    module and add `Pgvector.Extensions.Vector` to yours instead.
+
     ## Options
 
       * `--no-dashboard` - Skip adding the dashboard route
@@ -28,11 +36,6 @@ if Code.ensure_loaded?(Igniter) do
     alias Igniter.Code.Function
     alias Igniter.Libs.Phoenix
     alias Igniter.Project.Config
-
-    # Files that can hold `config :app, Repo, types: ...`. config.exs alone
-    # misses env files, which `import_config` pulls in but igniter's config
-    # helpers don't follow.
-    @config_files ["config.exs", "dev.exs", "test.exs", "prod.exs", "runtime.exs"]
 
     @types_define_marker "Postgrex.Types.define"
 
@@ -66,13 +69,13 @@ if Code.ensure_loaded?(Igniter) do
       web_module = Module.concat([app_module <> "Web"])
       types_module = Module.concat([app_module, "PostgrexTypes"])
 
-      {igniter, unparsable} = include_types_candidates(igniter)
-      existing_types = existing_types_module(igniter, app_name, repo_module)
+      {igniter, unparsable_lib} = include_types_candidates(igniter)
+      {existing_types, unparsable_config} = existing_types_module(igniter, app_name, repo_module)
 
       igniter
       |> create_migration(repo_module)
       |> setup_postgrex_types(existing_types, app_name, repo_module, types_module)
-      |> maybe_warn_unparsable(unparsable)
+      |> maybe_warn_unparsable(unparsable_lib ++ unparsable_config)
       |> maybe_add_dashboard_route(opts[:dashboard], web_module)
       |> Igniter.add_notice("""
 
@@ -276,8 +279,8 @@ if Code.ensure_loaded?(Igniter) do
 
       #{Enum.map_join(paths, "\n", &"    #{&1}")}
 
-      Installation continued as if no types module existed. If one of them
-      does define one, remove the module Arcana just generated and add
+      Detection ran without them. If one of them defines or configures a
+      types module, remove the one Arcana just generated (if any) and add
       Pgvector.Extensions.Vector to yours instead.
       """)
     end
@@ -285,9 +288,14 @@ if Code.ensure_loaded?(Igniter) do
     # Detects an existing Postgrex types module. The `:types` key on the repo
     # being configured is authoritative; a Postgrex.Types.define/3 call found
     # by scanning lib/ is a hint, since it may belong to a different repo.
+    #
+    # Returns the detection result plus any config files that could not be
+    # parsed, so the caller can say detection ran with a blind spot.
     defp existing_types_module(igniter, app_name, repo_module) do
-      configured_repo_types(igniter, app_name, repo_module) ||
-        find_postgrex_types_define(igniter)
+      case configured_repo_types(igniter, app_name, repo_module) do
+        {nil, unparsable} -> {find_postgrex_types_define(igniter), unparsable}
+        {configured, unparsable} -> {configured, unparsable}
+      end
     end
 
     defp find_postgrex_types_define(igniter) do
@@ -370,33 +378,129 @@ if Code.ensure_loaded?(Igniter) do
       end
     end
 
+    # Scans every config file for `config :app, Repo, types: ...`. Igniter's
+    # config helpers look at one named file and don't follow `import_config`,
+    # so the whole config directory gets scanned rather than a hardcoded list
+    # of the usual env files.
     defp configured_repo_types(igniter, app_name, repo_module) do
-      Enum.find_value(@config_files, fn file ->
-        if Config.configures_key?(igniter, file, app_name, [repo_module, :types]) do
-          {:config, file}
-        end
+      {found, unparsable} =
+        igniter
+        |> config_file_names()
+        |> Enum.reduce_while({nil, []}, fn file, {_found, unparsable} ->
+          case configured_types_in(igniter, file, app_name, repo_module) do
+            :none -> {:cont, {nil, unparsable}}
+            :unparsable -> {:cont, {nil, [config_path(igniter, file) | unparsable]}}
+            {:ok, module} -> {:halt, {{:config, config_path(igniter, file), module}, unparsable}}
+          end
+        end)
+
+      {found, Enum.reverse(unparsable)}
+    end
+
+    defp config_file_names(igniter) do
+      dir = config_dir(igniter)
+
+      igniter
+      |> project_file_paths(dir)
+      |> Enum.filter(&(Path.dirname(&1) == dir and String.ends_with?(&1, ".exs")))
+      |> Enum.map(&Path.basename/1)
+      |> Enum.sort()
+    end
+
+    defp project_file_paths(igniter, dir) do
+      if igniter.assigns[:test_mode?] do
+        Map.keys(igniter.assigns[:test_files])
+      else
+        Path.wildcard(Path.join(dir, "*.exs"))
+      end
+    end
+
+    # Igniter addresses config files by name relative to the project's config
+    # directory, which `:config_path` in mix.exs can move.
+    defp config_dir(igniter) do
+      igniter
+      |> Igniter.Project.Application.config_path()
+      |> Path.dirname()
+    end
+
+    defp config_path(igniter, file), do: Path.join(config_dir(igniter), file)
+
+    defp configured_types_in(igniter, file, app_name, repo_module) do
+      if Config.configures_key?(igniter, file, app_name, [repo_module, :types]) do
+        {:ok, configured_types_module(igniter, file, app_name, repo_module)}
+      else
+        :none
+      end
+    rescue
+      _ -> :unparsable
+    end
+
+    # Best effort: `configures_key?/4` above already said the key is there,
+    # this only recovers the module name for the notice. The two-argument
+    # `config :app, Repo: [types: ...]` shape and any non-literal value
+    # degrade to :unknown rather than naming the wrong module.
+    defp configured_types_module(igniter, file, app_name, repo_module) do
+      with {:ok, zipper} <- config_zipper(igniter, file),
+           {:ok, call} <- move_to_repo_config(zipper, app_name, repo_module),
+           {:ok, opts} <- Function.move_to_nth_argument(call, 2),
+           {:ok, value} <- Igniter.Code.Keyword.get_key(opts, :types),
+           {:__aliases__, _, parts} when is_list(parts) <- Sourceror.Zipper.node(value),
+           true <- Enum.all?(parts, &is_atom/1) do
+        Module.concat(parts)
+      else
+        _ -> :unknown
+      end
+    rescue
+      _ -> :unknown
+    end
+
+    defp move_to_repo_config(zipper, app_name, repo_module) do
+      Function.move_to_function_call_in_current_scope(zipper, :config, 3, fn call ->
+        Function.argument_equals?(call, 0, app_name) and
+          Function.argument_equals?(call, 1, repo_module)
       end)
+    end
+
+    defp config_zipper(igniter, file) do
+      path = config_path(igniter, file)
+      igniter = Igniter.include_existing_file(igniter, path, required?: false)
+
+      case Rewrite.source(igniter.rewrite, path) do
+        {:ok, source} -> {:ok, source |> Rewrite.Source.get(:quoted) |> Sourceror.Zipper.zip()}
+        _ -> :error
+      end
     end
 
     defp setup_postgrex_types(igniter, nil, app_name, repo_module, types_module) do
       igniter
       |> create_postgrex_types_module(types_module)
       |> configure_repo_types(app_name, repo_module, types_module)
+      |> Igniter.add_notice("""
+
+      Arcana generated #{inspect(types_module)} because it found no existing
+      Postgrex types module. It looked in #{config_dir(igniter)}/*.exs and in
+      lib/**/*.ex; config imported from elsewhere or built at runtime is not
+      followed. If you already have one, delete the generated module and add
+      Pgvector.Extensions.Vector to yours instead.
+      """)
     end
 
     defp setup_postgrex_types(igniter, existing, app_name, repo_module, _types_module) do
       Igniter.add_notice(igniter, existing_types_notice(existing, app_name, repo_module))
     end
 
-    defp existing_types_notice({:config, file}, _app_name, repo_module) do
+    defp existing_types_notice({:config, path, existing}, _app_name, repo_module) do
+      named = if existing == :unknown, do: "", else: ": #{inspect(existing)}"
+      module_code = if existing == :unknown, do: "YourApp.PostgrexTypes", else: inspect(existing)
+
       """
       #{inspect(repo_module)} already has a `:types` module configured in
-      config/#{file}, so Arcana skipped generating one.
+      #{path}#{named}, so Arcana skipped generating one.
 
       Make sure that module includes the pgvector extension:
 
           Postgrex.Types.define(
-            YourApp.PostgrexTypes,
+            #{module_code},
             [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
             []
           )

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -567,11 +567,17 @@ if Code.ensure_loaded?(Igniter) do
        igniter}
     end
 
-    # The search parses the files it looks at, so one unparsable file in lib/
-    # would otherwise abort the whole install with a Sourceror error. An app
-    # with a broken file still deserves a working installer, and the path check
-    # below is enough to keep us off an occupied name: whatever the file
-    # contains, it is there.
+    # The search parses the files it looks at, and its last resort parses every
+    # .ex/.exs under lib/, test/ and config/, so a single unparsable file
+    # anywhere in the project would otherwise abort the whole install with a
+    # Sourceror error. An app mid-refactor still deserves a working installer.
+    #
+    # Degrading to the path check is not free: when the broken file IS the
+    # candidate's own file, the path check still sees it and we skip the name.
+    # When the broken file is elsewhere AND the candidate is defined somewhere
+    # only the full scan would have found, we can still generate a second
+    # definition of it. That trade buys an installer that runs at all, and the
+    # compiler names the duplicate if it happens.
     defp module_defined?(igniter, candidate) do
       IgniterModule.module_exists(igniter, candidate)
     rescue

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -532,18 +532,43 @@ if Code.ensure_loaded?(Igniter) do
 
     # Never reuse the name (or the file) of a module that's already there: that
     # collision is what made the installer overwrite other people's types
-    # modules. The last candidate is the give-up value; a project where all
-    # three names are taken isn't worth more code.
-    defp free_types_module(_igniter, [last], _found, _found_path), do: last
+    # modules. Settling for an occupied name would be worse than stopping:
+    # module creation skips a path that already exists, so the repo config would
+    # end up pointing at somebody else's module, one with no pgvector extension
+    # in it, and the install would fail at runtime instead of here.
+    defp free_types_module(igniter, candidates, found, found_path) do
+      candidates
+      |> Enum.find(fn candidate ->
+        path = types_module_path(candidate)
 
-    defp free_types_module(igniter, [candidate | rest], found, found_path) do
-      path = types_module_path(candidate)
-
-      if candidate == found or path == found_path or Igniter.exists?(igniter, path) do
-        free_types_module(igniter, rest, found, found_path)
-      else
-        candidate
+        candidate != found and path != found_path and not Igniter.exists?(igniter, path)
+      end)
+      |> case do
+        nil -> raise Mix.Error, message: no_free_types_module_message(candidates)
+        candidate -> candidate
       end
+    end
+
+    defp no_free_types_module_message(candidates) do
+      taken = Enum.map_join(candidates, "\n", &"  * #{inspect(&1)} (#{types_module_path(&1)})")
+
+      """
+      Arcana needs to generate a Postgrex types module with the pgvector
+      extension in it, but every name it would use is already taken:
+
+      #{taken}
+
+      Rename or delete one of those, or add the extension to the types module
+      you already have:
+
+          Postgrex.Types.define(
+            YourApp.PostgrexTypes,
+            [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
+            []
+          )
+
+      and point your repo at it with `types: YourApp.PostgrexTypes`.
+      """
     end
 
     defp scanned_types_notice(found, path, app_name, repo_module, chosen) do

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -41,6 +41,8 @@ if Code.ensure_loaded?(Igniter) do
     alias Igniter.Code.Function
     alias Igniter.Libs.Phoenix
     alias Igniter.Project.Config
+    # Aliased, because plain Module is Elixir's and this file uses both.
+    alias Igniter.Project.Module, as: IgniterModule
 
     @types_define_marker "Postgrex.Types.define"
 
@@ -477,7 +479,8 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp setup_postgrex_types(igniter, nil, app_name, repo_module, types_module) do
-      chosen = free_types_module(igniter, candidates(types_module, repo_module), nil, nil)
+      {igniter, chosen} =
+        free_types_module(igniter, candidates(types_module, repo_module), nil, nil)
 
       igniter
       |> create_postgrex_types_module(chosen)
@@ -514,7 +517,8 @@ if Code.ensure_loaded?(Igniter) do
            repo_module,
            types_module
          ) do
-      chosen = free_types_module(igniter, candidates(types_module, repo_module), found, path)
+      {igniter, chosen} =
+        free_types_module(igniter, candidates(types_module, repo_module), found, path)
 
       igniter
       |> create_postgrex_types_module(chosen)
@@ -536,17 +540,31 @@ if Code.ensure_loaded?(Igniter) do
     # module creation skips a path that already exists, so the repo config would
     # end up pointing at somebody else's module, one with no pgvector extension
     # in it, and the install would fail at runtime instead of here.
+    # Checking the conventional path isn't enough: nothing stops an app from
+    # defining MyApp.PostgrexTypes in lib/my_app/db/types.ex, and generating a
+    # second definition of a module that already exists somewhere else is its
+    # own kind of breakage. IgniterModule.module_exists/2 searches the project
+    # for the definition wherever it lives, and hands back an igniter carrying
+    # the module index it built, which is why this threads one through.
     defp free_types_module(igniter, candidates, found, found_path) do
       candidates
-      |> Enum.find(fn candidate ->
-        path = types_module_path(candidate)
+      |> Enum.reduce_while({igniter, nil}, fn candidate, {igniter, _} ->
+        {taken?, igniter} = types_module_taken?(igniter, candidate, found, found_path)
 
-        candidate != found and path != found_path and not Igniter.exists?(igniter, path)
+        if taken?, do: {:cont, {igniter, nil}}, else: {:halt, {igniter, candidate}}
       end)
       |> case do
-        nil -> raise Mix.Error, message: no_free_types_module_message(candidates)
-        candidate -> candidate
+        {_igniter, nil} -> raise Mix.Error, message: no_free_types_module_message(candidates)
+        {igniter, candidate} -> {igniter, candidate}
       end
+    end
+
+    defp types_module_taken?(igniter, candidate, found, found_path) do
+      path = types_module_path(candidate)
+      {defined?, igniter} = IgniterModule.module_exists(igniter, candidate)
+
+      {candidate == found or path == found_path or defined? or Igniter.exists?(igniter, path),
+       igniter}
     end
 
     defp no_free_types_module_message(candidates) do

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -12,10 +12,15 @@ if Code.ensure_loaded?(Igniter) do
     - Create the Postgrex types module for pgvector
     - Configure your repo to use the types module
 
-    If your application already defines a Postgrex types module (a
-    `Postgrex.Types.define/3` call, or a `:types` key on your repo config),
-    the installer skips generating one and instead tells you how to add
-    the pgvector extension to your existing module.
+    If the repo already has a `:types` key in its config, the installer
+    leaves it alone and tells you how to add the pgvector extension to that
+    module.
+
+    A `Postgrex.Types.define/3` call found by scanning `lib/` is a weaker
+    signal: types modules are per-repo, and nothing in the call says which
+    repo it serves. The installer leaves that module untouched and generates
+    a separate one for the repo it is installing into, named so it cannot
+    collide, so the repo ends up with pgvector registered either way.
 
     Detection reads every `*.exs` file directly inside your config
     directory, plus every `lib/**/*.ex` file that mentions
@@ -472,12 +477,14 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp setup_postgrex_types(igniter, nil, app_name, repo_module, types_module) do
+      chosen = free_types_module(igniter, candidates(types_module, repo_module), nil, nil)
+
       igniter
-      |> create_postgrex_types_module(types_module)
-      |> configure_repo_types(app_name, repo_module, types_module)
+      |> create_postgrex_types_module(chosen)
+      |> configure_repo_types(app_name, repo_module, chosen)
       |> Igniter.add_notice("""
 
-      Arcana generated #{inspect(types_module)} because it found no existing
+      Arcana generated #{inspect(chosen)} because it found no existing
       Postgrex types module. It looked in #{config_dir(igniter)}/*.exs and in
       lib/**/*.ex; config imported from elsewhere or built at runtime is not
       followed. If you already have one, delete the generated module and add
@@ -485,8 +492,85 @@ if Code.ensure_loaded?(Igniter) do
       """)
     end
 
-    defp setup_postgrex_types(igniter, existing, app_name, repo_module, _types_module) do
+    defp setup_postgrex_types(
+           igniter,
+           {:config, _path, _module} = existing,
+           app_name,
+           repo_module,
+           _types_module
+         ) do
       Igniter.add_notice(igniter, existing_types_notice(existing, app_name, repo_module))
+    end
+
+    # A Postgrex.Types.define/3 call found by scanning lib/ says nothing about
+    # which repo it serves, and types modules are per-repo. Skipping here would
+    # leave the repo Arcana is installing into with no `:types` key at all, so
+    # pgvector would never be registered for it. Generate one anyway, under a
+    # name that can't collide with the module that's already there.
+    defp setup_postgrex_types(
+           igniter,
+           {:source, found, path},
+           app_name,
+           repo_module,
+           types_module
+         ) do
+      chosen = free_types_module(igniter, candidates(types_module, repo_module), found, path)
+
+      igniter
+      |> create_postgrex_types_module(chosen)
+      |> configure_repo_types(app_name, repo_module, chosen)
+      |> Igniter.add_notice(scanned_types_notice(found, path, app_name, repo_module, chosen))
+    end
+
+    defp candidates(types_module, repo_module) do
+      [
+        types_module,
+        Module.concat([repo_module, "PostgrexTypes"]),
+        Module.concat([repo_module, "ArcanaPostgrexTypes"])
+      ]
+    end
+
+    # Never reuse the name (or the file) of a module that's already there: that
+    # collision is what made the installer overwrite other people's types
+    # modules. The last candidate is the give-up value; a project where all
+    # three names are taken isn't worth more code.
+    defp free_types_module(_igniter, [last], _found, _found_path), do: last
+
+    defp free_types_module(igniter, [candidate | rest], found, found_path) do
+      path = types_module_path(candidate)
+
+      if candidate == found or path == found_path or Igniter.exists?(igniter, path) do
+        free_types_module(igniter, rest, found, found_path)
+      else
+        candidate
+      end
+    end
+
+    defp scanned_types_notice(found, path, app_name, repo_module, chosen) do
+      found_hint = if found == :unknown, do: "a types module", else: inspect(found)
+      found_code = if found == :unknown, do: "TheModuleAbove", else: inspect(found)
+
+      """
+      Arcana found #{found_hint} defined by a Postgrex.Types.define/3 call in
+      #{path}, but #{inspect(repo_module)} has no `:types` key pointing at it.
+
+      Postgrex types modules are per-repo, so Arcana left that one alone and
+      generated #{inspect(chosen)} for #{inspect(repo_module)} instead, with the
+      pgvector extension in it. Nothing else has to happen for Arcana to work.
+
+      If #{found_hint} was meant for #{inspect(repo_module)} all along, delete
+      #{inspect(chosen)}, add the extension to it:
+
+          Postgrex.Types.define(
+            #{found_code},
+            [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
+            []
+          )
+
+      and point the repo at that one instead:
+
+          config :#{app_name}, #{inspect(repo_module)}, types: #{found_code}
+      """
     end
 
     defp existing_types_notice({:config, path, existing}, _app_name, repo_module) do
@@ -507,35 +591,6 @@ if Code.ensure_loaded?(Igniter) do
       """
     end
 
-    defp existing_types_notice({:source, existing, path}, app_name, repo_module) do
-      module_hint = if existing == :unknown, do: "a types module", else: inspect(existing)
-      module_code = if existing == :unknown, do: "YourApp.PostgrexTypes", else: inspect(existing)
-
-      """
-      Arcana found #{module_hint} defined by a Postgrex.Types.define/3 call in
-      #{path}, so it skipped generating one.
-
-      #{inspect(repo_module)} has no `:types` key configured, so Arcana could
-      not confirm this module is the one it should use - in a multi-repo app it
-      may belong to a different repo. Please verify.
-
-      If it is the right module, add the pgvector extension to it:
-
-          Postgrex.Types.define(
-            #{module_code},
-            [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
-            []
-          )
-
-      and point the repo at it:
-
-          config :#{app_name}, #{inspect(repo_module)}, types: #{module_code}
-
-      If it belongs to a different repo, define a separate types module for
-      #{inspect(repo_module)} with the same snippet and configure that instead.
-      """
-    end
-
     defp create_postgrex_types_module(igniter, types_module) do
       types_content = """
       Postgrex.Types.define(
@@ -545,13 +600,16 @@ if Code.ensure_loaded?(Igniter) do
       )
       """
 
-      path =
-        types_module
-        |> Module.split()
-        |> Enum.map_join("/", &Macro.underscore/1)
-        |> then(&"lib/#{&1}.ex")
+      Igniter.create_new_file(igniter, types_module_path(types_module), types_content,
+        on_exists: :skip
+      )
+    end
 
-      Igniter.create_new_file(igniter, path, types_content, on_exists: :skip)
+    defp types_module_path(types_module) do
+      types_module
+      |> Module.split()
+      |> Enum.map_join("/", &Macro.underscore/1)
+      |> then(&"lib/#{&1}.ex")
     end
 
     defp configure_repo_types(igniter, app_name, repo_module, types_module) do

--- a/lib/mix/tasks/arcana.install.ex
+++ b/lib/mix/tasks/arcana.install.ex
@@ -12,6 +12,11 @@ if Code.ensure_loaded?(Igniter) do
     - Create the Postgrex types module for pgvector
     - Configure your repo to use the types module
 
+    If your application already defines a Postgrex types module (a
+    `Postgrex.Types.define/3` call, or a `:types` key on your repo config),
+    the installer skips generating one and instead tells you how to add
+    the pgvector extension to your existing module.
+
     ## Options
 
       * `--no-dashboard` - Skip adding the dashboard route
@@ -20,6 +25,7 @@ if Code.ensure_loaded?(Igniter) do
 
     use Igniter.Mix.Task
 
+    alias Igniter.Code.Function
     alias Igniter.Libs.Phoenix
     alias Igniter.Project.Config
 
@@ -53,10 +59,12 @@ if Code.ensure_loaded?(Igniter) do
       web_module = Module.concat([app_module <> "Web"])
       types_module = Module.concat([app_module, "PostgrexTypes"])
 
+      igniter = Igniter.include_glob(igniter, "lib/**/*.ex")
+      existing_types = existing_types_module(igniter, app_name, repo_module)
+
       igniter
       |> create_migration(repo_module)
-      |> create_postgrex_types_module(types_module)
-      |> configure_repo_types(app_name, repo_module, types_module)
+      |> setup_postgrex_types(existing_types, app_name, repo_module, types_module)
       |> maybe_add_dashboard_route(opts[:dashboard], web_module)
       |> Igniter.add_notice("""
 
@@ -203,6 +211,79 @@ if Code.ensure_loaded?(Igniter) do
       """
 
       Igniter.create_new_file(igniter, path, migration_content)
+    end
+
+    # Detects an existing Postgrex types module: either a Postgrex.Types.define/3
+    # call somewhere under lib/, or a :types key already set on the repo config.
+    # Returns the defined module, :unknown when detected but unnamed, or nil.
+    defp existing_types_module(igniter, app_name, repo_module) do
+      find_postgrex_types_define(igniter) ||
+        configured_repo_types(igniter, app_name, repo_module)
+    end
+
+    defp find_postgrex_types_define(igniter) do
+      igniter.rewrite
+      |> Rewrite.sources()
+      |> Enum.filter(&String.ends_with?(&1.path, ".ex"))
+      |> Enum.find_value(&postgrex_types_define_in_source/1)
+    end
+
+    defp postgrex_types_define_in_source(source) do
+      zipper = source |> Rewrite.Source.get(:quoted) |> Sourceror.Zipper.zip()
+
+      case Function.move_to_function_call(zipper, {Postgrex.Types, :define}, :any) do
+        {:ok, call} -> defined_types_module(call)
+        :error -> nil
+      end
+    end
+
+    defp defined_types_module(call_zipper) do
+      with {:ok, arg} <- Function.move_to_nth_argument(call_zipper, 0),
+           {:__aliases__, _, parts} when is_list(parts) <- Sourceror.Zipper.node(arg) do
+        Module.concat(parts)
+      else
+        _ -> :unknown
+      end
+    end
+
+    defp configured_repo_types(igniter, app_name, repo_module) do
+      if Config.configures_key?(igniter, "config.exs", app_name, [repo_module, :types]) do
+        :unknown
+      end
+    end
+
+    defp setup_postgrex_types(igniter, nil, app_name, repo_module, types_module) do
+      igniter
+      |> create_postgrex_types_module(types_module)
+      |> configure_repo_types(app_name, repo_module, types_module)
+    end
+
+    defp setup_postgrex_types(igniter, existing, app_name, repo_module, _types_module) do
+      Igniter.add_notice(igniter, existing_types_notice(existing, app_name, repo_module))
+    end
+
+    defp existing_types_notice(existing, app_name, repo_module) do
+      module_hint =
+        if existing == :unknown, do: "your existing types module", else: inspect(existing)
+
+      module_code = if existing == :unknown, do: "MyApp.PostgrexTypes", else: inspect(existing)
+
+      """
+      An existing Postgrex types module was detected, so Arcana skipped
+      generating one.
+
+      Make sure #{module_hint} includes the pgvector extension:
+
+          Postgrex.Types.define(
+            #{module_code},
+            [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
+            []
+          )
+
+      and that your repo is configured to use it:
+
+          config :#{app_name}, #{inspect(repo_module)}, types: #{module_code}
+      """
     end
 
     defp create_postgrex_types_module(igniter, types_module) do

--- a/lib/mix/tasks/arcana.reembed_chunks.ex
+++ b/lib/mix/tasks/arcana.reembed_chunks.ex
@@ -59,11 +59,7 @@ defmodule Mix.Tasks.Arcana.ReembedChunks do
     # Start the host application (which will start the repo)
     Mix.Task.run("app.start")
 
-    repo = Application.get_env(:arcana, :repo)
-
-    unless repo do
-      Mix.raise("No repo configured. Set config :arcana, repo: YourApp.Repo")
-    end
+    repo = Arcana.Config.repo!()
 
     # Show current embedding info
     info = Arcana.Maintenance.embedding_info()

--- a/lib/mix/tasks/arcana.reembed_chunks.ex
+++ b/lib/mix/tasks/arcana.reembed_chunks.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Arcana.ReembedChunks do
     # Start the host application (which will start the repo)
     Mix.Task.run("app.start")
 
-    repo = Arcana.Config.repo!()
+    repo = Arcana.MixHelpers.repo!()
 
     # Show current embedding info
     info = Arcana.Maintenance.embedding_info()

--- a/test/arcana/config_test.exs
+++ b/test/arcana/config_test.exs
@@ -250,6 +250,31 @@ defmodule Arcana.ConfigTest do
       assert stderr =~ "config :arcana, repo: Arcana.TestRepo"
     end
 
+    test "raises when :repo is explicitly false instead of scanning per-repo entries" do
+      put_arcana_env(:repo, false)
+
+      error = assert_raise ArgumentError, fn -> Config.repo!() end
+
+      assert error.message =~ "no Ecto repo configured"
+      assert error.message =~ "`repo: false` disables repo resolution"
+    end
+
+    test "raises for an explicit false in a passed env" do
+      env = [{:repo, false}, {FakeRepoOne, [priv: "priv/one"]}]
+
+      error = assert_raise ArgumentError, fn -> Config.repo!(env) end
+
+      assert error.message =~ "no Ecto repo configured"
+    end
+
+    test "treats a nil :repo in a passed env as absent" do
+      env = [{:repo, nil}, {FakeRepoOne, [priv: "priv/one"]}]
+
+      {repo, _stderr} = ExUnit.CaptureIO.with_io(:stderr, fn -> Config.repo!(env) end)
+
+      assert repo == FakeRepoOne
+    end
+
     test ":repo key wins over per-repo entries" do
       env = [{:repo, Arcana.TestRepo}, {FakeRepoOne, [priv: "priv/one"]}]
       assert Config.repo!(env) == Arcana.TestRepo

--- a/test/arcana/config_test.exs
+++ b/test/arcana/config_test.exs
@@ -220,4 +220,55 @@ defmodule Arcana.ConfigTest do
       assert Config.parse_reranker_config(fun) == {fun, []}
     end
   end
+
+  describe "repo!/1" do
+    defmodule FakeRepoOne do
+      def __adapter__, do: Ecto.Adapters.Postgres
+    end
+
+    defmodule FakeRepoTwo do
+      def __adapter__, do: Ecto.Adapters.Postgres
+    end
+
+    test "returns the :repo key when set" do
+      assert Config.repo!(repo: Arcana.TestRepo) == Arcana.TestRepo
+    end
+
+    test ":repo key wins over per-repo entries" do
+      env = [{:repo, Arcana.TestRepo}, {FakeRepoOne, [priv: "priv/one"]}]
+      assert Config.repo!(env) == Arcana.TestRepo
+    end
+
+    test "falls back to a single per-repo entry with a note" do
+      env = [
+        {FakeRepoOne, [priv: "priv/one"]},
+        {ArcanaWeb.Endpoint, [http: false]},
+        {:embedder, :local}
+      ]
+
+      {repo, stderr} =
+        ExUnit.CaptureIO.with_io(:stderr, fn -> Config.repo!(env) end)
+
+      assert repo == FakeRepoOne
+      assert stderr =~ "config :arcana, repo: Arcana.ConfigTest.FakeRepoOne"
+    end
+
+    test "raises when no repo is configured, naming both shapes" do
+      error = assert_raise ArgumentError, fn -> Config.repo!(embedder: :local) end
+
+      assert error.message =~ "config :arcana, repo: MyApp.Repo"
+      assert error.message =~ ~s|config :arcana, MyApp.Repo, priv: "priv/my_repo"|
+    end
+
+    test "raises when several per-repo entries exist without :repo" do
+      env = [{FakeRepoOne, []}, {FakeRepoTwo, []}]
+
+      error = assert_raise ArgumentError, fn -> Config.repo!(env) end
+
+      assert error.message =~ "FakeRepoOne"
+      assert error.message =~ "FakeRepoTwo"
+      assert error.message =~ "config :arcana, repo: MyApp.Repo"
+      assert error.message =~ ~s|config :arcana, MyApp.Repo, priv: "priv/my_repo"|
+    end
+  end
 end

--- a/test/arcana/config_test.exs
+++ b/test/arcana/config_test.exs
@@ -234,6 +234,22 @@ defmodule Arcana.ConfigTest do
       assert Config.repo!(repo: Arcana.TestRepo) == Arcana.TestRepo
     end
 
+    test "reads :repo through get_env/2 when called with no env" do
+      put_arcana_env(:repo, FakeRepoOne)
+
+      assert Config.repo!() == FakeRepoOne
+    end
+
+    test "falls back to the per-repo scan when the :repo override is nil" do
+      put_arcana_env(:repo, nil)
+
+      {repo, stderr} = ExUnit.CaptureIO.with_io(:stderr, fn -> Config.repo!() end)
+
+      # config/test.exs carries `config :arcana, Arcana.TestRepo, ...`
+      assert repo == Arcana.TestRepo
+      assert stderr =~ "config :arcana, repo: Arcana.TestRepo"
+    end
+
     test ":repo key wins over per-repo entries" do
       env = [{:repo, Arcana.TestRepo}, {FakeRepoOne, [priv: "priv/one"]}]
       assert Config.repo!(env) == Arcana.TestRepo

--- a/test/arcana/mix_helpers_test.exs
+++ b/test/arcana/mix_helpers_test.exs
@@ -1,0 +1,46 @@
+defmodule Arcana.MixHelpersTest do
+  use ExUnit.Case, async: true
+
+  import Arcana.ConfigCase
+
+  alias Arcana.MixHelpers
+
+  describe "repo!/0" do
+    test "returns the configured repo" do
+      put_arcana_env(:repo, Arcana.TestRepo)
+
+      assert MixHelpers.repo!() == Arcana.TestRepo
+    end
+
+    test "converts the library's ArgumentError into a clean Mix.Error" do
+      # Config.repo!/1 raises ArgumentError, which the CLI would print with a
+      # full stacktrace. Mix.Error prints as a single line and exits cleanly.
+      assert_raise ArgumentError, fn -> Arcana.Config.repo!(embedder: :local) end
+
+      error = assert_raise Mix.Error, fn -> MixHelpers.repo!(embedder: :local) end
+
+      assert error.message =~ "no Ecto repo configured"
+      assert error.message =~ "config :arcana, repo: MyApp.Repo"
+    end
+  end
+
+  describe "validate_dimensions!/2" do
+    test "returns positive integers unchanged" do
+      assert MixHelpers.validate_dimensions!(384) == 384
+    end
+
+    test "raises Mix.Error for zero, negatives and non-integers" do
+      for value <- [0, -1, "384", nil] do
+        assert_raise Mix.Error, ~r/--dimensions must be a positive integer/, fn ->
+          MixHelpers.validate_dimensions!(value)
+        end
+      end
+    end
+
+    test "names the flag it was given" do
+      assert_raise Mix.Error, ~r/--previous-dimensions must be a positive integer/, fn ->
+        MixHelpers.validate_dimensions!(0, "--previous-dimensions")
+      end
+    end
+  end
+end

--- a/test/arcana/mix_helpers_test.exs
+++ b/test/arcana/mix_helpers_test.exs
@@ -24,6 +24,27 @@ defmodule Arcana.MixHelpersTest do
     end
   end
 
+  describe "detect_dimensions!/0" do
+    defmodule ZeroDimensionEmbedder do
+      def dimensions(_opts), do: 0
+    end
+
+    test "returns what the embedder reports" do
+      put_arcana_env(:embedder, Arcana.Embedder.Local)
+
+      assert MixHelpers.detect_dimensions!() == 384
+    end
+
+    test "raises naming the embedder when it reports an invalid dimension" do
+      put_arcana_env(:embedder, ZeroDimensionEmbedder)
+
+      error = assert_raise Mix.Error, fn -> MixHelpers.detect_dimensions!() end
+
+      assert error.message =~ "ZeroDimensionEmbedder reported invalid embedding dimensions: 0"
+      refute error.message =~ "--dimensions must be"
+    end
+  end
+
   describe "validate_dimensions!/2" do
     test "returns positive integers unchanged" do
       assert MixHelpers.validate_dimensions!(384) == 384

--- a/test/mix/tasks/gen_embedding_migration_test.exs
+++ b/test/mix/tasks/gen_embedding_migration_test.exs
@@ -29,5 +29,26 @@ defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigrationTest do
 
   test "generated migration is valid Elixir" do
     assert {:ok, _ast} = Code.string_to_quoted(EmbeddingMigration.migration_content(512))
+    assert {:ok, _ast} = Code.string_to_quoted(EmbeddingMigration.migration_content(512, 1024))
+  end
+
+  test "down restores the previous dimensions, not a hardcoded 384" do
+    content = EmbeddingMigration.migration_content(1024, 768)
+
+    [up, down] = String.split(content, "def down do")
+
+    assert up =~ "modify :embedding, :vector, size: 1024"
+    assert down =~ "modify :embedding, :vector, size: 768"
+    refute down =~ "size: 384"
+  end
+
+  test "down raises instead of truncating when the previous dimensions are unknown" do
+    content = EmbeddingMigration.migration_content(1024)
+
+    [_up, down] = String.split(content, "def down do")
+
+    assert down =~ "raise \"Set the previous vector size"
+    # The old template silently rewrote any column back to 384
+    refute down =~ ~r/^\s+modify :embedding/m
   end
 end

--- a/test/mix/tasks/gen_embedding_migration_test.exs
+++ b/test/mix/tasks/gen_embedding_migration_test.exs
@@ -1,0 +1,33 @@
+defmodule Mix.Tasks.Arcana.Gen.EmbeddingMigrationTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Arcana.Gen.EmbeddingMigration
+
+  test "creates the HNSW index via raw SQL with the opclass, not Ecto options" do
+    content = EmbeddingMigration.migration_content(1024)
+
+    assert content =~ "size: 1024"
+
+    assert content =~ "CREATE INDEX arcana_chunks_embedding_idx ON arcana_chunks"
+    assert content =~ "USING hnsw (embedding vector_cosine_ops)"
+
+    # The old form rendered :options as a WITH (...) clause, which Postgres rejects
+    refute content =~ ~s|options: "vector_cosine_ops"|
+    refute content =~ "using: :hnsw"
+    refute content =~ "create index("
+  end
+
+  test "drops the install migration's index name, plus the Ecto default defensively" do
+    content = EmbeddingMigration.migration_content(768)
+
+    assert content =~ ~s|execute "DROP INDEX IF EXISTS arcana_chunks_embedding_idx"|
+    assert content =~ ~s|execute "DROP INDEX IF EXISTS arcana_chunks_embedding_index"|
+
+    # The old drop targeted the Ecto-default name and silently matched nothing
+    refute content =~ "drop_if_exists index("
+  end
+
+  test "generated migration is valid Elixir" do
+    assert {:ok, _ast} = Code.string_to_quoted(EmbeddingMigration.migration_content(512))
+  end
+end

--- a/test/mix/tasks/graph_install_test.exs
+++ b/test/mix/tasks/graph_install_test.exs
@@ -1,0 +1,60 @@
+defmodule Mix.Tasks.Arcana.Graph.InstallTest do
+  use ExUnit.Case, async: true
+
+  import Arcana.ConfigCase
+  import Igniter.Test
+
+  defmodule FakeEmbedder do
+    @behaviour Arcana.Embedder
+
+    @impl true
+    def embed(_text, _opts), do: {:ok, List.duplicate(0.0, 1024)}
+
+    @impl true
+    def embed_batch(texts, _opts),
+      do: {:ok, Enum.map(texts, fn _ -> List.duplicate(0.0, 1024) end)}
+
+    @impl true
+    def dimensions(_opts), do: 1024
+  end
+
+  test "sizes entity embeddings from the configured embedder" do
+    put_arcana_env(:embedder, FakeEmbedder)
+
+    igniter =
+      test_project()
+      |> Igniter.compose_task("arcana.graph.install", [])
+
+    assert migration_content(igniter) =~ ":embedding, :vector, size: 1024"
+  end
+
+  test "detects dimensions from the default (function) embedder config" do
+    # The test config's fn embedder produces 384-dim vectors; detection
+    # goes through Arcana.Embedder.Custom's probe.
+    igniter =
+      test_project()
+      |> Igniter.compose_task("arcana.graph.install", [])
+
+    assert migration_content(igniter) =~ ":embedding, :vector, size: 384"
+  end
+
+  test "--dimensions overrides detection" do
+    put_arcana_env(:embedder, FakeEmbedder)
+
+    igniter =
+      test_project()
+      |> Igniter.compose_task("arcana.graph.install", ["--dimensions", "512"])
+
+    assert migration_content(igniter) =~ ":embedding, :vector, size: 512"
+  end
+
+  defp migration_content(igniter) do
+    source =
+      igniter.rewrite
+      |> Rewrite.sources()
+      |> Enum.find(&String.contains?(&1.path, "create_arcana_graph_tables"))
+
+    assert source, "expected a create_arcana_graph_tables migration to be created"
+    Rewrite.Source.get(source, :content)
+  end
+end

--- a/test/mix/tasks/graph_install_test.exs
+++ b/test/mix/tasks/graph_install_test.exs
@@ -48,6 +48,15 @@ defmodule Mix.Tasks.Arcana.Graph.InstallTest do
     assert migration_content(igniter) =~ ":embedding, :vector, size: 512"
   end
 
+  test "rejects a non-positive --dimensions instead of generating vector(0)" do
+    for value <- ["0", "-5"] do
+      assert_raise Mix.Error, ~r/--dimensions must be a positive integer/, fn ->
+        test_project()
+        |> Igniter.compose_task("arcana.graph.install", ["--dimensions", value])
+      end
+    end
+  end
+
   defp migration_content(igniter) do
     source =
       igniter.rewrite

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -17,15 +17,67 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     |> assert_creates("lib/test/postgrex_types.ex")
   end
 
-  test "skips generating when the app already calls Postgrex.Types.define" do
-    test_project(files: %{"lib/test/my_types.ex" => @define_call})
-    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
-    |> refute_creates("lib/test/postgrex_types.ex")
-    |> assert_has_notice(&(&1 =~ "Test.MyTypes"))
-    |> assert_has_notice(&(&1 =~ "lib/test/my_types.ex"))
+  test "still configures the repo when the app defines an unrelated types module" do
+    igniter =
+      test_project(files: %{"lib/test/my_types.ex" => @define_call})
+      |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+
+    # The scanned module says nothing about which repo it serves, so Test.Repo
+    # gets its own - skipping would leave it without pgvector registered.
+    assert_creates(igniter, "lib/test/postgrex_types.ex")
+
+    assert_has_patch(
+      igniter,
+      "config/config.exs",
+      "|config :test, Test.Repo, types: Test.PostgrexTypes"
+    )
+
+    assert_has_notice(igniter, &(&1 =~ "Test.MyTypes"))
+    assert_has_notice(igniter, &(&1 =~ "lib/test/my_types.ex"))
+    assert_unchanged(igniter, "lib/test/my_types.ex")
   end
 
-  test "warns that a scanned types module may belong to a different repo" do
+  test "picks a name that can't collide with the module it found" do
+    collides = String.replace(@define_call, "Test.MyTypes", "Test.PostgrexTypes")
+
+    igniter =
+      test_project(files: %{"lib/test/postgrex_types.ex" => collides})
+      |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+
+    assert_creates(igniter, "lib/test/repo/postgrex_types.ex")
+
+    assert_has_patch(
+      igniter,
+      "config/config.exs",
+      "|config :test, Test.Repo, types: Test.Repo.PostgrexTypes"
+    )
+
+    assert_unchanged(igniter, "lib/test/postgrex_types.ex")
+  end
+
+  test "doesn't claim a lib file that's already there for something else" do
+    unrelated = """
+    defmodule Test.PostgrexTypes do
+      def whatever, do: :ok
+    end
+    """
+
+    igniter =
+      test_project(files: %{"lib/test/postgrex_types.ex" => unrelated})
+      |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+
+    assert_creates(igniter, "lib/test/repo/postgrex_types.ex")
+
+    assert_has_patch(
+      igniter,
+      "config/config.exs",
+      "|config :test, Test.Repo, types: Test.Repo.PostgrexTypes"
+    )
+
+    assert_unchanged(igniter, "lib/test/postgrex_types.ex")
+  end
+
+  test "leaves another repo's types module alone and generates one for ours" do
     postgis = """
     Postgrex.Types.define(
       Test.PostGISTypes,
@@ -34,10 +86,14 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     )
     """
 
-    test_project(files: %{"lib/test/postgis_types.ex" => postgis})
-    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
-    |> assert_has_notice(&(&1 =~ "may belong to a different repo"))
-    |> assert_has_notice(&(&1 =~ "config :test, Test.Repo, types: Test.PostGISTypes"))
+    igniter =
+      test_project(files: %{"lib/test/postgis_types.ex" => postgis})
+      |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+
+    assert_creates(igniter, "lib/test/postgrex_types.ex")
+    assert_unchanged(igniter, "lib/test/postgis_types.ex")
+    assert_has_notice(igniter, &(&1 =~ "generated Test.PostgrexTypes for Test.Repo"))
+    assert_has_notice(igniter, &(&1 =~ "config :test, Test.Repo, types: Test.PostGISTypes"))
   end
 
   test "resolves the __MODULE__.Types idiom instead of crashing" do
@@ -51,7 +107,7 @@ defmodule Mix.Tasks.Arcana.InstallTest do
 
     test_project(files: %{"lib/test/my_repo.ex" => code})
     |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
-    |> refute_creates("lib/test/postgrex_types.ex")
+    |> assert_creates("lib/test/postgrex_types.ex")
     |> assert_has_notice(&(&1 =~ "Test.MyRepo.Types"))
   end
 
@@ -63,7 +119,7 @@ defmodule Mix.Tasks.Arcana.InstallTest do
 
     test_project(files: %{"lib/test/weird_types.ex" => code})
     |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
-    |> refute_creates("lib/test/postgrex_types.ex")
+    |> assert_creates("lib/test/postgrex_types.ex")
     |> assert_has_notice(&(&1 =~ "Arcana found a types module defined by"))
   end
 

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -1,0 +1,50 @@
+defmodule Mix.Tasks.Arcana.InstallTest do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  alias Rewrite.Source.Ex
+
+  test "generates the PostgrexTypes module on a clean project" do
+    test_project()
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> assert_creates("lib/test/postgrex_types.ex")
+  end
+
+  test "skips generating when the app already calls Postgrex.Types.define" do
+    code = """
+    Postgrex.Types.define(
+      Test.MyTypes,
+      [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
+      []
+    )
+    """
+
+    # Injected straight into the rewrite: igniter's test mode can't match
+    # test_project(files:) fixtures against lib/** globs (relative glob vs
+    # absolute expanded path), so include_glob would never surface the file.
+    igniter = test_project()
+    source = Ex.from_string(code, path: "lib/test/my_types.ex")
+    igniter = %{igniter | rewrite: Rewrite.put!(igniter.rewrite, source)}
+
+    igniter
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> refute_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "Test.MyTypes"))
+  end
+
+  test "skips generating when the repo config already sets :types" do
+    test_project(
+      files: %{
+        "config/config.exs" => """
+        import Config
+
+        config :test, Test.Repo, types: Test.ExistingTypes
+        """
+      }
+    )
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> refute_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "existing Postgrex types module was detected"))
+  end
+end

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -128,7 +128,8 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     end
     """
 
-    test_project(files: %{"lib/test/broken.ex" => broken})
+    test_project()
+    |> add_file_after_setup("lib/test/broken.ex", broken)
     |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
     |> assert_creates("lib/test/postgrex_types.ex")
     |> assert_has_notice(&(&1 =~ "could not parse these files"))
@@ -144,10 +145,23 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     """
 
     igniter =
-      test_project(files: %{"lib/test/unrelated.ex" => broken})
+      test_project()
+      |> add_file_after_setup("lib/test/unrelated.ex", broken)
       |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
 
     assert_creates(igniter, "lib/test/postgrex_types.ex")
     refute Enum.any?(igniter.notices, &(&1 =~ "could not parse these files"))
+  end
+
+  # Files passed to `test_project(files: ...)` are pulled into the rewrite by
+  # its own `include_glob("**/*.*")`, which parses each one eagerly - so a
+  # deliberately unparsable fixture blows up before the installer ever runs.
+  # That glob is matched against absolute paths, and it silently matches
+  # nothing when the checkout lives under a dot-directory (git worktrees under
+  # `.claude/`, for one), which is why doing it the other way looks fine
+  # locally and fails on CI. Adding the file afterwards keeps the fixture out
+  # of that glob so the installer is the only thing that ever reads it.
+  defp add_file_after_setup(igniter, path, content) do
+    Igniter.assign(igniter, :test_files, Map.put(igniter.assigns.test_files, path, content))
   end
 end

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -81,6 +81,61 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     |> refute_creates("lib/test/postgrex_types.ex")
     |> assert_has_notice(&(&1 =~ "already has a `:types` module configured"))
     |> assert_has_notice(&(&1 =~ "config/config.exs"))
+    |> assert_has_notice(&(&1 =~ "Test.ExistingTypes"))
+  end
+
+  test "names the configured module in the skip notice, not a placeholder" do
+    igniter =
+      test_project(
+        files: %{
+          "config/config.exs" => """
+          import Config
+
+          config :test, Test.Repo, types: Test.ExistingTypes
+          """
+        }
+      )
+      |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+
+    assert_has_notice(igniter, &(&1 =~ "Postgrex.Types.define(\n      Test.ExistingTypes,"))
+    refute Enum.any?(igniter.notices, &(&1 =~ "YourApp.PostgrexTypes"))
+  end
+
+  test "detects :types in a config file outside the usual env set" do
+    test_project(
+      files: %{
+        "config/config.exs" => """
+        import Config
+
+        import_config "local.exs"
+        """,
+        "config/local.exs" => """
+        import Config
+
+        config :test, Test.Repo, types: Test.LocalTypes
+        """
+      }
+    )
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> refute_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "config/local.exs"))
+    |> assert_has_notice(&(&1 =~ "Test.LocalTypes"))
+  end
+
+  test "keeps installing when a config file can't be parsed" do
+    test_project()
+    |> add_file_after_setup("config/broken.exs", "import Config\n\nconfig :test, [\n")
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> assert_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "could not parse these files"))
+    |> assert_has_notice(&(&1 =~ "config/broken.exs"))
+  end
+
+  test "says which places detection looked at when it generates a module" do
+    test_project()
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> assert_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "config imported from elsewhere or built at runtime"))
   end
 
   test "the repo's own :types config wins over an unrelated define found in lib/" do
@@ -119,6 +174,7 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
     |> refute_creates("lib/test/postgrex_types.ex")
     |> assert_has_notice(&(&1 =~ "config/runtime.exs"))
+    |> assert_has_notice(&(&1 =~ "Test.ExistingTypes"))
   end
 
   test "keeps installing when a lib file mentioning the call has a syntax error" do

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -77,6 +77,30 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     assert_unchanged(igniter, "lib/test/postgrex_types.ex")
   end
 
+  test "finds a candidate module defined outside its conventional path" do
+    # Nothing makes an app put Test.PostgrexTypes in lib/test/postgrex_types.ex,
+    # and generating a second definition of it would be a duplicate module.
+    elsewhere = """
+    defmodule Test.PostgrexTypes do
+      def whatever, do: :ok
+    end
+    """
+
+    igniter =
+      test_project(files: %{"lib/test/db/types.ex" => elsewhere})
+      |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+
+    assert_creates(igniter, "lib/test/repo/postgrex_types.ex")
+
+    assert_has_patch(
+      igniter,
+      "config/config.exs",
+      "|config :test, Test.Repo, types: Test.Repo.PostgrexTypes"
+    )
+
+    assert_unchanged(igniter, "lib/test/db/types.ex")
+  end
+
   test "stops with an actionable error when every candidate name is taken" do
     occupied = fn module ->
       """

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -3,7 +3,13 @@ defmodule Mix.Tasks.Arcana.InstallTest do
 
   import Igniter.Test
 
-  alias Rewrite.Source.Ex
+  @define_call """
+  Postgrex.Types.define(
+    Test.MyTypes,
+    [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
+    []
+  )
+  """
 
   test "generates the PostgrexTypes module on a clean project" do
     test_project()
@@ -12,25 +18,53 @@ defmodule Mix.Tasks.Arcana.InstallTest do
   end
 
   test "skips generating when the app already calls Postgrex.Types.define" do
-    code = """
+    test_project(files: %{"lib/test/my_types.ex" => @define_call})
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> refute_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "Test.MyTypes"))
+    |> assert_has_notice(&(&1 =~ "lib/test/my_types.ex"))
+  end
+
+  test "warns that a scanned types module may belong to a different repo" do
+    postgis = """
     Postgrex.Types.define(
-      Test.MyTypes,
-      [Pgvector.Extensions.Vector] ++ Ecto.Adapters.Postgres.extensions(),
+      Test.PostGISTypes,
+      [Geo.PostGIS.Extension] ++ Ecto.Adapters.Postgres.extensions(),
       []
     )
     """
 
-    # Injected straight into the rewrite: igniter's test mode can't match
-    # test_project(files:) fixtures against lib/** globs (relative glob vs
-    # absolute expanded path), so include_glob would never surface the file.
-    igniter = test_project()
-    source = Ex.from_string(code, path: "lib/test/my_types.ex")
-    igniter = %{igniter | rewrite: Rewrite.put!(igniter.rewrite, source)}
+    test_project(files: %{"lib/test/postgis_types.ex" => postgis})
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> assert_has_notice(&(&1 =~ "may belong to a different repo"))
+    |> assert_has_notice(&(&1 =~ "config :test, Test.Repo, types: Test.PostGISTypes"))
+  end
 
-    igniter
+  test "resolves the __MODULE__.Types idiom instead of crashing" do
+    code = """
+    defmodule Test.MyRepo do
+      use Ecto.Repo, otp_app: :test, adapter: Ecto.Adapters.Postgres
+
+      Postgrex.Types.define(__MODULE__.Types, [], [])
+    end
+    """
+
+    test_project(files: %{"lib/test/my_repo.ex" => code})
     |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
     |> refute_creates("lib/test/postgrex_types.ex")
-    |> assert_has_notice(&(&1 =~ "Test.MyTypes"))
+    |> assert_has_notice(&(&1 =~ "Test.MyRepo.Types"))
+  end
+
+  test "falls back to an unnamed types module when the alias can't be resolved" do
+    # __MODULE__ outside any defmodule has no name to resolve against.
+    code = """
+    Postgrex.Types.define(__MODULE__.Types, [], [])
+    """
+
+    test_project(files: %{"lib/test/weird_types.ex" => code})
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> refute_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "Arcana found a types module defined by"))
   end
 
   test "skips generating when the repo config already sets :types" do
@@ -45,6 +79,75 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     )
     |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
     |> refute_creates("lib/test/postgrex_types.ex")
-    |> assert_has_notice(&(&1 =~ "existing Postgrex types module was detected"))
+    |> assert_has_notice(&(&1 =~ "already has a `:types` module configured"))
+    |> assert_has_notice(&(&1 =~ "config/config.exs"))
+  end
+
+  test "the repo's own :types config wins over an unrelated define found in lib/" do
+    igniter =
+      test_project(
+        files: %{
+          "lib/test/postgis_types.ex" => @define_call,
+          "config/config.exs" => """
+          import Config
+
+          config :test, Test.Repo, types: Test.ExistingTypes
+          """
+        }
+      )
+      |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+
+    assert_has_notice(igniter, &(&1 =~ "already has a `:types` module configured"))
+    refute Enum.any?(igniter.notices, &(&1 =~ "Test.MyTypes"))
+  end
+
+  test "detects :types configured in an env file, not just config.exs" do
+    test_project(
+      files: %{
+        "config/config.exs" => """
+        import Config
+
+        import_config "\#{config_env()}.exs"
+        """,
+        "config/runtime.exs" => """
+        import Config
+
+        config :test, Test.Repo, types: Test.ExistingTypes
+        """
+      }
+    )
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> refute_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "config/runtime.exs"))
+  end
+
+  test "keeps installing when a lib file mentioning the call has a syntax error" do
+    broken = """
+    defmodule Test.Broken do
+      Postgrex.Types.define(
+    end
+    """
+
+    test_project(files: %{"lib/test/broken.ex" => broken})
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> assert_creates("lib/test/postgrex_types.ex")
+    |> assert_has_notice(&(&1 =~ "could not parse these files"))
+    |> assert_has_notice(&(&1 =~ "lib/test/broken.ex"))
+  end
+
+  test "never reads lib files that don't mention Postgrex.Types.define" do
+    # A mid-refactor syntax error elsewhere in lib/ must not reach the parser.
+    broken = """
+    defmodule Test.Unrelated do
+      def oops do
+    end
+    """
+
+    igniter =
+      test_project(files: %{"lib/test/unrelated.ex" => broken})
+      |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+
+    assert_creates(igniter, "lib/test/postgrex_types.ex")
+    refute Enum.any?(igniter.notices, &(&1 =~ "could not parse these files"))
   end
 end

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -241,6 +241,18 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     |> assert_has_notice(&(&1 =~ "config/broken.exs"))
   end
 
+  test "keeps installing when a lib file at a candidate's path can't be parsed" do
+    # Looking for a module definition parses the file it looks at, so a broken
+    # one used to abort the install with a Sourceror error.
+    test_project()
+    |> add_file_after_setup(
+      "lib/test/postgrex_types.ex",
+      "defmodule Test.Broken do\n  def a(\nend\n"
+    )
+    |> Igniter.compose_task("arcana.install", ["--no-dashboard"])
+    |> assert_creates("lib/test/repo/postgrex_types.ex")
+  end
+
   test "says which places detection looked at when it generates a module" do
     test_project()
     |> Igniter.compose_task("arcana.install", ["--no-dashboard"])

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -77,6 +77,36 @@ defmodule Mix.Tasks.Arcana.InstallTest do
     assert_unchanged(igniter, "lib/test/postgrex_types.ex")
   end
 
+  test "stops with an actionable error when every candidate name is taken" do
+    occupied = fn module ->
+      """
+      defmodule #{module} do
+        def whatever, do: :ok
+      end
+      """
+    end
+
+    project =
+      test_project(
+        files: %{
+          "lib/test/postgrex_types.ex" => occupied.("Test.PostgrexTypes"),
+          "lib/test/repo/postgrex_types.ex" => occupied.("Test.Repo.PostgrexTypes"),
+          "lib/test/repo/arcana_postgrex_types.ex" => occupied.("Test.Repo.ArcanaPostgrexTypes")
+        }
+      )
+
+    # Picking an occupied name silently would point the repo config at a module
+    # that has no pgvector extension in it, so this has to stop the install.
+    error =
+      assert_raise Mix.Error, fn ->
+        Igniter.compose_task(project, "arcana.install", ["--no-dashboard"])
+      end
+
+    assert error.message =~ "Test.Repo.ArcanaPostgrexTypes"
+    assert error.message =~ "lib/test/repo/arcana_postgrex_types.ex"
+    assert error.message =~ "Pgvector.Extensions.Vector"
+  end
+
   test "leaves another repo's types module alone and generates one for ours" do
     postgis = """
     Postgrex.Types.define(


### PR DESCRIPTION
four installer/config issues from the multi-tenant adoption feedback:

**#95** — `gen.embedding_migration` emitted an HNSW index through Ecto's `options:`, which renders a `WITH (...)` clause instead of an opclass, so Postgres rejected the migration as shipped. It now emits raw SQL (`CREATE INDEX ... USING hnsw (embedding vector_cosine_ops)`) and drops both the install-migration index name and the Ecto-default name, closing the silent no-op drop that left the old-dimension index behind. Verified verbatim against Postgres: old index gone from pg_indexes, column resized, new index present.

**#96** — `mix arcana.install` unconditionally generated `<App>.PostgrexTypes`, colliding with apps that already define one. It now detects an existing `Postgrex.Types.define` under lib/ (or a `:types` key on the repo config) and skips generation with a notice showing the `Pgvector.Extensions.Vector` snippet to add.

**#97** — `graph.install` hardcoded 384-dim entity embeddings; it now asks the configured embedder (`Arcana.Embedder.dimensions/1`, same as gen.embedding_migration), with a `--dimensions` override and a clear error when detection fails.

**#100** — mix tasks resolved the repo only through `config :arcana, :repo`, silently no-oping when only the documented per-repo shape was set. New shared `Arcana.Config.repo!/1`: uses `:repo`; falls back to exactly one per-repo entry (filtered to real Ecto repos via `__adapter__/0`, since arcana configures `ArcanaWeb.Endpoint` under `:arcana` too); raises naming both accepted shapes otherwise. All 8 hand-rolled `Application.get_env(:arcana, :repo)` task sites swept.

14 new tests. Note: the non-Igniter fallback branches of install/graph.install never compile in this repo (Igniter present), so they're mirror-edited and reviewed, not test-executed.

Fixes #95, fixes #96, fixes #97, fixes #100

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes installer collisions and makes embedding migrations valid and reversible, while ensuring mix tasks resolve the repo from either accepted config shape. Previously the installer overwrote or mispointed types modules and the embedding migration used invalid index syntax with an irreversible down; now it detects existing configs/modules, emits valid SQL, restores previous sizes, and fails fast with actionable errors.

- Installer (`mix arcana.install`): skips types generation when the repo sets `:types`; otherwise scans `lib/**/*.ex` for `Postgrex.Types.define/3` and generates a repo-scoped types module under a non‑colliding name (`<App>.PostgrexTypes`, then `Repo.PostgrexTypes`, then `Repo.ArcanaPostgrexTypes`). Occupied names are detected by searching for the module definition anywhere in the project and by existing file paths; parse failures in `lib/` or `config/*.exs` don’t abort and are reported. If all candidates are taken, it stops with an actionable error. Router scope insertion is wrapped; on failure it prints manual instructions. Action: if you already have a types module for this repo, delete the generated one, add `Pgvector.Extensions.Vector` to yours, and set `config :your_app, YourApp.Repo, types: YourModule`.
- Embedding migration (`mix arcana.gen.embedding_migration`): creates the HNSW index via raw SQL with `vector_cosine_ops`; drops both the install‑migration name (`arcana_chunks_embedding_idx`) and the Ecto‑default name (`arcana_chunks_embedding_index`); reads the column’s previous size from the DB (reusing a started repo) or `--previous-dimensions`; `down` restores that value or raises when unknown.
- Graph install (`mix arcana.graph.install`): sizes entity embeddings from `Arcana.Embedder.dimensions/1`, validates they’re positive integers, and supports `--dimensions` override.
- Mix tasks: use `Arcana.MixHelpers` to resolve the repo via `Arcana.Config.repo!/1` and to detect/validate dimensions. Support both `config :arcana, repo: MyApp.Repo` and a single per‑repo entry; treat `repo: false` as “no repo” and error instead of guessing; filter candidates to actual Ecto repos; raise clean `Mix.Error`s with clear messages.

<sup>Written for commit c683c9c5193584c8419e89caf20c3743b843a9e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

