### PR TITLE
fix: Vector equality for changeset dirty tracking

### DIFF
--- a/lib/arcana/chunk.ex
+++ b/lib/arcana/chunk.ex
@@ -14,7 +14,7 @@ defmodule Arcana.Chunk do
 
   schema "arcana_chunks" do
     field(:text, :string)
-    field(:embedding, Pgvector.Ecto.Vector)
+    field(:embedding, Arcana.Ecto.Vector)
     field(:chunk_index, :integer, default: 0)
     field(:token_count, :integer)
     field(:metadata, :map, default: %{})

--- a/lib/arcana/ecto/vector.ex
+++ b/lib/arcana/ecto/vector.ex
@@ -1,0 +1,48 @@
+defmodule Arcana.Ecto.Vector do
+  @moduledoc """
+  Drop-in wrapper around `Pgvector.Ecto.Vector` with a real `equal?/2`.
+
+  `Pgvector.Ecto.Vector` inherits Ecto's default `equal?/2` (plain `==`),
+  so change detection compares terms structurally. Whenever the value
+  loaded from the database isn't the exact same representation as the
+  value being written back — a custom Postgrex types module decoding to
+  a different struct, or list-vs-`%Pgvector{}` round trips — a
+  byte-identical embedding always dirties the changeset, turning
+  idempotent re-stores into write amplification plus HNSW index churn.
+
+  This type delegates `type/cast/load/dump` to `Pgvector.Ecto.Vector`
+  (identical wire behavior) and compares values by their encoded binary,
+  so byte-identical vectors are equal regardless of representation.
+
+  If pgvector-elixir ships `equal?/2` upstream (pgvector-python's
+  `Vector.__eq__` is the family precedent), this module becomes a no-op
+  layer that can be dropped in a major release.
+  """
+
+  use Ecto.Type
+
+  def type, do: Pgvector.Ecto.Vector.type()
+
+  defdelegate cast(value), to: Pgvector.Ecto.Vector
+  defdelegate load(data), to: Pgvector.Ecto.Vector
+  defdelegate dump(value), to: Pgvector.Ecto.Vector
+
+  def equal?(a, b), do: normalize(a) == normalize(b)
+
+  # Compare by encoded binary: lists, %Pgvector{} structs, and Nx tensors
+  # all normalize through Pgvector.new/1. Values cast can't handle (e.g.
+  # a custom types module's own struct) fall back to themselves, which
+  # degrades to today's structural comparison rather than crashing.
+  defp normalize(nil), do: nil
+  defp normalize(%Pgvector{} = vector), do: Pgvector.to_binary(vector)
+
+  defp normalize(value) do
+    case Pgvector.Ecto.Vector.cast(value) do
+      {:ok, %Pgvector{} = vector} -> Pgvector.to_binary(vector)
+      _ -> value
+    end
+  rescue
+    # Pgvector.new/1 raises on uncastable input (e.g. a string)
+    _ -> value
+  end
+end

--- a/lib/arcana/ecto/vector.ex
+++ b/lib/arcana/ecto/vector.ex
@@ -4,15 +4,19 @@ defmodule Arcana.Ecto.Vector do
 
   `Pgvector.Ecto.Vector` inherits Ecto's default `equal?/2` (plain `==`),
   so change detection compares terms structurally. Whenever the value
-  loaded from the database isn't the exact same representation as the
-  value being written back — a custom Postgrex types module decoding to
-  a different struct, or list-vs-`%Pgvector{}` round trips — a
-  byte-identical embedding always dirties the changeset, turning
-  idempotent re-stores into write amplification plus HNSW index churn.
+  loaded from the database isn't the exact representation being written
+  back — a custom Postgrex types module decoding to a different struct,
+  or list-vs-`%Pgvector{}` round trips — a byte-identical embedding
+  always dirties the changeset, turning idempotent re-stores into write
+  amplification plus HNSW index churn.
 
   This type delegates `type/cast/load/dump` to `Pgvector.Ecto.Vector`
   (identical wire behavior) and compares values by their encoded binary,
   so byte-identical vectors are equal regardless of representation.
+
+  Values it can't encode (an opaque struct from a custom decoder that is
+  neither enumerable nor castable) fall back to structural comparison,
+  which is today's behavior rather than a crash.
 
   If pgvector-elixir ships `equal?/2` upstream (pgvector-python's
   `Vector.__eq__` is the family precedent), this module becomes a no-op
@@ -21,28 +25,45 @@ defmodule Arcana.Ecto.Vector do
 
   use Ecto.Type
 
-  def type, do: Pgvector.Ecto.Vector.type()
+  alias Pgvector.Ecto.Vector, as: PgvectorVector
 
-  defdelegate cast(value), to: Pgvector.Ecto.Vector
-  defdelegate load(data), to: Pgvector.Ecto.Vector
-  defdelegate dump(value), to: Pgvector.Ecto.Vector
+  def type, do: PgvectorVector.type()
+
+  defdelegate cast(value), to: PgvectorVector
+  defdelegate load(data), to: PgvectorVector
+  defdelegate dump(value), to: PgvectorVector
 
   def equal?(a, b), do: normalize(a) == normalize(b)
 
-  # Compare by encoded binary: lists, %Pgvector{} structs, and Nx tensors
-  # all normalize through Pgvector.new/1. Values cast can't handle (e.g.
-  # a custom types module's own struct) fall back to themselves, which
-  # degrades to today's structural comparison rather than crashing.
+  # Reduce every representation we can recognize to the encoded binary:
+  # %Pgvector{} structs, lists, Nx tensors (via Pgvector.new/1), and any
+  # other enumerable vector-like struct a custom Postgrex types module
+  # might decode into.
   defp normalize(nil), do: nil
   defp normalize(%Pgvector{} = vector), do: Pgvector.to_binary(vector)
 
-  defp normalize(value) do
-    case Pgvector.Ecto.Vector.cast(value) do
+  defp normalize(value) when is_list(value) do
+    encode(value, value)
+  end
+
+  defp normalize(value) when is_struct(value) do
+    case Enumerable.impl_for(value) do
+      nil -> encode(value, value)
+      _ -> encode(Enum.to_list(value), value)
+    end
+  end
+
+  defp normalize(value), do: value
+
+  # Falls back to the original term when the value can't be encoded, so
+  # comparison degrades to structural equality instead of raising.
+  defp encode(value, original) do
+    case PgvectorVector.cast(value) do
       {:ok, %Pgvector{} = vector} -> Pgvector.to_binary(vector)
-      _ -> value
+      _ -> original
     end
   rescue
-    # Pgvector.new/1 raises on uncastable input (e.g. a string)
-    _ -> value
+    # Pgvector.new/1 raises on anything it can't build a vector from
+    _ -> original
   end
 end

--- a/lib/arcana/ecto/vector.ex
+++ b/lib/arcana/ecto/vector.ex
@@ -49,11 +49,19 @@ defmodule Arcana.Ecto.Vector do
   defp normalize(value) when is_struct(value) do
     case Enumerable.impl_for(value) do
       nil -> encode(value, value)
-      _ -> encode(Enum.to_list(value), value)
+      _ -> encode_enumerable(value)
     end
   end
 
   defp normalize(value), do: value
+
+  # Enumerating is itself fallible (a stream can raise mid-traversal), so
+  # it happens inside the rescue too.
+  defp encode_enumerable(value) do
+    encode(Enum.to_list(value), value)
+  rescue
+    _ -> value
+  end
 
   # Falls back to the original term when the value can't be encoded, so
   # comparison degrades to structural equality instead of raising.

--- a/lib/arcana/graph/entity.ex
+++ b/lib/arcana/graph/entity.ex
@@ -18,7 +18,7 @@ defmodule Arcana.Graph.Entity do
     field(:name, :string)
     field(:type, :string)
     field(:description, :string)
-    field(:embedding, Pgvector.Ecto.Vector)
+    field(:embedding, Arcana.Ecto.Vector)
     field(:metadata, :map, default: %{})
 
     belongs_to(:chunk, Chunk)

--- a/test/arcana/ecto/vector_test.exs
+++ b/test/arcana/ecto/vector_test.exs
@@ -1,3 +1,8 @@
+defmodule OpaqueVector do
+  @moduledoc false
+  defstruct [:blob]
+end
+
 defmodule Arcana.Ecto.VectorTest do
   use Arcana.DataCase, async: true
 
@@ -28,6 +33,28 @@ defmodule Arcana.Ecto.VectorTest do
     test "uncastable values fall back to structural comparison without raising" do
       refute Vector.equal?("not a vector", [1.0])
       assert Vector.equal?("same", "same")
+    end
+
+    test "an enumerable struct from a custom decoder compares by value" do
+      # A custom Postgrex types module can decode vectors into its own
+      # struct; as long as it enumerates to the same numbers it must
+      # compare equal to the list/Pgvector representations (issue #98).
+      # A range stands in for that struct here: protocols are
+      # consolidated in test, so an Enumerable impl defined in this file
+      # would be invisible at runtime.
+      enumerable_struct = 1..3
+
+      assert Vector.equal?(enumerable_struct, [1.0, 2.0, 3.0])
+      assert Vector.equal?([1.0, 2.0, 3.0], enumerable_struct)
+      assert Vector.equal?(enumerable_struct, Pgvector.new([1.0, 2.0, 3.0]))
+      refute Vector.equal?(enumerable_struct, [1.0, 2.0, 3.5])
+    end
+
+    test "an opaque struct falls back to structural comparison" do
+      opaque = %OpaqueVector{blob: "unknown"}
+
+      assert Vector.equal?(opaque, opaque)
+      refute Vector.equal?(opaque, [1.0])
     end
   end
 

--- a/test/arcana/ecto/vector_test.exs
+++ b/test/arcana/ecto/vector_test.exs
@@ -1,0 +1,62 @@
+defmodule Arcana.Ecto.VectorTest do
+  use Arcana.DataCase, async: true
+
+  alias Arcana.Chunk
+  alias Arcana.Ecto.Vector
+
+  describe "equal?/2" do
+    test "byte-identical values are equal across representations" do
+      list = [1.0, 2.5, -3.25]
+      pgv = Pgvector.new(list)
+
+      assert Vector.equal?(list, list)
+      assert Vector.equal?(pgv, pgv)
+      assert Vector.equal?(list, pgv)
+      assert Vector.equal?(pgv, list)
+    end
+
+    test "different values are not equal" do
+      refute Vector.equal?([1.0, 2.0], [1.0, 2.1])
+      refute Vector.equal?(Pgvector.new([1.0]), Pgvector.new([2.0]))
+      refute Vector.equal?([1.0], nil)
+    end
+
+    test "nil equals nil" do
+      assert Vector.equal?(nil, nil)
+    end
+
+    test "uncastable values fall back to structural comparison without raising" do
+      refute Vector.equal?("not a vector", [1.0])
+      assert Vector.equal?("same", "same")
+    end
+  end
+
+  describe "changeset dirty tracking" do
+    test "re-storing a byte-identical embedding is a no-op change" do
+      {:ok, doc} = Arcana.ingest("Vector equality regression", repo: Repo)
+
+      chunk = Repo.one!(from(c in Chunk, where: c.document_id == ^doc.id, limit: 1))
+      same_embedding = Pgvector.to_list(chunk.embedding)
+
+      changeset = Chunk.changeset(chunk, %{embedding: same_embedding})
+
+      # Before Arcana.Ecto.Vector, comparing the loaded %Pgvector{}
+      # against a cast list dirtied the changeset on every re-store
+      assert changeset.changes == %{}
+
+      {:ok, updated} = Repo.update(changeset)
+      assert updated.updated_at == chunk.updated_at
+    end
+
+    test "a genuinely different embedding is still detected" do
+      {:ok, doc} = Arcana.ingest("Vector inequality regression", repo: Repo)
+
+      chunk = Repo.one!(from(c in Chunk, where: c.document_id == ^doc.id, limit: 1))
+      [first | rest] = Pgvector.to_list(chunk.embedding)
+
+      changeset = Chunk.changeset(chunk, %{embedding: [first + 1.0 | rest]})
+
+      assert Map.has_key?(changeset.changes, :embedding)
+    end
+  end
+end

--- a/test/arcana/ecto/vector_test.exs
+++ b/test/arcana/ecto/vector_test.exs
@@ -50,6 +50,16 @@ defmodule Arcana.Ecto.VectorTest do
       refute Vector.equal?(enumerable_struct, [1.0, 2.0, 3.5])
     end
 
+    test "an enumerable that raises falls back instead of crashing" do
+      # Streams are enumerable structs, so normalize/1 tries to walk them;
+      # a raising one must degrade to structural comparison, not blow up
+      # the caller's changeset
+      raising = Stream.map([1], fn _ -> raise "boom" end)
+
+      refute Vector.equal?(raising, [1.0])
+      refute Vector.equal?([1.0], raising)
+    end
+
     test "an opaque struct falls back to structural comparison" do
       opaque = %OpaqueVector{blob: "unknown"}
 
@@ -59,31 +69,47 @@ defmodule Arcana.Ecto.VectorTest do
   end
 
   describe "changeset dirty tracking" do
-    test "re-storing a byte-identical embedding is a no-op change" do
+    test "casting an equal value produces no change" do
+      # The discriminating case: cast/3 encodes the incoming list, and
+      # without equal?/2 the loaded representation and the cast one
+      # compare unequal, marking the embedding changed on every re-store.
+      chunk = %Chunk{text: "x", embedding: [1.0, 2.0]}
+
+      changeset = Ecto.Changeset.cast(chunk, %{"embedding" => [1.0, 2.0]}, [:embedding])
+
+      assert changeset.changes == %{}
+    end
+
+    test "a genuinely different embedding is still detected" do
+      chunk = %Chunk{text: "x", embedding: [1.0, 2.0]}
+
+      changeset = Ecto.Changeset.cast(chunk, %{"embedding" => [1.0, 2.5]}, [:embedding])
+
+      assert Map.has_key?(changeset.changes, :embedding)
+    end
+
+    test "re-storing a byte-identical embedding leaves the row untouched" do
       {:ok, doc} = Arcana.ingest("Vector equality regression", repo: Repo)
 
       chunk = Repo.one!(from(c in Chunk, where: c.document_id == ^doc.id, limit: 1))
       same_embedding = Pgvector.to_list(chunk.embedding)
 
       changeset = Chunk.changeset(chunk, %{embedding: same_embedding})
-
-      # Before Arcana.Ecto.Vector, comparing the loaded %Pgvector{}
-      # against a cast list dirtied the changeset on every re-store
-      assert changeset.changes == %{}
-
       {:ok, updated} = Repo.update(changeset)
+
       assert updated.updated_at == chunk.updated_at
     end
 
-    test "a genuinely different embedding is still detected" do
+    test "a changed embedding round-trips through the database" do
       {:ok, doc} = Arcana.ingest("Vector inequality regression", repo: Repo)
 
       chunk = Repo.one!(from(c in Chunk, where: c.document_id == ^doc.id, limit: 1))
       [first | rest] = Pgvector.to_list(chunk.embedding)
+      changed = [first + 1.0 | rest]
 
-      changeset = Chunk.changeset(chunk, %{embedding: [first + 1.0 | rest]})
+      {:ok, _} = chunk |> Chunk.changeset(%{embedding: changed}) |> Repo.update()
 
-      assert Map.has_key?(changeset.changes, :embedding)
+      assert Repo.reload!(chunk).embedding |> Pgvector.to_list() == changed
     end
   end
 end

--- a/test/arcana/ecto/vector_test.exs
+++ b/test/arcana/ecto/vector_test.exs
@@ -109,7 +109,13 @@ defmodule Arcana.Ecto.VectorTest do
 
       {:ok, _} = chunk |> Chunk.changeset(%{embedding: changed}) |> Repo.update()
 
-      assert Repo.reload!(chunk).embedding |> Pgvector.to_list() == changed
+      # The column is float4, so compare against the f32-normalized value
+      # rather than the f64 arithmetic result
+      expected = changed |> Pgvector.new() |> Pgvector.to_list()
+      reloaded = Repo.reload!(chunk).embedding |> Pgvector.to_list()
+
+      assert reloaded == expected
+      refute reloaded == Pgvector.to_list(chunk.embedding)
     end
   end
 end


### PR DESCRIPTION
`Pgvector.Ecto.Vector` inherits Ecto's default `equal?/2` (plain `==`), so any setup where the loaded value isn't the exact representation being written back — a custom Postgrex types module decoding to a different struct, or list-vs-`%Pgvector{}` round trips — dirties the changeset on byte-identical embeddings. Idempotent re-stores become write amplification plus HNSW index churn.

new `Arcana.Ecto.Vector` delegates `type/cast/load/dump` to `Pgvector.Ecto.Vector` (identical wire behavior) and adds `equal?/2` comparing encoded binaries across representations; `Chunk` and `Graph.Entity` embeddings now use it. Uncastable values fall back to structural comparison rather than raising.

context: pgvector-python's `Vector.__eq__` does value equality and pgvector-ruby casts to native arrays, so the Elixir client is the family outlier — if upstream ships `equal?/2` this wrapper drops to a no-op removable in a major. (Not filing upstream per George.)

tests: `equal?/2` truth table across representations, plus regression tests asserting a byte-identical re-store produces `changes == %{}` with `updated_at` untouched, while a genuinely different embedding is still detected.

Fixes #98

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops false positives in changeset dirty tracking for vector embeddings by adding `Arcana.Ecto.Vector` with value-based equality. Old: Ecto used `==`, so list vs `%Pgvector{}` or custom decoder structs always looked changed; new: `equal?/2` compares encoded binaries, making byte-identical re-stores no-ops and avoiding HNSW index churn. Fixes #98.

- `Arcana.Ecto.Vector` delegates `type/cast/load/dump` to `Pgvector.Ecto.Vector`; storage and wire format are unchanged.
- `equal?/2` normalizes lists, `%Pgvector{}`, and any Enumerable struct; it catches enumeration errors and falls back to structural equality for opaque or uncastable values.
- Switched `Chunk.embedding` and `Graph.Entity.embedding` to `Arcana.Ecto.Vector`; no migrations.
- Tests cover a discriminating `cast/3` scenario and a raising-enumerable case; round-trip assertions compare float32-normalized values to match the `float4` column.

<sup>Written for commit 71caf22010c43b1319f8108d56a17015221d6761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

