### PR TITLE
feat: Opt-in graph_depth traversal for query-time graph retrieval

### DIFF
--- a/guides/graphrag.md
+++ b/guides/graphrag.md
@@ -26,6 +26,56 @@ When `graph: true` is enabled:
 - **Ingest** extracts entities (people, organizations, etc.) and relationships from each chunk
 - **Search** finds entities in your query, traverses the graph, and combines results with vector search using Reciprocal Rank Fusion (RRF)
 
+## Traversal Depth at Query Time
+
+By default, graph-enhanced search retrieves only chunks that directly mention
+the entities matched from your query. The `graph_depth` option expands matched
+entities through the relationships table for N hops before fetching chunks, so
+a query matching entity A can also retrieve chunks about A's neighbors:
+
+```elixir
+# Direct mentions only (default)
+{:ok, results} = Arcana.search("Who leads OpenAI?", repo: MyApp.Repo, graph: true)
+
+# Also retrieve chunks mentioning one-hop neighbors of matched entities
+{:ok, results} = Arcana.search("Who leads OpenAI?",
+  repo: MyApp.Repo,
+  graph: true,
+  graph_depth: 1
+)
+
+# Works for ask/2 too: expands retrieval AND includes relationships from
+# matched entities to their neighbors in the prompt context
+{:ok, answer, context} = Arcana.ask("What applies to the thing covered by X?",
+  repo: MyApp.Repo,
+  llm: "openai:gpt-4o-mini",
+  graph: true,
+  graph_depth: 1
+)
+```
+
+Chunks reached through traversal are down-weighted per hop (score decays by
+`query_depth_decay` per hop, 0.5 by default), so direct matches still rank
+first when results are fused with vector search. Expansion respects collection
+scoping: entities from other collections are never pulled in.
+
+Set a global default and tune the decay in config (per-call `graph_depth`
+wins):
+
+```elixir
+config :arcana,
+  graph: [
+    enabled: true,
+    query_depth: 1,        # hops to expand matched entities (default: 0)
+    query_depth_decay: 0.5 # score decay per hop for traversed chunks
+  ]
+```
+
+Depths of 1-2 are usually enough; each hop widens retrieval and costs one
+extra query. Note this is different from the `depth:` option of the in-memory
+`Arcana.Graph.search/traverse` API further down this guide — `graph_depth` is
+the option for the `Arcana.search/2` and `Arcana.ask/2` query path.
+
 ## Installation
 
 GraphRAG requires additional database tables. Install them separately:

--- a/guides/graphrag.md
+++ b/guides/graphrag.md
@@ -54,10 +54,15 @@ a query matching entity A can also retrieve chunks about A's neighbors:
 )
 ```
 
-Chunks reached through traversal are down-weighted per hop (score decays by
-`query_depth_decay` per hop, 0.5 by default), so direct matches still rank
-first when results are fused with vector search. Expansion respects collection
-scoping: entities from other collections are never pulled in.
+Chunks reached through traversal are down-weighted per hop: a chunk's graph
+score is `mentions * 0.1 * query_depth_decay^hop` (decay 0.5 by default), so a
+neighbor chunk always scores below an equally-mentioned direct chunk. It does
+not rank below *every* direct chunk — a hop-1 chunk mentioning a neighbor
+three times (`3 * 0.1 * 0.5 = 0.15`) still outscores a direct chunk mentioned
+once (`0.1`). Lower `query_depth_decay` if you want traversal to weigh less.
+
+Expansion respects collection scoping (entities from other collections are
+never pulled in) and honors `:source_id`.
 
 Set a global default and tune the decay in config (per-call `graph_depth`
 wins):

--- a/lib/arcana/ask.ex
+++ b/lib/arcana/ask.ex
@@ -40,6 +40,12 @@ defmodule Arcana.Ask do
     * `:reranker` - Reranker module/function (passed through to search)
     * `:rewriter` - Query rewriter (passed through to search)
     * `:graph` - Enable/disable GraphRAG (default: global config)
+    * `:graph_depth` - When GraphRAG is enabled, how many relationship hops
+      to expand matched entities (default: 0). Affects both retrieval (chunks
+      mentioning neighbor entities are pulled in, down-weighted per hop) and
+      the prompt's relationship context, which then includes edges from
+      matched entities to their expanded neighbors. The global default is
+      `config :arcana, graph: [query_depth: n]`.
 
   Defaults for `:limit` can be set globally:
 
@@ -204,7 +210,7 @@ defmodule Arcana.Ask do
 
   defp fetch_graph_context(question, repo, opts) do
     import Ecto.Query
-    alias Arcana.Graph.{Community, Entity, GraphStore, Relationship}
+    alias Arcana.Graph.{Community, GraphStore}
 
     graph_config = Arcana.Graph.config()
     entity_limit = graph_config[:context_entity_limit] || 10
@@ -233,19 +239,15 @@ defmodule Arcana.Ask do
       %{}
     else
       entity_ids = Enum.map(matched_entities, & &1.id)
+      graph_depth = Arcana.Graph.query_depth(opts)
 
-      relationships =
-        repo.all(
-          from(r in Relationship,
-            join: src in Entity,
-            on: r.source_id == src.id,
-            join: tgt in Entity,
-            on: r.target_id == tgt.id,
-            where: r.source_id in ^entity_ids and r.target_id in ^entity_ids,
-            select: %{source: src.name, target: tgt.name, type: r.type},
-            limit: ^rel_limit
-          )
-        )
+      expanded_ids =
+        entity_ids
+        |> Arcana.Graph.expand_entity_ids(graph_depth, collection_ids, repo: repo)
+        |> Map.values()
+        |> List.flatten()
+
+      relationships = fetch_relationships(expanded_ids, entity_ids, graph_depth, rel_limit, repo)
 
       community_summaries =
         repo.all(
@@ -265,6 +267,45 @@ defmodule Arcana.Ask do
         community_summaries: community_summaries
       }
     end
+  end
+
+  # With no traversal the context keeps its original shape: only edges whose
+  # source AND target both matched the query. With graph_depth > 0 the edge
+  # closure runs over the expanded entity set, ordered so edges touching a
+  # directly matched entity win the limit over neighbor-to-neighbor edges.
+  defp fetch_relationships(expanded_ids, _matched_ids, 0, rel_limit, repo) do
+    import Ecto.Query
+    alias Arcana.Graph.{Entity, Relationship}
+
+    repo.all(
+      from(r in Relationship,
+        join: src in Entity,
+        on: r.source_id == src.id,
+        join: tgt in Entity,
+        on: r.target_id == tgt.id,
+        where: r.source_id in ^expanded_ids and r.target_id in ^expanded_ids,
+        select: %{source: src.name, target: tgt.name, type: r.type},
+        limit: ^rel_limit
+      )
+    )
+  end
+
+  defp fetch_relationships(expanded_ids, matched_ids, _depth, rel_limit, repo) do
+    import Ecto.Query
+    alias Arcana.Graph.{Entity, Relationship}
+
+    repo.all(
+      from(r in Relationship,
+        join: src in Entity,
+        on: r.source_id == src.id,
+        join: tgt in Entity,
+        on: r.target_id == tgt.id,
+        where: r.source_id in ^expanded_ids and r.target_id in ^expanded_ids,
+        order_by: [desc: r.source_id in ^matched_ids or r.target_id in ^matched_ids],
+        select: %{source: src.name, target: tgt.name, type: r.type},
+        limit: ^rel_limit
+      )
+    )
   end
 
   defp entity_ids_to_binary(entity_ids) do

--- a/lib/arcana/ask.ex
+++ b/lib/arcana/ask.ex
@@ -29,7 +29,10 @@ defmodule Arcana.Ask do
     * `:repo` - The Ecto repo to use (required)
     * `:llm` - Any type implementing the `Arcana.LLM` protocol (required)
     * `:limit` - Maximum number of context chunks to retrieve (default: 5)
-    * `:source_id` - Filter context to a specific source
+    * `:source_id` - Filter context to a specific source. Chunks, matched
+      entities, and relationships are scoped to it; community summaries
+      are collection-level artifacts and may describe entities beyond the
+      source. Use collections (see `:strict_collections`) for isolation.
     * `:threshold` - Minimum similarity score for context (default: 0.0)
     * `:mode` - Search mode: `:vector` (default), `:keyword`, or `:hybrid`.
       `:semantic` and `:fulltext` are deprecated aliases and log a warning.
@@ -235,9 +238,12 @@ defmodule Arcana.Ask do
           []
       end
 
-    # :source_id scopes the graph context too, not just the chunks: without
-    # this, entity descriptions, relationships, and community summaries
-    # from other sources reach the prompt (and traversal widens the leak).
+    # :source_id scopes the graph context too, not just the chunks:
+    # matched entities (and, through them, relationships and which
+    # communities are considered) are limited to the source. Community
+    # SUMMARY TEXT is not: a community is a collection-level cluster, so
+    # its summary can describe entities from other sources in the same
+    # collection. Collections, not sources, are the isolation boundary.
     source_id = Keyword.get(opts, :source_id)
     matched_entities = scope_entities_by_source(matched_entities, source_id, repo)
 

--- a/lib/arcana/ask.ex
+++ b/lib/arcana/ask.ex
@@ -235,6 +235,12 @@ defmodule Arcana.Ask do
           []
       end
 
+    # :source_id scopes the graph context too, not just the chunks: without
+    # this, entity descriptions, relationships, and community summaries
+    # from other sources reach the prompt (and traversal widens the leak).
+    source_id = Keyword.get(opts, :source_id)
+    matched_entities = scope_entities_by_source(matched_entities, source_id, repo)
+
     if matched_entities == [] do
       %{}
     else
@@ -246,6 +252,7 @@ defmodule Arcana.Ask do
         |> Arcana.Graph.expand_entity_ids(graph_depth, collection_ids, repo: repo)
         |> Map.values()
         |> List.flatten()
+        |> entity_ids_in_source(source_id, repo)
 
       relationships = fetch_relationships(expanded_ids, entity_ids, graph_depth, rel_limit, repo)
 
@@ -304,6 +311,42 @@ defmodule Arcana.Ask do
         order_by: [desc: r.source_id in ^matched_ids or r.target_id in ^matched_ids],
         select: %{source: src.name, target: tgt.name, type: r.type},
         limit: ^rel_limit
+      )
+    )
+  end
+
+  defp scope_entities_by_source(entities, nil, _repo), do: entities
+  defp scope_entities_by_source([], _source_id, _repo), do: []
+
+  defp scope_entities_by_source(entities, source_id, repo) do
+    in_source =
+      entities
+      |> Enum.map(& &1.id)
+      |> entity_ids_in_source(source_id, repo)
+      |> MapSet.new()
+
+    Enum.filter(entities, &MapSet.member?(in_source, &1.id))
+  end
+
+  # An entity belongs to a source when at least one of its mentions sits
+  # on a chunk of a document with that source_id.
+  defp entity_ids_in_source(ids, nil, _repo), do: ids
+  defp entity_ids_in_source([], _source_id, _repo), do: []
+
+  defp entity_ids_in_source(ids, source_id, repo) do
+    import Ecto.Query
+    alias Arcana.{Chunk, Document}
+    alias Arcana.Graph.EntityMention
+
+    repo.all(
+      from(m in EntityMention,
+        join: c in Chunk,
+        on: c.id == m.chunk_id,
+        join: d in Document,
+        on: d.id == c.document_id,
+        where: m.entity_id in ^ids and d.source_id == ^source_id,
+        select: m.entity_id,
+        distinct: true
       )
     )
   end

--- a/lib/arcana/graph.ex
+++ b/lib/arcana/graph.ex
@@ -40,6 +40,10 @@ defmodule Arcana.Graph do
           rrf_k: 60,               # Ranking constant (higher = less weight to top ranks)
           rrf_pool_multiplier: 2,  # Over-fetch multiplier before RRF combine
 
+          # Query-time graph traversal
+          query_depth: 0,          # Hops to expand matched entities (0 = direct mentions only)
+          query_depth_decay: 0.5,  # Score decay per hop for chunks reached via traversal
+
           # Community summaries in ask pipeline
           community_summary_limit: 5,  # Max summaries injected as background context
           community_summary_level: 0,  # Hierarchy level to pull summaries from
@@ -127,6 +131,8 @@ defmodule Arcana.Graph do
     min_size: 1,
     rrf_k: 60,
     rrf_pool_multiplier: 2,
+    query_depth: 0,
+    query_depth_decay: 0.5,
     community_summary_limit: 5,
     community_summary_level: 0,
     summary_max_entities: 50,
@@ -177,6 +183,109 @@ defmodule Arcana.Graph do
   """
   def enabled? do
     config().enabled
+  end
+
+  @doc """
+  Resolves the query-time graph traversal depth from per-call opts and
+  global config.
+
+  Reads `:graph_depth` from `opts` first, then falls back to
+  `config :arcana, graph: [query_depth: n]` (default 0). Raises
+  `ArgumentError` on anything other than a non-negative integer.
+  """
+  def query_depth(opts) do
+    depth = Keyword.get(opts, :graph_depth) || config()[:query_depth] || 0
+
+    unless is_integer(depth) and depth >= 0 do
+      raise ArgumentError,
+            "graph_depth must be a non-negative integer, got: #{inspect(depth)}"
+    end
+
+    depth
+  end
+
+  @doc """
+  Expands entity ids through the relationships table for `depth` hops.
+
+  Walks `arcana_graph_relationships` breadth-first (both directions) from
+  the given entity ids, returning a map of hop distance to the entity ids
+  first discovered at that hop: `%{0 => direct_ids, 1 => neighbors, ...}`.
+  Each entity appears once, at its minimal hop distance.
+
+  `collection_ids` follows the usual scoping semantics: `nil` is unscoped,
+  a list restricts discovered neighbors to those collections, and an empty
+  list matches nothing (no neighbors are pulled in).
+
+  ## Options
+
+    * `:repo` - Ecto repo (required)
+
+  """
+  def expand_entity_ids(entity_ids, depth, collection_ids, opts)
+
+  def expand_entity_ids([], _depth, _collection_ids, _opts), do: %{}
+
+  def expand_entity_ids(entity_ids, 0, _collection_ids, _opts),
+    do: %{0 => Enum.uniq(entity_ids)}
+
+  def expand_entity_ids(entity_ids, depth, collection_ids, opts)
+      when is_integer(depth) and depth > 0 do
+    repo = Keyword.fetch!(opts, :repo)
+    frontier = Enum.uniq(entity_ids)
+
+    do_expand(frontier, MapSet.new(frontier), %{0 => frontier}, 1, depth, collection_ids, repo)
+  end
+
+  defp do_expand(frontier, visited, acc, hop, depth, collection_ids, repo)
+
+  defp do_expand(_frontier, _visited, acc, hop, depth, _collection_ids, _repo)
+       when hop > depth,
+       do: acc
+
+  defp do_expand(frontier, visited, acc, hop, depth, collection_ids, repo) do
+    neighbors =
+      frontier
+      |> neighbor_entity_ids(repo)
+      |> Enum.reject(&MapSet.member?(visited, &1))
+      |> scope_entity_ids(collection_ids, repo)
+
+    case neighbors do
+      [] ->
+        acc
+
+      ids ->
+        visited = MapSet.union(visited, MapSet.new(ids))
+        do_expand(ids, visited, Map.put(acc, hop, ids), hop + 1, depth, collection_ids, repo)
+    end
+  end
+
+  defp neighbor_entity_ids(frontier, repo) do
+    import Ecto.Query
+
+    repo.all(
+      from(r in Arcana.Graph.Relationship,
+        where: r.source_id in ^frontier or r.target_id in ^frontier,
+        select: {r.source_id, r.target_id}
+      )
+    )
+    |> Enum.flat_map(fn {source, target} -> [source, target] end)
+    |> Enum.uniq()
+  end
+
+  # nil means unscoped; a list scopes the expansion, and an empty list must
+  # match nothing (`in []` compiles to false) — never fall back to global.
+  defp scope_entity_ids([], _collection_ids, _repo), do: []
+  defp scope_entity_ids(ids, nil, _repo), do: ids
+
+  defp scope_entity_ids(ids, collection_ids, repo) when is_list(collection_ids) do
+    import Ecto.Query
+
+    repo.all(
+      from(e in Arcana.Graph.Entity,
+        where: e.id in ^ids and e.collection_id in ^collection_ids,
+        select: e.id
+      )
+    )
   end
 
   @doc """

--- a/lib/arcana/graph.ex
+++ b/lib/arcana/graph.ex
@@ -194,7 +194,13 @@ defmodule Arcana.Graph do
   `ArgumentError` on anything other than a non-negative integer.
   """
   def query_depth(opts) do
-    depth = Keyword.get(opts, :graph_depth) || config()[:query_depth] || 0
+    depth =
+      case Keyword.fetch(opts, :graph_depth) do
+        # `false` disables traversal, matching the `reranker: false` idiom
+        {:ok, false} -> 0
+        {:ok, value} -> value
+        :error -> config()[:query_depth] || 0
+      end
 
     unless is_integer(depth) and depth >= 0 do
       raise ArgumentError,

--- a/lib/arcana/graph.ex
+++ b/lib/arcana/graph.ex
@@ -251,9 +251,8 @@ defmodule Arcana.Graph do
   defp do_expand(frontier, visited, acc, hop, depth, collection_ids, repo) do
     neighbors =
       frontier
-      |> neighbor_entity_ids(repo)
+      |> neighbor_entity_ids(collection_ids, repo)
       |> Enum.reject(&MapSet.member?(visited, &1))
-      |> scope_entity_ids(collection_ids, repo)
 
     case neighbors do
       [] ->
@@ -265,34 +264,36 @@ defmodule Arcana.Graph do
     end
   end
 
-  defp neighbor_entity_ids(frontier, repo) do
+  # One query per hop: joining both endpoints carries each neighbor's
+  # collection along, so scoping needs no second round trip.
+  defp neighbor_entity_ids(frontier, collection_ids, repo) do
     import Ecto.Query
 
     repo.all(
       from(r in Arcana.Graph.Relationship,
+        join: s in Arcana.Graph.Entity,
+        on: s.id == r.source_id,
+        join: t in Arcana.Graph.Entity,
+        on: t.id == r.target_id,
         where: r.source_id in ^frontier or r.target_id in ^frontier,
-        select: {r.source_id, r.target_id}
+        select: {r.source_id, s.collection_id, r.target_id, t.collection_id}
       )
     )
-    |> Enum.flat_map(fn {source, target} -> [source, target] end)
+    |> Enum.flat_map(fn {source, source_collection, target, target_collection} ->
+      [{source, source_collection}, {target, target_collection}]
+    end)
+    |> Enum.filter(fn {_id, collection_id} -> in_scope?(collection_id, collection_ids) end)
+    |> Enum.map(fn {id, _collection_id} -> id end)
     |> Enum.uniq()
   end
 
+  # nil means unscoped; a list scopes traversal, and an empty list
+  # expands nothing (same semantics as collection filters elsewhere).
+  defp in_scope?(_collection_id, nil), do: true
+  defp in_scope?(collection_id, collection_ids), do: collection_id in collection_ids
+
   # nil means unscoped; a list scopes the expansion, and an empty list must
   # match nothing (`in []` compiles to false) — never fall back to global.
-  defp scope_entity_ids([], _collection_ids, _repo), do: []
-  defp scope_entity_ids(ids, nil, _repo), do: ids
-
-  defp scope_entity_ids(ids, collection_ids, repo) when is_list(collection_ids) do
-    import Ecto.Query
-
-    repo.all(
-      from(e in Arcana.Graph.Entity,
-        where: e.id in ^ids and e.collection_id in ^collection_ids,
-        select: e.id
-      )
-    )
-  end
 
   @doc """
   Builds graph data from document chunks.

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -70,6 +70,11 @@ defmodule Arcana.Search do
     * `:reranker` - Reranker module or function. Defaults to `config :arcana, :reranker`.
       Pass `false` to disable a globally configured reranker for this call.
       When set, retrieves `limit * over_fetch` candidates, reranks, returns top `limit`.
+    * `:graph_depth` - When graph search is enabled, how many relationship
+      hops to expand matched entities before fetching mentioned chunks
+      (default: 0, direct mentions only). Chunks reached via traversal are
+      down-weighted per hop so direct matches still rank first. The global
+      default is `config :arcana, graph: [query_depth: n]`.
 
   Defaults for `:limit`, `:threshold`, and `:mode` can be set globally:
 
@@ -310,6 +315,8 @@ defmodule Arcana.Search do
 
     {matcher, matcher_opts} = resolve_entity_matcher(opts, graph_config)
     matcher_opts = matcher_opts |> Keyword.put(:repo, repo) |> Keyword.merge(opts)
+    graph_depth = Arcana.Graph.query_depth(opts)
+    depth_decay = graph_config[:query_depth_decay] || 0.5
 
     case matcher.match(query, collection_ids, matcher_opts) do
       {:ok, entity_ids} when entity_ids != [] ->
@@ -317,7 +324,10 @@ defmodule Arcana.Search do
           [:arcana, :graph, :search],
           %{query: query, entity_count: length(entity_ids), matcher: matcher},
           fn ->
-            graph_results = graph_search_by_entity_ids(entity_ids, repo)
+            ids_by_hop =
+              Arcana.Graph.expand_entity_ids(entity_ids, graph_depth, collection_ids, repo: repo)
+
+            graph_results = graph_search_by_entity_ids(ids_by_hop, repo, depth_decay)
             combined = rrf_combine(vector_results, graph_results, limit * rrf_pool, rrf_k)
             final_results = Enum.take(combined, limit)
 
@@ -331,7 +341,10 @@ defmodule Arcana.Search do
             telemetry_metadata = %{
               graph_result_count: length(graph_results),
               combined_count: length(final_results),
-              matcher: matcher
+              matcher: matcher,
+              graph_depth: graph_depth,
+              expanded_entity_count:
+                ids_by_hop |> Map.values() |> Enum.map(&length/1) |> Enum.sum()
             }
 
             {{{:ok, final_results}, caller_result}, telemetry_metadata}
@@ -352,15 +365,17 @@ defmodule Arcana.Search do
     Arcana.Config.parse_entity_matcher_config(value)
   end
 
-  defp graph_search_by_entity_ids(entity_ids, repo) do
+  defp graph_search_by_entity_ids(ids_by_hop, repo, depth_decay) do
     import Ecto.Query
     alias Arcana.Chunk
     alias Arcana.Graph.EntityMention
 
+    all_entity_ids = ids_by_hop |> Map.values() |> List.flatten()
+
     chunk_ids =
       repo.all(
         from(m in EntityMention,
-          where: m.entity_id in ^entity_ids,
+          where: m.entity_id in ^all_entity_ids,
           select: m.chunk_id,
           distinct: true
         )
@@ -369,15 +384,9 @@ defmodule Arcana.Search do
     if chunk_ids == [] do
       []
     else
-      # Score by mention count
-      scored =
-        repo.all(
-          from(m in EntityMention,
-            where: m.chunk_id in ^chunk_ids and m.entity_id in ^entity_ids,
-            group_by: m.chunk_id,
-            select: %{chunk_id: m.chunk_id, score: count() * 0.1}
-          )
-        )
+      # Score by mention count, decayed per hop so chunks that only mention
+      # traversal neighbors rank below chunks mentioning direct matches.
+      scored = score_chunks_by_hop(chunk_ids, ids_by_hop, depth_decay, repo)
 
       chunk_map =
         repo.all(from(c in Chunk, where: c.id in ^chunk_ids, select: {c.id, c}))
@@ -408,6 +417,33 @@ defmodule Arcana.Search do
       end)
       |> Enum.sort_by(& &1.score, :desc)
     end
+  end
+
+  # Returns [%{chunk_id: id, score: score}] where score sums, per hop h,
+  # mention_count_h * 0.1 * decay^h. With a single hop-0 group this reduces
+  # to the original mention_count * 0.1 (decay^0 is exactly 1.0).
+  defp score_chunks_by_hop(chunk_ids, ids_by_hop, depth_decay, repo) do
+    import Ecto.Query
+    alias Arcana.Graph.EntityMention
+
+    ids_by_hop
+    |> Enum.reduce(%{}, fn {hop, entity_ids}, acc ->
+      weight = 0.1 * :math.pow(depth_decay, hop)
+
+      counts =
+        repo.all(
+          from(m in EntityMention,
+            where: m.chunk_id in ^chunk_ids and m.entity_id in ^entity_ids,
+            group_by: m.chunk_id,
+            select: {m.chunk_id, count()}
+          )
+        )
+
+      Enum.reduce(counts, acc, fn {chunk_id, count}, scores ->
+        Map.update(scores, chunk_id, count * weight, &(&1 + count * weight))
+      end)
+    end)
+    |> Enum.map(fn {chunk_id, score} -> %{chunk_id: chunk_id, score: score} end)
   end
 
   # Strict validation already ran at the entry point, so unknown names can

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -429,9 +429,6 @@ defmodule Arcana.Search do
     end
   end
 
-  # Returns [%{chunk_id: id, score: score}] where score sums, per hop h,
-  # mention_count_h * 0.1 * decay^h. With a single hop-0 group this reduces
-  # to the original mention_count * 0.1 (decay^0 is exactly 1.0).
   defp filter_mentions_by_source(query, nil), do: query
 
   defp filter_mentions_by_source(query, source_id) do
@@ -447,6 +444,9 @@ defmodule Arcana.Search do
     )
   end
 
+  # Returns [%{chunk_id: id, score: score}] where score sums, per hop h,
+  # mention_count_h * 0.1 * decay^h. With a single hop-0 group this reduces
+  # to the original mention_count * 0.1 (decay^0 is exactly 1.0).
   defp score_chunks_by_hop(chunk_ids, ids_by_hop, depth_decay, repo) do
     import Ecto.Query
     alias Arcana.Graph.EntityMention

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -327,7 +327,14 @@ defmodule Arcana.Search do
             ids_by_hop =
               Arcana.Graph.expand_entity_ids(entity_ids, graph_depth, collection_ids, repo: repo)
 
-            graph_results = graph_search_by_entity_ids(ids_by_hop, repo, depth_decay)
+            graph_results =
+              graph_search_by_entity_ids(
+                ids_by_hop,
+                repo,
+                depth_decay,
+                Keyword.get(opts, :source_id)
+              )
+
             combined = rrf_combine(vector_results, graph_results, limit * rrf_pool, rrf_k)
             final_results = Enum.take(combined, limit)
 
@@ -365,21 +372,24 @@ defmodule Arcana.Search do
     Arcana.Config.parse_entity_matcher_config(value)
   end
 
-  defp graph_search_by_entity_ids(ids_by_hop, repo, depth_decay) do
+  defp graph_search_by_entity_ids(ids_by_hop, repo, depth_decay, source_id) do
     import Ecto.Query
     alias Arcana.Chunk
     alias Arcana.Graph.EntityMention
 
     all_entity_ids = ids_by_hop |> Map.values() |> List.flatten()
 
-    chunk_ids =
-      repo.all(
-        from(m in EntityMention,
-          where: m.entity_id in ^all_entity_ids,
-          select: m.chunk_id,
-          distinct: true
-        )
+    # Graph-derived chunks honor :source_id like the vector/keyword paths
+    # do; without this a source-scoped search leaks chunks from other
+    # documents that happen to mention a matched entity.
+    mentions_query =
+      from(m in EntityMention,
+        where: m.entity_id in ^all_entity_ids,
+        select: m.chunk_id,
+        distinct: true
       )
+
+    chunk_ids = repo.all(filter_mentions_by_source(mentions_query, source_id))
 
     if chunk_ids == [] do
       []
@@ -422,6 +432,21 @@ defmodule Arcana.Search do
   # Returns [%{chunk_id: id, score: score}] where score sums, per hop h,
   # mention_count_h * 0.1 * decay^h. With a single hop-0 group this reduces
   # to the original mention_count * 0.1 (decay^0 is exactly 1.0).
+  defp filter_mentions_by_source(query, nil), do: query
+
+  defp filter_mentions_by_source(query, source_id) do
+    import Ecto.Query
+    alias Arcana.{Chunk, Document}
+
+    from(m in query,
+      join: c in Chunk,
+      on: c.id == m.chunk_id,
+      join: d in Document,
+      on: d.id == c.document_id,
+      where: d.source_id == ^source_id
+    )
+  end
+
   defp score_chunks_by_hop(chunk_ids, ids_by_hop, depth_decay, repo) do
     import Ecto.Query
     alias Arcana.Graph.EntityMention

--- a/test/arcana/ask_test.exs
+++ b/test/arcana/ask_test.exs
@@ -1,7 +1,7 @@
 defmodule Arcana.AskTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Graph.{Community, Entity, EntityMention}
+  alias Arcana.Graph.{Community, Entity, EntityMention, Relationship}
 
   setup do
     {:ok, doc} =
@@ -15,6 +15,31 @@ defmodule Arcana.AskTest do
     end
 
     %{doc: doc, llm: llm}
+  end
+
+  # Runs ask/2 against the "ask-graph-depth" collection with an arity-3
+  # prompt that captures the graph context handed to it.
+  defp captured_graph_context(llm, opts) do
+    received = :ets.new(:received, [:set, :public])
+
+    prompt = fn _question, _context, graph_context ->
+      :ets.insert(received, {:graph_context, graph_context})
+      "System prompt"
+    end
+
+    base_opts = [
+      repo: Arcana.TestRepo,
+      llm: llm,
+      collection: "ask-graph-depth",
+      graph: true,
+      prompt: prompt
+    ]
+
+    {:ok, _, _} = Arcana.ask("Alice", Keyword.merge(base_opts, opts))
+
+    [{:graph_context, graph_context}] = :ets.lookup(received, :graph_context)
+    :ets.delete(received)
+    graph_context
   end
 
   describe "ask/2" do
@@ -124,6 +149,79 @@ defmodule Arcana.AskTest do
 
       [{:prompt, _prompt}] = :ets.lookup(received, :prompt)
       :ets.delete(received)
+    end
+  end
+
+  describe "ask/2 with graph_depth" do
+    setup do
+      collection =
+        %Arcana.Collection{}
+        |> Arcana.Collection.changeset(%{name: "ask-graph-depth"})
+        |> Repo.insert!()
+
+      # Only Alice gets an embedding, so only Alice matches the question.
+      {:ok, embedding} = Arcana.Embedder.embed(Arcana.Config.embedder(), "Alice", intent: :query)
+
+      alice =
+        %Entity{}
+        |> Entity.changeset(%{
+          name: "Alice",
+          type: "person",
+          collection_id: collection.id,
+          embedding: embedding
+        })
+        |> Repo.insert!()
+
+      bob =
+        %Entity{}
+        |> Entity.changeset(%{name: "Bob", type: "person", collection_id: collection.id})
+        |> Repo.insert!()
+
+      carol =
+        %Entity{}
+        |> Entity.changeset(%{name: "Carol", type: "person", collection_id: collection.id})
+        |> Repo.insert!()
+
+      %Relationship{}
+      |> Relationship.changeset(%{
+        source_id: alice.id,
+        target_id: bob.id,
+        type: "knows"
+      })
+      |> Repo.insert!()
+
+      %Relationship{}
+      |> Relationship.changeset(%{
+        source_id: bob.id,
+        target_id: carol.id,
+        type: "mentors"
+      })
+      |> Repo.insert!()
+
+      llm = fn _prompt, _context, _opts -> {:ok, "answer"} end
+
+      %{llm: llm}
+    end
+
+    test "depth 0 keeps relationships restricted to matched entities", %{llm: llm} do
+      graph_context = captured_graph_context(llm, [])
+
+      assert [%{name: "Alice"}] = graph_context.entities
+      assert graph_context.relationships == []
+    end
+
+    test "depth 1 includes edges from matched entities to their neighbors", %{llm: llm} do
+      graph_context = captured_graph_context(llm, graph_depth: 1)
+
+      assert [%{name: "Alice"}] = graph_context.entities
+      assert [%{source: "Alice", target: "Bob", type: "knows"}] = graph_context.relationships
+    end
+
+    test "depth 2 includes the two-hop path edges", %{llm: llm} do
+      graph_context = captured_graph_context(llm, graph_depth: 2)
+
+      types = graph_context.relationships |> Enum.map(& &1.type) |> Enum.sort()
+      assert types == ["knows", "mentors"]
     end
   end
 end

--- a/test/arcana/ask_test.exs
+++ b/test/arcana/ask_test.exs
@@ -203,6 +203,44 @@ defmodule Arcana.AskTest do
       %{llm: llm}
     end
 
+    test "source_id scopes graph context, not just chunks", %{llm: llm} do
+      # Alice is mentioned in src-a, her neighbour Bob only in src-b.
+      # Asking within src-a must not leak Bob's edge into the prompt.
+      collection = Repo.get_by!(Arcana.Collection, name: "ask-graph-depth")
+      alice = Repo.get_by!(Entity, name: "Alice", collection_id: collection.id)
+      bob = Repo.get_by!(Entity, name: "Bob", collection_id: collection.id)
+
+      for {entity, source} <- [{alice, "src-a"}, {bob, "src-b"}] do
+        document =
+          %Arcana.Document{}
+          |> Arcana.Document.changeset(%{
+            content: "doc for #{source}",
+            source_id: source,
+            status: :completed,
+            collection_id: collection.id
+          })
+          |> Repo.insert!()
+
+        chunk =
+          %Arcana.Chunk{}
+          |> Arcana.Chunk.changeset(%{
+            text: "chunk for #{source}",
+            document_id: document.id,
+            embedding: Enum.map(1..384, fn _ -> 0.1 end)
+          })
+          |> Repo.insert!()
+
+        %EntityMention{}
+        |> EntityMention.changeset(%{entity_id: entity.id, chunk_id: chunk.id})
+        |> Repo.insert!()
+      end
+
+      graph_context = captured_graph_context(llm, graph_depth: 1, source_id: "src-a")
+
+      assert [%{name: "Alice"}] = graph_context.entities
+      assert graph_context.relationships == []
+    end
+
     test "depth 0 keeps relationships restricted to matched entities", %{llm: llm} do
       graph_context = captured_graph_context(llm, [])
 

--- a/test/arcana/graph_expand_test.exs
+++ b/test/arcana/graph_expand_test.exs
@@ -43,6 +43,15 @@ defmodule Arcana.GraphExpandTest do
     test "raises on invalid values" do
       assert_raise ArgumentError, fn -> Graph.query_depth(graph_depth: -1) end
       assert_raise ArgumentError, fn -> Graph.query_depth(graph_depth: "two") end
+      assert_raise ArgumentError, fn -> Graph.query_depth(graph_depth: nil) end
+    end
+
+    test "graph_depth: false disables traversal even with a global default" do
+      put_arcana_env(:graph, query_depth: 2)
+
+      # matches the reranker: false disable idiom; previously fell
+      # through || to the global config and silently traversed
+      assert Graph.query_depth(graph_depth: false) == 0
     end
   end
 

--- a/test/arcana/graph_expand_test.exs
+++ b/test/arcana/graph_expand_test.exs
@@ -1,0 +1,118 @@
+defmodule Arcana.GraphExpandTest do
+  use Arcana.DataCase, async: true
+
+  alias Arcana.Collection
+  alias Arcana.Graph
+  alias Arcana.Graph.{Entity, Relationship}
+
+  defp create_collection(name) do
+    %Collection{}
+    |> Collection.changeset(%{name: name})
+    |> Repo.insert!()
+  end
+
+  defp create_entity(collection, name, type \\ "person") do
+    %Entity{}
+    |> Entity.changeset(%{name: name, type: type, collection_id: collection.id})
+    |> Repo.insert!()
+  end
+
+  defp create_relationship(source, target, type \\ "knows") do
+    %Relationship{}
+    |> Relationship.changeset(%{source_id: source.id, target_id: target.id, type: type})
+    |> Repo.insert!()
+  end
+
+  describe "query_depth/1" do
+    test "defaults to 0" do
+      assert Graph.query_depth([]) == 0
+    end
+
+    test "reads the per-call graph_depth option" do
+      assert Graph.query_depth(graph_depth: 2) == 2
+    end
+
+    test "per-call option wins over global query_depth config" do
+      put_arcana_env(:graph, query_depth: 3)
+
+      assert Graph.query_depth([]) == 3
+      assert Graph.query_depth(graph_depth: 1) == 1
+      assert Graph.query_depth(graph_depth: 0) == 0
+    end
+
+    test "raises on invalid values" do
+      assert_raise ArgumentError, fn -> Graph.query_depth(graph_depth: -1) end
+      assert_raise ArgumentError, fn -> Graph.query_depth(graph_depth: "two") end
+    end
+  end
+
+  describe "expand_entity_ids/4" do
+    setup do
+      collection = create_collection("expand-test")
+      alice = create_entity(collection, "Alice")
+      bob = create_entity(collection, "Bob")
+      carol = create_entity(collection, "Carol")
+      create_relationship(alice, bob)
+      create_relationship(bob, carol)
+
+      %{collection: collection, alice: alice, bob: bob, carol: carol}
+    end
+
+    test "depth 0 returns only the input ids at hop 0", %{alice: alice} do
+      assert Graph.expand_entity_ids([alice.id], 0, nil, repo: Repo) ==
+               %{0 => [alice.id]}
+    end
+
+    test "depth 1 discovers one-hop neighbors", %{alice: alice, bob: bob} do
+      assert Graph.expand_entity_ids([alice.id], 1, nil, repo: Repo) ==
+               %{0 => [alice.id], 1 => [bob.id]}
+    end
+
+    test "depth 2 reaches two hops, each entity at its minimal hop", ctx do
+      %{alice: alice, bob: bob, carol: carol} = ctx
+
+      assert Graph.expand_entity_ids([alice.id], 2, nil, repo: Repo) ==
+               %{0 => [alice.id], 1 => [bob.id], 2 => [carol.id]}
+    end
+
+    test "traverses edges in both directions", %{alice: alice, bob: bob, carol: carol} do
+      expanded = Graph.expand_entity_ids([carol.id], 2, nil, repo: Repo)
+
+      assert expanded[1] == [bob.id]
+      assert expanded[2] == [alice.id]
+    end
+
+    test "does not revisit entities in cyclic graphs", ctx do
+      %{alice: alice, bob: bob, carol: carol} = ctx
+      create_relationship(carol, alice, "closes_cycle")
+
+      expanded = Graph.expand_entity_ids([alice.id], 3, nil, repo: Repo)
+
+      assert expanded[0] == [alice.id]
+      assert Enum.sort(expanded[1]) == Enum.sort([bob.id, carol.id])
+      refute Map.has_key?(expanded, 2)
+    end
+
+    test "collection scoping excludes neighbors from other collections", ctx do
+      %{collection: collection, alice: alice, bob: bob} = ctx
+      other = create_collection("expand-other")
+      dave = create_entity(other, "Dave")
+      create_relationship(alice, dave)
+
+      expanded = Graph.expand_entity_ids([alice.id], 1, [collection.id], repo: Repo)
+      assert expanded == %{0 => [alice.id], 1 => [bob.id]}
+
+      unscoped = Graph.expand_entity_ids([alice.id], 1, nil, repo: Repo)
+      assert Enum.sort(unscoped[1]) == Enum.sort([bob.id, dave.id])
+    end
+
+    test "empty collection list expands to nothing beyond hop 0", %{alice: alice} do
+      assert Graph.expand_entity_ids([alice.id], 2, [], repo: Repo) ==
+               %{0 => [alice.id]}
+    end
+
+    test "empty input returns empty map" do
+      assert Graph.expand_entity_ids([], 2, nil, repo: Repo) == %{}
+    end
+  end
+end

--- a/test/arcana/graph_integration_test.exs
+++ b/test/arcana/graph_integration_test.exs
@@ -9,15 +9,20 @@ defmodule Arcana.GraphIntegrationTest do
     |> Repo.insert!()
   end
 
-  defp create_document(collection) do
+  defp create_document(collection, attrs \\ %{}) do
     %Arcana.Document{}
-    |> Arcana.Document.changeset(%{
-      title: "test-doc",
-      source: "test",
-      content: "Test document content",
-      collection_id: collection.id,
-      status: :completed
-    })
+    |> Arcana.Document.changeset(
+      Map.merge(
+        %{
+          title: "test-doc",
+          source: "test",
+          content: "Test document content",
+          collection_id: collection.id,
+          status: :completed
+        },
+        attrs
+      )
+    )
     |> Repo.insert!()
   end
 
@@ -314,7 +319,7 @@ defmodule Arcana.GraphIntegrationTest do
       collection = create_collection("depth-test")
       other_collection = create_collection("depth-other")
 
-      document = create_document(collection)
+      document = create_document(collection, %{source_id: "scoped-source"})
       other_document = create_document(other_collection)
 
       chunk_a = create_chunk(document, "Chunk about Alice")
@@ -347,7 +352,15 @@ defmodule Arcana.GraphIntegrationTest do
         end
       ]
 
-      %{opts: opts, chunk_a: chunk_a, chunk_b: chunk_b, chunk_c: chunk_c, chunk_d: chunk_d}
+      %{
+        opts: opts,
+        collection: collection,
+        bob: bob,
+        chunk_a: chunk_a,
+        chunk_b: chunk_b,
+        chunk_c: chunk_c,
+        chunk_d: chunk_d
+      }
     end
 
     test "default depth 0 returns only direct-mention chunks", ctx do
@@ -362,6 +375,25 @@ defmodule Arcana.GraphIntegrationTest do
       {:ok, depth_zero_results} = Arcana.search("Alice", Keyword.put(ctx.opts, :graph_depth, 0))
 
       assert depth_zero_results == default_results
+    end
+
+    test "graph results honor :source_id at every hop", %{opts: opts} = ctx do
+      # Bob (a hop-1 neighbor of Alice) is also mentioned by a chunk in a
+      # different source; a source-scoped search must not surface it
+      other_source_doc = create_document(ctx.collection, %{source_id: "other-source"})
+      foreign_chunk = create_chunk(other_source_doc, "Bob in another source")
+      create_mention(ctx.bob, foreign_chunk)
+
+      scoped_opts =
+        opts
+        |> Keyword.put(:graph_depth, 1)
+        |> Keyword.put(:source_id, "scoped-source")
+
+      {:ok, results} = Arcana.search("Alice", scoped_opts)
+      ids = Enum.map(results, & &1.id)
+
+      assert ctx.chunk_a.id in ids
+      refute foreign_chunk.id in ids
     end
 
     test "graph_depth: 1 pulls in neighbor chunks ranked below direct matches", ctx do

--- a/test/arcana/graph_integration_test.exs
+++ b/test/arcana/graph_integration_test.exs
@@ -3,6 +3,52 @@ defmodule Arcana.GraphIntegrationTest do
 
   alias Arcana.Graph.{Entity, EntityMention, Relationship}
 
+  defp create_collection(name) do
+    %Arcana.Collection{}
+    |> Arcana.Collection.changeset(%{name: name})
+    |> Repo.insert!()
+  end
+
+  defp create_document(collection) do
+    %Arcana.Document{}
+    |> Arcana.Document.changeset(%{
+      title: "test-doc",
+      source: "test",
+      content: "Test document content",
+      collection_id: collection.id,
+      status: :completed
+    })
+    |> Repo.insert!()
+  end
+
+  defp create_chunk(document, text) do
+    %Arcana.Chunk{}
+    |> Arcana.Chunk.changeset(%{
+      text: text,
+      document_id: document.id,
+      embedding: Enum.map(1..384, fn _ -> :rand.uniform() end)
+    })
+    |> Repo.insert!()
+  end
+
+  defp create_entity(collection, name, type \\ "person") do
+    %Entity{}
+    |> Entity.changeset(%{name: name, type: type, collection_id: collection.id})
+    |> Repo.insert!()
+  end
+
+  defp create_mention(entity, chunk) do
+    %EntityMention{}
+    |> EntityMention.changeset(%{entity_id: entity.id, chunk_id: chunk.id})
+    |> Repo.insert!()
+  end
+
+  defp create_relationship(source, target, type \\ "knows") do
+    %Relationship{}
+    |> Relationship.changeset(%{source_id: source.id, target_id: target.id, type: type})
+    |> Repo.insert!()
+  end
+
   describe "graph_enabled?/1" do
     test "returns false when no option and config disabled" do
       refute Arcana.graph_enabled?([])
@@ -255,6 +301,102 @@ defmodule Arcana.GraphIntegrationTest do
         )
 
       assert length(results) == 1
+    end
+  end
+
+  describe "search/2 with graph_depth" do
+    # Entities: Alice -- Bob -- Carol (chained relationships) in "depth-test",
+    # plus Dave in "depth-other" linked to Alice across collections. Each
+    # entity is mentioned by exactly one chunk. The query matches only Alice
+    # (fixed NER matcher) and threshold: 0.99 suppresses vector results, so
+    # everything retrieved comes from the graph side.
+    setup do
+      collection = create_collection("depth-test")
+      other_collection = create_collection("depth-other")
+
+      document = create_document(collection)
+      other_document = create_document(other_collection)
+
+      chunk_a = create_chunk(document, "Chunk about Alice")
+      chunk_b = create_chunk(document, "Chunk about Bob")
+      chunk_c = create_chunk(document, "Chunk about Carol")
+      chunk_d = create_chunk(other_document, "Chunk about Dave")
+
+      alice = create_entity(collection, "Alice")
+      bob = create_entity(collection, "Bob")
+      carol = create_entity(collection, "Carol")
+      dave = create_entity(other_collection, "Dave")
+
+      create_mention(alice, chunk_a)
+      create_mention(bob, chunk_b)
+      create_mention(carol, chunk_c)
+      create_mention(dave, chunk_d)
+
+      create_relationship(alice, bob)
+      create_relationship(bob, carol)
+      create_relationship(alice, dave)
+
+      opts = [
+        repo: Repo,
+        graph: true,
+        collection: "depth-test",
+        threshold: 0.99,
+        entity_matcher: :ner,
+        entity_extractor: fn _query, _opts ->
+          {:ok, [%{name: "Alice", type: "person"}]}
+        end
+      ]
+
+      %{opts: opts, chunk_a: chunk_a, chunk_b: chunk_b, chunk_c: chunk_c, chunk_d: chunk_d}
+    end
+
+    test "default depth 0 returns only direct-mention chunks", ctx do
+      {:ok, results} = Arcana.search("Alice", ctx.opts)
+
+      ids = Enum.map(results, & &1.id)
+      assert ids == [ctx.chunk_a.id]
+    end
+
+    test "graph_depth: 0 returns exactly the default results", ctx do
+      {:ok, default_results} = Arcana.search("Alice", ctx.opts)
+      {:ok, depth_zero_results} = Arcana.search("Alice", Keyword.put(ctx.opts, :graph_depth, 0))
+
+      assert depth_zero_results == default_results
+    end
+
+    test "graph_depth: 1 pulls in neighbor chunks ranked below direct matches", ctx do
+      {:ok, results} = Arcana.search("Alice", Keyword.put(ctx.opts, :graph_depth, 1))
+
+      assert [first, second] = results
+      assert first.id == ctx.chunk_a.id
+      assert second.id == ctx.chunk_b.id
+      assert first.score > second.score
+      refute ctx.chunk_c.id in Enum.map(results, & &1.id)
+    end
+
+    test "graph_depth: 2 reaches two-hop neighbors", ctx do
+      {:ok, results} = Arcana.search("Alice", Keyword.put(ctx.opts, :graph_depth, 2))
+
+      assert Enum.map(results, & &1.id) == [ctx.chunk_a.id, ctx.chunk_b.id, ctx.chunk_c.id]
+    end
+
+    test "expansion respects collection scoping", ctx do
+      {:ok, results} = Arcana.search("Alice", Keyword.put(ctx.opts, :graph_depth, 2))
+
+      ids = Enum.map(results, & &1.id)
+      # in-collection neighbors came in, the cross-collection one did not
+      assert ctx.chunk_b.id in ids
+      refute ctx.chunk_d.id in ids
+    end
+
+    test "global query_depth config applies and per-call graph_depth wins", ctx do
+      put_arcana_env(:graph, query_depth: 1)
+
+      {:ok, global_results} = Arcana.search("Alice", ctx.opts)
+      assert Enum.map(global_results, & &1.id) == [ctx.chunk_a.id, ctx.chunk_b.id]
+
+      {:ok, override_results} = Arcana.search("Alice", Keyword.put(ctx.opts, :graph_depth, 0))
+      assert Enum.map(override_results, & &1.id) == [ctx.chunk_a.id]
     end
   end
 


### PR DESCRIPTION
closes the gap where graph-enhanced retrieval never traversed: matched entities' neighbors contributed no chunks unless they independently won on vector similarity.

new opt-in `graph_depth` on `Arcana.search/2` and `Arcana.ask/2` (default 0 = exactly current behavior, proven by a test asserting depth-0 results equal default results):

- `Arcana.Graph.expand_entity_ids/4`: iterative BFS over `arcana_graph_relationships`, one query per hop, both edge directions, visited set, each entity at its minimal hop. Collection semantics preserved (nil unscoped, list scoped, `[]` expands nothing).
- search scores expanded chunks `mention_count * 0.1 * decay^hop` (decay 0.5, configurable via `config :arcana, graph: [query_depth_decay: f]`), so RRF still favors direct matches; hop 0 weight is byte-identical to the old `count * 0.1`.
- ask's graph context includes relationships from matched entities to expanded neighbors (matched-touching edges ordered first within the existing rel_limit); entities and community summaries stay matched-only.
- global default via `config :arcana, graph: [query_depth: n]`, per-call `graph_depth` wins.
- documented in search/ask docs and a new graphrag.md section, distinguishing this from the in-memory `Graph.traverse` API that the issue noted was unreachable from the query path.

21 new tests: hop grouping, cycles, cross-collection isolation during expansion, depth-1 ranking below direct matches, depth-2 reach, ask context expansion, config resolution.

Fixes #117

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in query-time graph traversal to `Arcana.search/2` and `Arcana.ask/2`, expanding matched entities by `graph_depth` hops with decayed scoring. Previously only direct-mention chunks and matched-to-matched edges were used; now retrieval and ask graph context are scoped by `:source_id`, and docs clarify that community summaries are collection-level and may describe entities beyond the source.

- Per-call `graph_depth` controls traversal; global defaults via `config :arcana, graph: [query_depth: n, query_depth_decay: f]`. Per-call wins; `graph_depth: false` disables traversal; invalid values raise. Each hop costs one query.
- `Arcana.Graph.expand_entity_ids/4` performs BFS in both directions, tags minimal-hop, respects collection scoping (`nil` unscoped, list scoped, `[]` expands nothing).
- Search: scores graph chunks by hop as `mentions * 0.1 * decay^hop` (hop 0 unchanged). Multi-mention neighbor chunks can outrank single-mention direct chunks; RRF still combines with vector results. Graph-derived chunks and mentions honor `:source_id`.
- Ask: filters matched entities by `:source_id`, expands ids by `graph_depth`, and includes relationships across the expanded set (edges touching matched entities ordered first). Community summaries are chosen from communities related to the filtered entities but may describe other-source entities; use collections for isolation.
- Docs updated in `guides/graphrag.md`; tests cover depth-0 equivalence, cycles, scoping (including `:source_id`), ranking, and config precedence.

<sup>Written for commit 478a239f43792bb63064f22ca328db195d36c0b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

