### PR TITLE
feat: Host-provided collection scoping for the dashboard

### DIFF
--- a/guides/dashboard.md
+++ b/guides/dashboard.md
@@ -91,9 +91,9 @@ arcana_dashboard "/arcana",
 
 By default the dashboard sees (and can mutate) every collection, so it's
 superuser territory. The `collections:` option lets you expose it below
-that level: a `{module, function}` pair that gets the `%Plug.Conn{}` at
-request time and returns either `:all` or the list of collection names
-this request may touch.
+that level: a `{module, function}` pair that gets the `%Plug.Conn{}` of
+the page request and returns either `:all` or the list of collection
+names that user may touch.
 
 ```elixir
 arcana_dashboard "/arcana",
@@ -114,8 +114,8 @@ end
 
 The restriction applies everywhere, and fails closed:
 
-- listings, search, ask, graph views, and the header stats only cover
-  the allowed collections
+- listings, search, ask, graph views, evaluation test cases and runs,
+  and the header stats only cover the allowed collections
 - ingest and maintenance actions must target an allowed collection;
   "All Collections" operations disappear
 - events naming any other collection (including forged form payloads)
@@ -126,6 +126,32 @@ The restriction applies everywhere, and fails closed:
 - renaming a collection is blocked: a rename could otherwise move
   documents into a name another tenant is allowed to see
 - an empty list means the dashboard shows and does nothing
+
+#### When the decision is made
+
+The MFA runs while the page request is served and its answer is
+snapshotted into the signed LiveView session, which is valid for the
+session max age (14 days by default). The websocket connect, reconnects
+and in-dashboard `live_patch`/`live_redirect` all read that snapshot back
+instead of calling the MFA again; only a full page request re-runs it.
+Narrowing someone's permissions therefore doesn't narrow a dashboard they
+already have open. The `on_mount` hook can't fix this by itself, since a
+LiveView mount has no `%Plug.Conn{}` to re-resolve from.
+
+Cut the socket when permissions change. Put a per-user `live_socket_id`
+in the session and broadcast a disconnect:
+
+```elixir
+# on login
+put_session(conn, :live_socket_id, "users_socket:#{user.id}")
+
+# when access changes
+MyAppWeb.Endpoint.broadcast("users_socket:#{user.id}", "disconnect", %{})
+```
+
+The client then reconnects through a full request, which re-runs the MFA
+with the current conn. A shorter session max age puts a hard bound on how
+long a stale scope can survive without that broadcast.
 
 It's a plain `{module, function}` tuple rather than a function capture
 so the router metadata stays serializable. The option composes with

--- a/guides/dashboard.md
+++ b/guides/dashboard.md
@@ -120,6 +120,11 @@ The restriction applies everywhere, and fails closed:
   "All Collections" operations disappear
 - events naming any other collection (including forged form payloads)
   are rejected server-side, not just hidden from the UI
+- retrieval runs under `strict_collections: true`, so an allowed
+  collection that doesn't exist errors out instead of widening the
+  search to everything
+- renaming a collection is blocked: a rename could otherwise move
+  documents into a name another tenant is allowed to see
 - an empty list means the dashboard shows and does nothing
 
 It's a plain `{module, function}` tuple rather than a function capture

--- a/guides/dashboard.md
+++ b/guides/dashboard.md
@@ -71,9 +71,11 @@ appear literally instead of being formatted.
 
 ```elixir
 arcana_dashboard "/arcana",
-  repo: MyApp.Repo,                    # Override repo
-  on_mount: [MyAppWeb.Auth],           # Add authentication
-  live_socket_path: "/live"            # Custom LiveView socket path
+  repo: MyApp.Repo,                            # Override repo
+  on_mount: [MyAppWeb.Auth],                   # Add authentication
+  live_socket_path: "/live",                   # Custom LiveView socket path
+  live_session_name: :arcana_dashboard,        # Unique per mount in one router
+  collections: {MyAppWeb.Access, :collections} # Scope to a collection subset
 ```
 
 ### Authentication
@@ -84,6 +86,50 @@ Protect the dashboard with your existing authentication:
 arcana_dashboard "/arcana",
   on_mount: [MyAppWeb.RequireAdmin]
 ```
+
+### Collection scoping
+
+By default the dashboard sees (and can mutate) every collection, so it's
+superuser territory. The `collections:` option lets you expose it below
+that level: a `{module, function}` pair that gets the `%Plug.Conn{}` at
+request time and returns either `:all` or the list of collection names
+this request may touch.
+
+```elixir
+arcana_dashboard "/arcana",
+  collections: {MyAppWeb.ArcanaAccess, :allowed_collections}
+```
+
+```elixir
+defmodule MyAppWeb.ArcanaAccess do
+  def allowed_collections(conn) do
+    case conn.assigns.current_user do
+      %{admin: true} -> :all
+      %{tenant: tenant} -> ["#{tenant}-docs", "#{tenant}-tickets"]
+      _ -> []
+    end
+  end
+end
+```
+
+The restriction applies everywhere, and fails closed:
+
+- listings, search, ask, graph views, and the header stats only cover
+  the allowed collections
+- ingest and maintenance actions must target an allowed collection;
+  "All Collections" operations disappear
+- events naming any other collection (including forged form payloads)
+  are rejected server-side, not just hidden from the UI
+- an empty list means the dashboard shows and does nothing
+
+It's a plain `{module, function}` tuple rather than a function capture
+so the router metadata stays serializable. The option composes with
+`on_mount:` auth hooks: use `on_mount` to decide who gets in, and
+`collections:` to decide what they see once inside. It scopes the
+dashboard only, not `Arcana.search/2` or other API calls your app makes.
+
+To mount two dashboards in one router (say a superuser one plus a scoped
+one), give the second a unique `live_session_name:`.
 
 ## Pages
 

--- a/lib/arcana/evaluation.ex
+++ b/lib/arcana/evaluation.ex
@@ -25,6 +25,7 @@ defmodule Arcana.Evaluation do
 
   import Ecto.Query
 
+  alias Arcana.{Collection, Document}
   alias Arcana.Evaluation.{Generator, Metrics, Run, TestCase}
 
   @doc """
@@ -62,6 +63,18 @@ defmodule Arcana.Evaluation do
       strategies (e.g., `Arcana.Loop`) against the same test set with the
       same metrics. The chunks returned must be maps with `:id` so the
       metrics can match them against the test case's `relevant_chunks`.
+    * `:run_ref` - Opaque term echoed back in the per-test-case telemetry
+      metadata. `[:arcana, :evaluation, :test_case, :*]` events carry the
+      question being evaluated, and handlers are global, so a listener that
+      wants only its own run's questions has to filter on something; this
+      is it.
+    * `:collections` - List of collection names to confine the run to. It
+      scopes which test cases run (see `list_test_cases/1`), is forwarded to
+      the retriever so retrieval can't reach outside those collections, and
+      is recorded on the run so scoped listings can find it again.
+      Retrieval then runs with `strict_collections: true` unless
+      `:strict_collections` says otherwise, so a collection name with no
+      row fails the search instead of widening it to the whole corpus.
 
   """
   def run(opts) do
@@ -70,7 +83,12 @@ defmodule Arcana.Evaluation do
     source_id = Keyword.get(opts, :source_id)
     evaluate_answers = Keyword.get(opts, :evaluate_answers, false)
     llm = Keyword.get(opts, :llm)
+    collections = Keyword.get(opts, :collections)
+    run_ref = Keyword.get(opts, :run_ref)
     retriever = Keyword.get(opts, :retriever, &default_retriever/2)
+
+    retriever_opts =
+      [repo: repo, mode: mode, limit: 10] ++ retrieval_scope_opts(opts, collections)
 
     # Validate llm is provided when evaluate_answers is true
     if evaluate_answers and is_nil(llm) do
@@ -90,6 +108,7 @@ defmodule Arcana.Evaluation do
         |> Map.put(:mode, mode)
         |> Map.put(:source_id, source_id)
         |> Map.put(:evaluate_answers, evaluate_answers)
+        |> put_run_collections(collections)
 
       # Create a run record
       {:ok, run} =
@@ -121,6 +140,7 @@ defmodule Arcana.Evaluation do
             %{index: index},
             %{
               run_id: run.id,
+              run_ref: run_ref,
               index: index,
               total: total,
               question: test_case.question
@@ -130,7 +150,7 @@ defmodule Arcana.Evaluation do
           started_at = System.monotonic_time()
 
           result =
-            evaluate_test_case(test_case, repo, mode, evaluate_answers, llm, retriever)
+            evaluate_test_case(test_case, retriever_opts, evaluate_answers, llm, retriever)
 
           duration_ms =
             System.convert_time_unit(
@@ -144,6 +164,7 @@ defmodule Arcana.Evaluation do
             %{duration_ms: duration_ms, index: index},
             %{
               run_id: run.id,
+              run_ref: run_ref,
               index: index,
               total: total,
               question: test_case.question
@@ -186,9 +207,25 @@ defmodule Arcana.Evaluation do
     end
   end
 
-  defp evaluate_test_case(test_case, repo, mode, evaluate_answers, llm, retriever) do
+  # Retrieval scope for the run. Passing `:collections` without strict
+  # resolution would let a collection name with no row resolve to "no
+  # filter", which is the whole corpus — the opposite of what a scoped run
+  # asked for.
+  defp retrieval_scope_opts(_opts, nil), do: []
+
+  defp retrieval_scope_opts(opts, collections) when is_list(collections) do
+    [
+      collections: collections,
+      strict_collections: Keyword.get(opts, :strict_collections, true)
+    ]
+  end
+
+  defp put_run_collections(config, nil), do: config
+  defp put_run_collections(config, collections), do: Map.put(config, :collections, collections)
+
+  defp evaluate_test_case(test_case, retriever_opts, evaluate_answers, llm, retriever) do
     {search_results, pre_generated_answer} =
-      case retriever.(test_case.question, repo: repo, mode: mode, limit: 10) do
+      case retriever.(test_case.question, retriever_opts) do
         {:ok, chunks} -> {chunks, nil}
         {:ok, chunks, answer} -> {chunks, answer}
         # A failing retriever (e.g. Arcana.search/2 returning {:error, _})
@@ -327,6 +364,18 @@ defmodule Arcana.Evaluation do
 
     * `:repo` - Ecto repo (required)
     * `:source_id` - Filter by source (optional)
+    * `:collections` - List of collection names to scope the listing to.
+      See "Collection scoping" below.
+
+  ## Collection scoping
+
+  A test case has no collection of its own: it reaches one through its
+  chunks (the relevant chunks it is scored against, and the source chunk it
+  was generated from). When `:collections` is given, only test cases whose
+  every linked chunk resolves to one of those collections are returned, and
+  at least one link has to resolve. Anything else — a test case straddling
+  two collections, one whose chunks were deleted, one with no links at all
+  — stays hidden, since rendering it would expose the foreign half.
 
   """
   def list_test_cases(opts) do
@@ -350,15 +399,119 @@ defmodule Arcana.Evaluation do
         query
       end
 
-    repo.all(query)
+    query
+    |> scope_test_cases(Keyword.get(opts, :collections))
+    |> repo.all()
   end
 
   @doc """
   Gets a single test case by ID.
+
+  Accepts the same `:collections` scoping option as `list_test_cases/1`;
+  a test case outside the scope reads as missing.
   """
   def get_test_case(id, opts) do
     repo = Keyword.fetch!(opts, :repo)
-    repo.get(TestCase, id) |> repo.preload([:relevant_chunks, :source_chunk])
+
+    case Ecto.UUID.cast(id) do
+      :error ->
+        nil
+
+      {:ok, uuid} ->
+        from(tc in TestCase,
+          where: tc.id == ^uuid,
+          preload: [:relevant_chunks, :source_chunk]
+        )
+        |> scope_test_cases(Keyword.get(opts, :collections))
+        |> repo.one()
+    end
+  end
+
+  defp scope_test_cases(query, nil), do: query
+
+  defp scope_test_cases(query, collections) when is_list(collections) do
+    from(tc in query, where: tc.id in subquery(scoped_test_case_ids(collections)))
+  end
+
+  # Every linked chunk has to land inside the allowed collections, and at
+  # least one has to land there at all. The correlations live inside this
+  # standalone SELECT so callers can use it from `delete_all` too.
+  defp scoped_test_case_ids(collections) do
+    from(tc in TestCase,
+      as: :scoped_test_case,
+      where:
+        exists(allowed_chunks_query(collections)) or
+          exists(allowed_source_chunk_query(collections)),
+      where: not exists(foreign_chunks_query(collections)),
+      where: not exists(foreign_source_chunk_query(collections)),
+      select: tc.id
+    )
+  end
+
+  defp allowed_chunks_query(collections) do
+    from(tc in TestCase,
+      join: chunk in assoc(tc, :relevant_chunks),
+      join: doc in assoc(chunk, :document),
+      join: col in assoc(doc, :collection),
+      where: tc.id == parent_as(:scoped_test_case).id,
+      where: col.name in ^collections,
+      select: 1
+    )
+  end
+
+  defp allowed_source_chunk_query(collections) do
+    from(tc in TestCase,
+      join: chunk in assoc(tc, :source_chunk),
+      join: doc in assoc(chunk, :document),
+      join: col in assoc(doc, :collection),
+      where: tc.id == parent_as(:scoped_test_case).id,
+      where: col.name in ^collections,
+      select: 1
+    )
+  end
+
+  # Left joins on purpose: a chunk whose document or collection is gone has
+  # no readable collection, so it counts as foreign rather than dropping out
+  # of the check.
+  defp foreign_chunks_query(collections) do
+    from(tc in TestCase,
+      join: chunk in assoc(tc, :relevant_chunks),
+      left_join: doc in Document,
+      on: chunk.document_id == doc.id,
+      left_join: col in Collection,
+      on: doc.collection_id == col.id,
+      where: tc.id == parent_as(:scoped_test_case).id,
+      where: is_nil(col.name) or col.name not in ^collections,
+      select: 1
+    )
+  end
+
+  defp foreign_source_chunk_query(collections) do
+    from(tc in TestCase,
+      join: chunk in assoc(tc, :source_chunk),
+      left_join: doc in Document,
+      on: chunk.document_id == doc.id,
+      left_join: col in Collection,
+      on: doc.collection_id == col.id,
+      where: tc.id == parent_as(:scoped_test_case).id,
+      where: is_nil(col.name) or col.name not in ^collections,
+      select: 1
+    )
+  end
+
+  # Runs carry no collection either, and unlike test cases they have nothing
+  # to derive one from, so `run/1` records the scope it ran under in the run
+  # config. A scoped listing only sees runs whose recorded scope is a
+  # non-empty subset of what the caller may read: unscoped runs (an
+  # unrestricted dashboard's, or any run predating this) stay hidden.
+  defp scope_runs(query, nil), do: query
+
+  defp scope_runs(query, collections) when is_list(collections) do
+    from(r in query,
+      where: fragment("jsonb_typeof(?->'collections') = 'array'", r.config),
+      where: fragment("?->'collections' <> '[]'::jsonb", r.config),
+      where: fragment("?->'collections' <@ to_jsonb(?::text[])", r.config, ^collections)
+    )
   end
 
   @doc """
@@ -404,13 +557,19 @@ defmodule Arcana.Evaluation do
 
   @doc """
   Deletes a test case.
+
+  With `:collections`, the scope predicate rides inside the DELETE, so a
+  test case outside the allowed collections is rejected with
+  `{:error, :not_found}` and nothing can change between the check and the
+  delete. A malformed id is rejected the same way.
   """
   def delete_test_case(id, opts) do
     repo = Keyword.fetch!(opts, :repo)
 
-    case repo.get(TestCase, id) do
-      nil -> {:error, :not_found}
-      test_case -> {:ok, repo.delete!(test_case)}
+    with {:ok, uuid} <- cast_id(id) do
+      from(tc in TestCase, where: tc.id == ^uuid, select: tc)
+      |> scope_test_cases(Keyword.get(opts, :collections))
+      |> delete_one(repo)
     end
   end
 
@@ -421,6 +580,8 @@ defmodule Arcana.Evaluation do
 
     * `:repo` - Ecto repo (required)
     * `:limit` - Maximum runs to return (default: 20)
+    * `:collections` - Only list runs recorded as having run under a
+      non-empty subset of these collection names
 
   """
   def list_runs(opts) do
@@ -431,34 +592,70 @@ defmodule Arcana.Evaluation do
       order_by: [desc: r.inserted_at, desc: r.id],
       limit: ^limit
     )
+    |> scope_runs(Keyword.get(opts, :collections))
     |> repo.all()
   end
 
   @doc """
   Gets a single evaluation run by ID.
+
+  Accepts the same `:collections` scoping option as `list_runs/1`.
   """
   def get_run(id, opts) do
     repo = Keyword.fetch!(opts, :repo)
-    repo.get(Run, id)
+
+    case cast_id(id) do
+      {:ok, uuid} ->
+        from(r in Run, where: r.id == ^uuid)
+        |> scope_runs(Keyword.get(opts, :collections))
+        |> repo.one()
+
+      {:error, :not_found} ->
+        nil
+    end
   end
 
   @doc """
   Deletes an evaluation run.
+
+  Scoped the same way as `delete_test_case/2`.
   """
   def delete_run(id, opts) do
     repo = Keyword.fetch!(opts, :repo)
 
-    case repo.get(Run, id) do
-      nil -> {:error, :not_found}
-      run -> {:ok, repo.delete!(run)}
+    with {:ok, uuid} <- cast_id(id) do
+      from(r in Run, where: r.id == ^uuid, select: r)
+      |> scope_runs(Keyword.get(opts, :collections))
+      |> delete_one(repo)
     end
   end
 
   @doc """
   Returns count of test cases.
+
+  Accepts the same `:collections` scoping option as `list_test_cases/1`.
   """
   def count_test_cases(opts) do
     repo = Keyword.fetch!(opts, :repo)
-    repo.aggregate(TestCase, :count)
+
+    from(tc in TestCase, select: count(tc.id))
+    |> scope_test_cases(Keyword.get(opts, :collections))
+    |> repo.one() || 0
+  end
+
+  # A forged id that isn't a UUID can't match anything, so it's rejected
+  # before it reaches a query that would raise on the cast.
+  defp cast_id(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, :not_found}
+    end
+  end
+
+  defp delete_one(query, repo) do
+    case repo.delete_all(query) do
+      {0, _} -> {:error, :not_found}
+      {_count, [record | _]} -> {:ok, record}
+    end
   end
 end

--- a/lib/arcana/pipeline.ex
+++ b/lib/arcana/pipeline.ex
@@ -553,6 +553,10 @@ defmodule Arcana.Pipeline do
   2. `ctx.collections` (set by `select/2` if LLM selection was used)
   3. Falls back to `"default"` collection
 
+  The resolved list is recorded on `ctx.collections`, so later steps that
+  retrieve (like `reason/2`) search the same scope instead of picking one
+  of their own.
+
   This allows you to explicitly specify a collection without using LLM-based selection:
 
       # Search a specific collection
@@ -612,14 +616,7 @@ defmodule Arcana.Pipeline do
   def search(%Context{} = ctx, opts) do
     searcher = Keyword.get(opts, :searcher, Arcana.Searcher.Arcana)
 
-    # Collection priority: option > ctx.collections > default
-    collections =
-      cond do
-        Keyword.has_key?(opts, :collections) -> Keyword.get(opts, :collections)
-        Keyword.has_key?(opts, :collection) -> [Keyword.get(opts, :collection)]
-        ctx.collections != nil -> ctx.collections
-        true -> ["default"]
-      end
+    collections = resolve_collections(ctx, opts)
 
     start_metadata = %{
       question: ctx.question,
@@ -639,7 +636,7 @@ defmodule Arcana.Pipeline do
           %{question: question, collection: collection, chunks: chunks}
         end
 
-      updated_ctx = %{ctx | results: results, searcher: searcher}
+      updated_ctx = %{ctx | results: results, searcher: searcher, collections: collections}
       total_chunks = results |> Enum.flat_map(& &1.chunks) |> length()
 
       stop_metadata = %{
@@ -649,6 +646,21 @@ defmodule Arcana.Pipeline do
 
       {updated_ctx, stop_metadata}
     end)
+  end
+
+  # Collection priority: option > ctx.collections > the "default" collection
+  # that Arcana.ingest/2 writes to when the caller names none.
+  #
+  # search/2 records what this returns on the context, so every later step
+  # that retrieves resolves the same scope by calling this with no options
+  # instead of guessing one from whatever results survived.
+  defp resolve_collections(ctx, opts) do
+    cond do
+      Keyword.has_key?(opts, :collections) -> Keyword.get(opts, :collections)
+      Keyword.has_key?(opts, :collection) -> [Keyword.get(opts, :collection)]
+      ctx.collections != nil -> ctx.collections
+      true -> ["default"]
+    end
   end
 
   defp searcher_name(searcher) when is_atom(searcher), do: searcher
@@ -688,6 +700,9 @@ defmodule Arcana.Pipeline do
     the option. Falls back to `Arcana.Searcher.Arcana` when `search/2` never
     ran.
 
+  Follow-up searches run against `ctx.collections`, which `search/2` records,
+  so the collection scope keeps applying too.
+
   ## Example
 
       ctx
@@ -713,8 +728,14 @@ defmodule Arcana.Pipeline do
       # Follow-up searches go through the same searcher as search/2, so a
       # caller that scoped retrieval there can't be widened here. search/2
       # records its searcher on the context, so the inheritance holds even
-      # when reason/2 is called without repeating the option.
-      searcher = Keyword.get(opts, :searcher) || ctx.searcher || Arcana.Searcher.Arcana
+      # when reason/2 is called without repeating the option. fetch, not
+      # get: an explicit `searcher: nil` is a caller mistake and should
+      # fail the same way it does on search/2, not quietly inherit.
+      searcher =
+        case Keyword.fetch(opts, :searcher) do
+          {:ok, searcher} -> searcher
+          :error -> ctx.searcher || Arcana.Searcher.Arcana
+        end
 
       # Initialize queries_tried if not set
       queries_tried = ctx.queries_tried || MapSet.new([ctx.question])
@@ -825,13 +846,11 @@ defmodule Arcana.Pipeline do
   end
 
   defp do_additional_search(ctx, query, searcher) do
-    # Determine which collections to search
-    collections =
-      cond do
-        ctx.collections && ctx.collections != [] -> ctx.collections
-        ctx.results && ctx.results != [] -> [hd(ctx.results).collection]
-        true -> ["default"]
-      end
+    # Follow-ups search exactly what search/2 searched. Deriving the scope
+    # from ctx.results instead would drift: merge_results drops results
+    # whose chunks came back empty, so one dry follow-up leaves nothing to
+    # derive from and the next one widens past what the caller asked for.
+    collections = resolve_collections(ctx, [])
 
     Enum.map(collections, fn collection ->
       search_opts = [

--- a/lib/arcana/pipeline.ex
+++ b/lib/arcana/pipeline.ex
@@ -706,11 +706,15 @@ defmodule Arcana.Pipeline do
       llm = Keyword.get(opts, :llm, ctx.llm)
       max_iterations = Keyword.get(opts, :max_iterations, 2)
       custom_prompt_fn = Keyword.get(opts, :prompt)
+      # Follow-up searches go through the same searcher as search/2, so a
+      # caller that scoped retrieval there can't be widened here.
+      searcher = Keyword.get(opts, :searcher, Arcana.Searcher.Arcana)
 
       # Initialize queries_tried if not set
       queries_tried = ctx.queries_tried || MapSet.new([ctx.question])
 
-      updated_ctx = do_reason_loop(ctx, llm, custom_prompt_fn, max_iterations, queries_tried, 0)
+      updated_ctx =
+        do_reason_loop(ctx, llm, custom_prompt_fn, max_iterations, queries_tried, 0, searcher)
 
       stop_metadata = %{iterations: updated_ctx.reason_iterations}
 
@@ -718,12 +722,14 @@ defmodule Arcana.Pipeline do
     end)
   end
 
-  defp do_reason_loop(ctx, _llm, _prompt_fn, max_iterations, queries_tried, iteration)
+  defp do_reason_loop(ctx, llm, prompt_fn, max_iterations, queries_tried, iteration, searcher)
+
+  defp do_reason_loop(ctx, _llm, _prompt_fn, max_iterations, queries_tried, iteration, _searcher)
        when iteration >= max_iterations do
     %{ctx | queries_tried: queries_tried, reason_iterations: iteration}
   end
 
-  defp do_reason_loop(ctx, llm, prompt_fn, max_iterations, queries_tried, iteration) do
+  defp do_reason_loop(ctx, llm, prompt_fn, max_iterations, queries_tried, iteration, searcher) do
     all_chunks =
       (ctx.results || [])
       |> Enum.flat_map(& &1.chunks)
@@ -740,7 +746,7 @@ defmodule Arcana.Pipeline do
           # Search with follow-up query
           updated_queries = MapSet.put(queries_tried, follow_up_query)
 
-          new_results = do_additional_search(ctx, follow_up_query)
+          new_results = do_additional_search(ctx, follow_up_query, searcher)
           merged_results = merge_results(ctx.results, new_results)
           updated_ctx = %{ctx | results: merged_results}
 
@@ -750,7 +756,8 @@ defmodule Arcana.Pipeline do
             prompt_fn,
             max_iterations,
             updated_queries,
-            iteration + 1
+            iteration + 1,
+            searcher
           )
         end
 
@@ -811,7 +818,7 @@ defmodule Arcana.Pipeline do
     end
   end
 
-  defp do_additional_search(ctx, query) do
+  defp do_additional_search(ctx, query, searcher) do
     # Determine which collections to search
     collections =
       cond do
@@ -827,11 +834,7 @@ defmodule Arcana.Pipeline do
         threshold: ctx.threshold
       ]
 
-      chunks =
-        case Arcana.Search.search(query, Keyword.put(search_opts, :collection, collection)) do
-          {:ok, results} -> results
-          {:error, _} -> []
-        end
+      chunks = do_simple_search(searcher, query, collection, search_opts)
 
       %{question: query, collection: collection, chunks: chunks}
     end)

--- a/lib/arcana/pipeline.ex
+++ b/lib/arcana/pipeline.ex
@@ -639,7 +639,7 @@ defmodule Arcana.Pipeline do
           %{question: question, collection: collection, chunks: chunks}
         end
 
-      updated_ctx = %{ctx | results: results}
+      updated_ctx = %{ctx | results: results, searcher: searcher}
       total_chunks = results |> Enum.flat_map(& &1.chunks) |> length()
 
       stop_metadata = %{
@@ -683,6 +683,10 @@ defmodule Arcana.Pipeline do
   - `:max_iterations` - Maximum additional searches (default: 2)
   - `:prompt` - Custom prompt function `fn question, chunks -> prompt_string end`
   - `:llm` - Override the LLM function for this step
+  - `:searcher` - Searcher for the follow-up searches. Defaults to the one
+    `search/2` used, so a scoped searcher keeps applying without repeating
+    the option. Falls back to `Arcana.Searcher.Arcana` when `search/2` never
+    ran.
 
   ## Example
 
@@ -707,8 +711,10 @@ defmodule Arcana.Pipeline do
       max_iterations = Keyword.get(opts, :max_iterations, 2)
       custom_prompt_fn = Keyword.get(opts, :prompt)
       # Follow-up searches go through the same searcher as search/2, so a
-      # caller that scoped retrieval there can't be widened here.
-      searcher = Keyword.get(opts, :searcher, Arcana.Searcher.Arcana)
+      # caller that scoped retrieval there can't be widened here. search/2
+      # records its searcher on the context, so the inheritance holds even
+      # when reason/2 is called without repeating the option.
+      searcher = Keyword.get(opts, :searcher) || ctx.searcher || Arcana.Searcher.Arcana
 
       # Initialize queries_tried if not set
       queries_tried = ctx.queries_tried || MapSet.new([ctx.question])

--- a/lib/arcana/pipeline/context.ex
+++ b/lib/arcana/pipeline/context.ex
@@ -20,7 +20,8 @@ defmodule Arcana.Pipeline.Context do
   - `:rewritten_query` - Conversational input rewritten as a clear search query
 
   ### Populated by `select/2`
-  - `:collections` - List of collection names to search
+  - `:collections` - List of collection names to search (also recorded by
+    `search/2`, see below)
   - `:selection_reasoning` - LLM's reasoning for the selection decision
 
   ### Populated by `expand/2`
@@ -38,6 +39,9 @@ defmodule Arcana.Pipeline.Context do
   - `:searcher` - The searcher used, so later steps that retrieve (like
     `reason/2`) stay on the caller's searcher instead of silently falling
     back to the default one
+  - `:collections` - The collections actually searched, for the same reason.
+    `search/2` resolves them from its own options first, then this field
+    (which `select/2` may have set), so an explicit option still wins
 
   ### Populated by `reason/2`
   - `:queries_tried` - MapSet of queries already searched (prevents loops)

--- a/lib/arcana/pipeline/context.ex
+++ b/lib/arcana/pipeline/context.ex
@@ -35,6 +35,9 @@ defmodule Arcana.Pipeline.Context do
 
   ### Populated by `search/2`
   - `:results` - List of `%{question: _, collection: _, chunks: _}` maps
+  - `:searcher` - The searcher used, so later steps that retrieve (like
+    `reason/2`) stay on the caller's searcher instead of silently falling
+    back to the default one
 
   ### Populated by `reason/2`
   - `:queries_tried` - MapSet of queries already searched (prevents loops)
@@ -85,6 +88,7 @@ defmodule Arcana.Pipeline.Context do
 
     # Populated by search/2
     :results,
+    :searcher,
 
     # Populated by reason/2
     :queries_tried,

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -792,7 +792,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       |> maybe_expand(opts)
       |> maybe_decompose(opts)
       |> Pipeline.search(search_opts)
-      |> maybe_reason(opts)
+      |> maybe_reason(opts, search_opts)
       |> maybe_rerank(opts)
       |> maybe_answer_with_hallucinations(opts)
       |> maybe_ground(opts)
@@ -825,8 +825,14 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       if Keyword.get(opts, :use_decompose, false), do: Arcana.Pipeline.decompose(ctx), else: ctx
     end
 
-    defp maybe_reason(ctx, opts) do
-      if Keyword.get(opts, :use_reason, false), do: Arcana.Pipeline.reason(ctx), else: ctx
+    defp maybe_reason(ctx, opts, search_opts) do
+      if Keyword.get(opts, :use_reason, false) do
+        # Carry the strict searcher into reasoning: its follow-up searches
+        # would otherwise run unscoped and could widen past the allow-list.
+        Arcana.Pipeline.reason(ctx, Keyword.take(search_opts, [:searcher]))
+      else
+        ctx
+      end
     end
 
     defp maybe_rerank(ctx, opts) do

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -177,7 +177,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     def handle_event("form_changed", params, socket) do
-      selected = params["collections"] || []
+      # A forged non-list selection is dropped here too: the render path
+      # enumerates @selected_collections, so anything else would crash the
+      # LiveView on the next paint.
+      selected = if is_list(params["collections"]), do: params["collections"], else: []
       pipeline_steps = Map.new(@pipeline_step_keys, &{&1, params[&1] == "true"})
       # Carry the textarea content forward on every form-change so a
       # checkbox click (collections, pipeline steps) doesn't blow away
@@ -251,6 +254,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     # today's semantics). Restricted ones fail closed: an empty allowed set
     # refuses every ask, no selection means "all allowed collections", and a
     # selection naming anything outside the allowed set is rejected whole.
+    #
+    # The non-list clause comes first so a forged scalar or map selection is
+    # rejected rather than blowing up in Enum.all?/2 (or slipping through
+    # the :all clause untouched).
+    defp resolve_ask_collections(requested, _allowed) when not is_list(requested), do: :error
     defp resolve_ask_collections(requested, :all), do: {:ok, requested}
     defp resolve_ask_collections(_requested, []), do: :error
     defp resolve_ask_collections([], allowed), do: {:ok, allowed}
@@ -339,6 +347,14 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       repo = socket.assigns.repo
       sub_tab = params["sub_tab"] || "advanced"
       parent = self()
+
+      # Carries both halves of the scoping decision into the task: what the
+      # user picked, and whether this dashboard is restricted at all (which
+      # decides whether retrieval runs under :strict_collections).
+      scope = %{
+        collections: selected_collections,
+        allowed: socket.assigns.allowed_collections
+      }
 
       ArcanaWeb.TaskSupervisor.start_child(fn ->
         handler_id = "pipeline-progress-#{inspect(parent)}"
@@ -472,7 +488,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             llm,
             socket.assigns.collections,
             params,
-            selected_collections
+            scope
           )
 
         :telemetry.detach(handler_id)
@@ -486,21 +502,22 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       System.convert_time_unit(duration, :native, :millisecond)
     end
 
-    defp run_ask("advanced", question, repo, llm, _all_collections, params, selected_collections) do
-      run_advanced_ask(question, repo, llm, selected_collections, params)
+    defp run_ask("advanced", question, repo, llm, _all_collections, params, scope) do
+      run_advanced_ask(question, repo, llm, scope, params)
     end
 
-    defp run_ask("loop", question, repo, llm, _all_collections, params, selected_collections) do
-      run_loop_ask(question, repo, llm, selected_collections, params)
+    defp run_ask("loop", question, repo, llm, _all_collections, params, scope) do
+      run_loop_ask(question, repo, llm, scope, params)
     end
 
-    defp run_ask("pipeline", question, repo, llm, all_collections, params, selected_collections) do
+    defp run_ask("pipeline", question, repo, llm, all_collections, params, scope) do
       run_pipeline_ask(
         question,
         repo,
         llm,
         all_collections,
-        collections: selected_collections,
+        collections: scope.collections,
+        allowed: scope.allowed,
         use_llm_select: params["llm_select"] == "true",
         use_gate: params["use_gate"] == "true",
         use_rewrite: params["use_rewrite"] == "true",
@@ -622,7 +639,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp mark_step_done([], _step, _duration_ms, _metadata), do: []
 
-    defp run_loop_ask(question, repo, llm, selected_collections, params) do
+    defp run_loop_ask(question, repo, llm, scope, params) do
       max_iterations =
         case Integer.parse(params["max_iterations"] || "10") do
           {n, _} when n > 0 -> n
@@ -644,7 +661,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
       new_opts =
         [repo: repo]
-        |> maybe_put_collection_opt(selected_collections)
+        |> maybe_put_collection_opt(scope.collections)
 
       run_opts =
         [
@@ -655,6 +672,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         |> maybe_put(:controller_temperature, controller_temperature)
         |> maybe_put(:answer_temperature, answer_temperature)
         |> maybe_put(:fallback_temperature, fallback_temperature)
+        |> maybe_put_loop_search_opts(scope.allowed)
 
       ctx = Arcana.Loop.new(question, new_opts)
       runner = loop_runner()
@@ -695,6 +713,22 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp maybe_put_collection_opt(opts, []), do: opts
     defp maybe_put_collection_opt(opts, list), do: Keyword.put(opts, :collections, list)
 
+    # Restricted dashboards retrieve strictly: an allowed collection that
+    # doesn't exist (never created, or deleted mid-session) has to error out
+    # instead of resolving to "no filter", which would widen retrieval to
+    # every collection. Unrestricted dashboards keep the library default.
+    defp maybe_put_strict_opt(opts, :all), do: opts
+
+    defp maybe_put_strict_opt(opts, allowed) when is_list(allowed),
+      do: Keyword.put(opts, :strict_collections, true)
+
+    # The Loop reaches Arcana.search/2 through its search tool, which merges
+    # `:search_opts` over the collection opts it derives from the context.
+    defp maybe_put_loop_search_opts(opts, :all), do: opts
+
+    defp maybe_put_loop_search_opts(opts, allowed) when is_list(allowed),
+      do: Keyword.put(opts, :search_opts, strict_collections: true)
+
     defp format_loop_result(%Arcana.Loop.Context{} = ctx, question) do
       %{
         result_type: :loop,
@@ -715,12 +749,14 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       }
     end
 
-    defp run_advanced_ask(question, repo, llm, selected_collections, params) do
+    defp run_advanced_ask(question, repo, llm, scope, params) do
       graph = params["graph_search"] == "true"
+      selected_collections = scope.collections
 
       opts =
         [repo: repo, llm: llm, graph: graph]
         |> maybe_put_collection_opt(selected_collections)
+        |> maybe_put_strict_opt(scope.allowed)
 
       case Arcana.ask(question, opts) do
         {:ok, answer, results} ->
@@ -850,10 +886,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     defp build_search_opts(opts, all_collection_names) do
-      base = [
-        self_correct: Keyword.get(opts, :self_correct, false),
-        graph: Keyword.get(opts, :graph, false)
-      ]
+      base =
+        [
+          self_correct: Keyword.get(opts, :self_correct, false),
+          graph: Keyword.get(opts, :graph, false)
+        ]
+        |> maybe_put_strict_searcher(Keyword.get(opts, :allowed, :all))
 
       use_llm_select = Keyword.get(opts, :use_llm_select, false)
 
@@ -866,6 +904,29 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp add_collection_opts(opts, []), do: opts
     defp add_collection_opts(opts, list), do: Keyword.put(opts, :collections, list)
+
+    # `Arcana.Pipeline.search/2` builds its own searcher opts and drops
+    # everything else, so :strict_collections can't just ride along like it
+    # does on the advanced and loop paths. Swapping in an explicit searcher
+    # is the supported hook: it re-checks the collection against the allowed
+    # set (the LLM-select step can name anything) and searches strictly, so
+    # a missing collection returns an error instead of widening.
+    defp maybe_put_strict_searcher(opts, :all), do: opts
+
+    defp maybe_put_strict_searcher(opts, allowed) when is_list(allowed) do
+      Keyword.put(opts, :searcher, fn question, collection, searcher_opts ->
+        if collection in allowed do
+          Arcana.search(
+            question,
+            searcher_opts
+            |> Keyword.take([:repo, :limit, :threshold])
+            |> Keyword.merge(collection: collection, strict_collections: true)
+          )
+        else
+          {:ok, []}
+        end
+      end)
+    end
 
     defp format_pipeline_result(%{error: error}, _question) when not is_nil(error) do
       {:error, error}

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -104,14 +104,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_data(socket) do
       repo = socket.assigns.repo
+      allowed = socket.assigns.allowed_collections
 
       socket
-      |> assign(stats: load_stats(repo))
-      |> assign(collections: load_collections_with_graph_status(repo))
+      |> assign(stats: load_stats(repo, allowed))
+      |> assign(collections: load_collections_with_graph_status(repo, allowed))
     end
 
-    defp load_collections_with_graph_status(repo) do
-      collections = load_collections(repo)
+    defp load_collections_with_graph_status(repo, allowed) do
+      collections = load_collections(repo, allowed)
 
       # Get entity counts per collection
       entity_counts =
@@ -139,32 +140,20 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     @impl true
     def handle_event("ask_submit", params, socket) do
       question = params["question"] || ""
+      requested = params["collections"] || []
 
-      case {Arcana.Config.get_env(:llm), question} do
-        {nil, _} ->
+      # Collection scoping is checked before anything else (including the
+      # LLM config) so a forged selection never reaches a retrieval call.
+      case resolve_ask_collections(requested, socket.assigns.allowed_collections) do
+        {:ok, collections} ->
+          submit_ask(socket, params, question, collections)
+
+        :error ->
           {:noreply,
            assign(socket,
-             ask_error: "No LLM configured. Set :arcana, :llm in your config.",
+             ask_error: "The selected collections are not allowed",
              ask_running: false
            )}
-
-        {_, ""} ->
-          {:noreply, assign(socket, ask_error: "Please enter a question")}
-
-        {llm, question} ->
-          socket =
-            assign(socket,
-              ask_running: true,
-              ask_error: nil,
-              ask_question: question,
-              ask_context: nil,
-              loop_live_history: [],
-              loop_phase: :idle,
-              trace_history: []
-            )
-
-          start_ask_task(socket, params, llm, question)
-          {:noreply, socket}
       end
     end
 
@@ -226,6 +215,48 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         end)
 
       {:noreply, assign(socket, pipeline_steps: steps)}
+    end
+
+    defp submit_ask(socket, params, question, collections) do
+      case {Arcana.Config.get_env(:llm), question} do
+        {nil, _} ->
+          {:noreply,
+           assign(socket,
+             ask_error: "No LLM configured. Set :arcana, :llm in your config.",
+             ask_running: false
+           )}
+
+        {_, ""} ->
+          {:noreply, assign(socket, ask_error: "Please enter a question")}
+
+        {llm, question} ->
+          socket =
+            assign(socket,
+              ask_running: true,
+              ask_error: nil,
+              ask_question: question,
+              ask_context: nil,
+              loop_live_history: [],
+              loop_phase: :idle,
+              trace_history: []
+            )
+
+          start_ask_task(socket, params, llm, question, collections)
+          {:noreply, socket}
+      end
+    end
+
+    # Resolves the user's collection selection against the allowed set.
+    # Unrestricted dashboards pass the selection through untouched ([] keeps
+    # today's semantics). Restricted ones fail closed: an empty allowed set
+    # refuses every ask, no selection means "all allowed collections", and a
+    # selection naming anything outside the allowed set is rejected whole.
+    defp resolve_ask_collections(requested, :all), do: {:ok, requested}
+    defp resolve_ask_collections(_requested, []), do: :error
+    defp resolve_ask_collections([], allowed), do: {:ok, allowed}
+
+    defp resolve_ask_collections(requested, allowed) do
+      if Enum.all?(requested, &(&1 in allowed)), do: {:ok, requested}, else: :error
     end
 
     defp ask_loading_label(:advanced, _step, _phase), do: "Generating answer..."
@@ -304,10 +335,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp format_llm_spec(model) when is_atom(model), do: Atom.to_string(model)
     defp format_llm_spec(other), do: inspect(other, limit: 1)
 
-    defp start_ask_task(socket, params, llm, question) do
+    defp start_ask_task(socket, params, llm, question, selected_collections) do
       repo = socket.assigns.repo
       sub_tab = params["sub_tab"] || "advanced"
-      selected_collections = params["collections"] || []
       parent = self()
 
       ArcanaWeb.TaskSupervisor.start_child(fn ->

--- a/lib/arcana_web/live/collections_live.ex
+++ b/lib/arcana_web/live/collections_live.ex
@@ -117,8 +117,6 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         )
         |> Map.new()
 
-      has_graph_data = map_size(entity_counts) > 0 or map_size(relationship_counts) > 0
-
       collections_with_stats =
         Enum.map(collections, fn c ->
           c
@@ -126,6 +124,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           |> Map.put(:relationship_count, Map.get(relationship_counts, c.id, 0))
           |> Map.put(:community_count, Map.get(community_counts, c.id, 0))
         end)
+
+      # Derived from the visible collections, not the global count maps:
+      # otherwise the graph columns render (leaking that graph data exists
+      # at all) because some collection outside the allowed set has entities.
+      has_graph_data =
+        Enum.any?(
+          collections_with_stats,
+          &(&1.entity_count > 0 or &1.relationship_count > 0)
+        )
 
       {collections_with_stats, has_graph_data}
     rescue
@@ -166,20 +173,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     def handle_event("update_collection", %{"id" => id, "collection" => params}, socket) do
-      repo = socket.assigns.repo
-
       case fetch_allowed_collection(socket, id) do
         nil ->
           {:noreply, put_flash(socket, :error, "Collection is not allowed")}
 
         collection ->
-          changeset =
-            Collection.changeset(collection, %{
-              name: params["name"] || collection.name,
-              description: params["description"]
-            })
-
-          update_collection(socket, repo, changeset)
+          update_allowed_collection(socket, collection, params)
       end
     end
 
@@ -201,6 +200,29 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         collection ->
           repo.delete!(collection)
           {:noreply, socket |> assign(confirm_delete_collection: nil) |> load_data()}
+      end
+    end
+
+    # Restricted dashboards can edit a description but never rename. Only
+    # validating the target name against the allowed set isn't enough:
+    # allow-lists can overlap, so renaming onto a shared name would drag
+    # this tenant's documents into another tenant's scope while still
+    # passing the check. The name input is disabled in the form, so a
+    # legitimate edit never carries a new name and only forged events hit
+    # this rejection.
+    defp update_allowed_collection(socket, collection, params) do
+      name = params["name"] || collection.name
+
+      if name != collection.name and socket.assigns.allowed_collections != :all do
+        {:noreply, put_flash(socket, :error, "Renaming collections is not allowed")}
+      else
+        changeset =
+          Collection.changeset(collection, %{
+            name: name,
+            description: params["description"]
+          })
+
+        update_collection(socket, socket.assigns.repo, changeset)
       end
     end
 
@@ -239,160 +261,180 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             Organize documents into collections for scoped searches and better organization.
           </p>
 
-          <div class="arcana-ingest-form">
-            <h3>Create Collection</h3>
-            <form id="new-collection-form" phx-submit="create_collection">
-              <div class="arcana-form-row" style="margin-bottom: 0.75rem;">
-                <input
-                  type="text"
-                  name="collection[name]"
-                  placeholder="Collection name"
-                  class="arcana-input"
-                  style="flex: 1; max-width: 300px;"
-                  required
-                />
-              </div>
-              <div class="arcana-form-row">
-                <input
-                  type="text"
-                  name="collection[description]"
-                  placeholder="Description (optional) - helps the agent select the right collection"
-                  class="arcana-input"
-                  style="flex: 1;"
-                />
-                <button type="submit" class="arcana-btn arcana-btn-primary">
-                  Create
-                </button>
-              </div>
-            </form>
-          </div>
-
-          <div class="arcana-doc-list">
-            <%= if Enum.empty?(@collections) do %>
-              <div class="arcana-empty">No collections yet. Create one above.</div>
-            <% else %>
-              <table class="arcana-table">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Description</th>
-                    <th>Docs</th>
-                    <th>Chunks</th>
-                    <%= if @show_graph_stats do %>
-                      <th>Entities</th>
-                      <th>Rels</th>
-                      <th>Communities</th>
-                    <% end %>
-                    <th style="width: 120px;">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <%= for collection <- @collections do %>
-                    <tr id={"collection-#{collection.name}"}>
-                      <%= if @editing_collection && @editing_collection.id == collection.id do %>
-                        <td colspan={if @show_graph_stats, do: 8, else: 5}>
-                          <form
-                            id={"edit-collection-form-#{collection.id}"}
-                            phx-submit="update_collection"
-                            phx-value-id={collection.id}
-                            class="arcana-edit-form"
-                          >
-                            <div class="arcana-form-row">
-                              <input
-                                type="text"
-                                name="collection[name]"
-                                value={collection.name}
-                                class="arcana-input"
-                                disabled
-                              />
-                              <input
-                                type="text"
-                                name="collection[description]"
-                                value={collection.description || ""}
-                                placeholder="Description"
-                                class="arcana-input"
-                                style="flex: 2;"
-                              />
-                              <button type="submit" class="arcana-btn arcana-btn-primary">Save</button>
-                              <button
-                                type="button"
-                                class="arcana-btn"
-                                phx-click="cancel_edit_collection"
-                              >
-                                Cancel
-                              </button>
-                            </div>
-                          </form>
-                        </td>
-                      <% else %>
-                        <td><code><%= collection.name %></code></td>
-                        <td><%= collection.description || "-" %></td>
-                        <td><%= collection.document_count %></td>
-                        <td><%= collection.chunk_count %></td>
-                        <%= if @show_graph_stats do %>
-                          <td><%= collection[:entity_count] || 0 %></td>
-                          <td><%= collection[:relationship_count] || 0 %></td>
-                          <td><%= collection[:community_count] || 0 %></td>
-                        <% end %>
-                        <td>
-                          <%= if @confirm_delete_collection == collection.id do %>
-                            <div class="arcana-confirm-delete">
-                              <span>Delete?</span>
-                              <button
-                                id="confirm-delete"
-                                class="arcana-btn arcana-btn-danger"
-                                phx-click="delete_collection"
-                                phx-value-id={collection.id}
-                              >
-                                Yes
-                              </button>
-                              <button
-                                class="arcana-btn"
-                                phx-click="cancel_delete_collection"
-                              >
-                                No
-                              </button>
-                            </div>
-                          <% else %>
-                            <div class="arcana-actions-cell">
-                              <button
-                                id={"edit-collection-#{collection.id}"}
-                                class="arcana-icon-btn"
-                                phx-click="edit_collection"
-                                phx-value-id={collection.id}
-                                title="Edit collection"
-                              >
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-                                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-                                </svg>
-                              </button>
-                              <button
-                                id={"delete-collection-#{collection.id}"}
-                                class="arcana-delete-btn"
-                                phx-click="confirm_delete_collection"
-                                phx-value-id={collection.id}
-                                title="Delete collection"
-                              >
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                  <polyline points="3 6 5 6 21 6"></polyline>
-                                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                                  <line x1="10" y1="11" x2="10" y2="17"></line>
-                                  <line x1="14" y1="11" x2="14" y2="17"></line>
-                                </svg>
-                              </button>
-                            </div>
-                          <% end %>
-                        </td>
-                      <% end %>
-                    </tr>
-                  <% end %>
-                </tbody>
-              </table>
-            <% end %>
-          </div>
+          <%= if @allowed_collections == [] do %>
+            <div class="arcana-empty">
+              No collections are available on this dashboard. Ask an administrator to grant
+              access to a collection.
+            </div>
+          <% else %>
+            <.collections_manager
+              collections={@collections}
+              show_graph_stats={@show_graph_stats}
+              editing_collection={@editing_collection}
+              confirm_delete_collection={@confirm_delete_collection}
+            />
+          <% end %>
         </div>
       </.dashboard_layout>
+      """
+    end
+
+    defp collections_manager(assigns) do
+      ~H"""
+      <div>
+        <div class="arcana-ingest-form">
+          <h3>Create Collection</h3>
+          <form id="new-collection-form" phx-submit="create_collection">
+            <div class="arcana-form-row" style="margin-bottom: 0.75rem;">
+              <input
+                type="text"
+                name="collection[name]"
+                placeholder="Collection name"
+                class="arcana-input"
+                style="flex: 1; max-width: 300px;"
+                required
+              />
+            </div>
+            <div class="arcana-form-row">
+              <input
+                type="text"
+                name="collection[description]"
+                placeholder="Description (optional) - helps the agent select the right collection"
+                class="arcana-input"
+                style="flex: 1;"
+              />
+              <button type="submit" class="arcana-btn arcana-btn-primary">
+                Create
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div class="arcana-doc-list">
+          <%= if Enum.empty?(@collections) do %>
+            <div class="arcana-empty">No collections yet. Create one above.</div>
+          <% else %>
+            <table class="arcana-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Description</th>
+                  <th>Docs</th>
+                  <th>Chunks</th>
+                  <%= if @show_graph_stats do %>
+                    <th>Entities</th>
+                    <th>Rels</th>
+                    <th>Communities</th>
+                  <% end %>
+                  <th style="width: 120px;">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <%= for collection <- @collections do %>
+                  <tr id={"collection-#{collection.name}"}>
+                    <%= if @editing_collection && @editing_collection.id == collection.id do %>
+                      <td colspan={if @show_graph_stats, do: 8, else: 5}>
+                        <form
+                          id={"edit-collection-form-#{collection.id}"}
+                          phx-submit="update_collection"
+                          phx-value-id={collection.id}
+                          class="arcana-edit-form"
+                        >
+                          <div class="arcana-form-row">
+                            <input
+                              type="text"
+                              name="collection[name]"
+                              value={collection.name}
+                              class="arcana-input"
+                              disabled
+                            />
+                            <input
+                              type="text"
+                              name="collection[description]"
+                              value={collection.description || ""}
+                              placeholder="Description"
+                              class="arcana-input"
+                              style="flex: 2;"
+                            />
+                            <button type="submit" class="arcana-btn arcana-btn-primary">Save</button>
+                            <button
+                              type="button"
+                              class="arcana-btn"
+                              phx-click="cancel_edit_collection"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </form>
+                      </td>
+                    <% else %>
+                      <td><code><%= collection.name %></code></td>
+                      <td><%= collection.description || "-" %></td>
+                      <td><%= collection.document_count %></td>
+                      <td><%= collection.chunk_count %></td>
+                      <%= if @show_graph_stats do %>
+                        <td><%= collection[:entity_count] || 0 %></td>
+                        <td><%= collection[:relationship_count] || 0 %></td>
+                        <td><%= collection[:community_count] || 0 %></td>
+                      <% end %>
+                      <td>
+                        <%= if @confirm_delete_collection == collection.id do %>
+                          <div class="arcana-confirm-delete">
+                            <span>Delete?</span>
+                            <button
+                              id="confirm-delete"
+                              class="arcana-btn arcana-btn-danger"
+                              phx-click="delete_collection"
+                              phx-value-id={collection.id}
+                            >
+                              Yes
+                            </button>
+                            <button
+                              class="arcana-btn"
+                              phx-click="cancel_delete_collection"
+                            >
+                              No
+                            </button>
+                          </div>
+                        <% else %>
+                          <div class="arcana-actions-cell">
+                            <button
+                              id={"edit-collection-#{collection.id}"}
+                              class="arcana-icon-btn"
+                              phx-click="edit_collection"
+                              phx-value-id={collection.id}
+                              title="Edit collection"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                              </svg>
+                            </button>
+                            <button
+                              id={"delete-collection-#{collection.id}"}
+                              class="arcana-delete-btn"
+                              phx-click="confirm_delete_collection"
+                              phx-value-id={collection.id}
+                              title="Delete collection"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="3 6 5 6 21 6"></polyline>
+                                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                <line x1="10" y1="11" x2="10" y2="17"></line>
+                                <line x1="14" y1="11" x2="14" y2="17"></line>
+                              </svg>
+                            </button>
+                          </div>
+                        <% end %>
+                      </td>
+                    <% end %>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          <% end %>
+        </div>
+      </div>
       """
     end
   end

--- a/lib/arcana_web/live/collections_live.ex
+++ b/lib/arcana_web/live/collections_live.ex
@@ -238,16 +238,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     # Fetches a collection by id only when its name is inside the allowed
     # set. Forged ids pointing at collections outside the scope resolve to
-    # nil, the same as a missing row.
+    # nil, the same as a missing row; ids that aren't UUIDs at all are
+    # rejected before the query would raise an Ecto.Query.CastError.
     defp fetch_allowed_collection(socket, id) do
-      case socket.assigns.repo.get(Collection, id) do
-        nil ->
-          nil
-
-        collection ->
-          if allowed_collection?(socket.assigns.allowed_collections, collection.name),
-            do: collection,
-            else: nil
+      with {:ok, uuid} <- Ecto.UUID.cast(id),
+           collection when not is_nil(collection) <- socket.assigns.repo.get(Collection, uuid),
+           true <- allowed_collection?(socket.assigns.allowed_collections, collection.name) do
+        collection
+      else
+        _ -> nil
       end
     end
 

--- a/lib/arcana_web/live/collections_live.ex
+++ b/lib/arcana_web/live/collections_live.ex
@@ -32,31 +32,38 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_data(socket) do
       repo = socket.assigns.repo
-      {collections, has_graph_data} = load_collections_with_stats(repo)
+      allowed = socket.assigns.allowed_collections
+      {collections, has_graph_data} = load_collections_with_stats(repo, allowed)
 
       socket
-      |> assign(stats: load_stats(repo))
+      |> assign(stats: load_stats(repo, allowed))
       |> assign(collections: collections)
       |> assign(show_graph_stats: has_graph_data)
     end
 
-    defp load_collections_with_stats(repo) do
+    defp load_collections_with_stats(repo, allowed) do
       # Base collection data with document count
-      collections =
-        repo.all(
-          from(c in Collection,
-            left_join: d in Arcana.Document,
-            on: d.collection_id == c.id,
-            group_by: c.id,
-            order_by: c.name,
-            select: %{
-              id: c.id,
-              name: c.name,
-              description: c.description,
-              document_count: count(d.id)
-            }
-          )
+      base_query =
+        from(c in Collection,
+          left_join: d in Arcana.Document,
+          on: d.collection_id == c.id,
+          group_by: c.id,
+          order_by: c.name,
+          select: %{
+            id: c.id,
+            name: c.name,
+            description: c.description,
+            document_count: count(d.id)
+          }
         )
+
+      base_query =
+        case allowed do
+          :all -> base_query
+          names when is_list(names) -> where(base_query, [c], c.name in ^names)
+        end
+
+      collections = repo.all(base_query)
 
       # Add chunk counts
       chunk_counts =
@@ -132,20 +139,26 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       name = params["name"] || ""
       description = params["description"]
 
-      case Collection.get_or_create(name, repo, description) do
-        {:ok, _collection} ->
-          {:noreply, load_data(socket)}
+      if allowed_collection?(socket.assigns.allowed_collections, name) do
+        case Collection.get_or_create(name, repo, description) do
+          {:ok, _collection} ->
+            {:noreply, load_data(socket)}
 
-        {:error, changeset} ->
-          {:noreply,
-           put_flash(socket, :error, "Failed to create collection: #{inspect(changeset.errors)}")}
+          {:error, changeset} ->
+            {:noreply,
+             put_flash(
+               socket,
+               :error,
+               "Failed to create collection: #{inspect(changeset.errors)}"
+             )}
+        end
+      else
+        {:noreply, put_flash(socket, :error, "Collection #{inspect(name)} is not allowed")}
       end
     end
 
     def handle_event("edit_collection", %{"id" => id}, socket) do
-      repo = socket.assigns.repo
-      collection = repo.get(Collection, id)
-      {:noreply, assign(socket, editing_collection: collection)}
+      {:noreply, assign(socket, editing_collection: fetch_allowed_collection(socket, id))}
     end
 
     def handle_event("cancel_edit_collection", _params, socket) do
@@ -154,20 +167,19 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     def handle_event("update_collection", %{"id" => id, "collection" => params}, socket) do
       repo = socket.assigns.repo
-      collection = repo.get!(Collection, id)
 
-      changeset =
-        Collection.changeset(collection, %{
-          name: params["name"] || collection.name,
-          description: params["description"]
-        })
+      case fetch_allowed_collection(socket, id) do
+        nil ->
+          {:noreply, put_flash(socket, :error, "Collection is not allowed")}
 
-      case repo.update(changeset) do
-        {:ok, _updated} ->
-          {:noreply, socket |> assign(editing_collection: nil) |> load_data()}
+        collection ->
+          changeset =
+            Collection.changeset(collection, %{
+              name: params["name"] || collection.name,
+              description: params["description"]
+            })
 
-        {:error, changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to update: #{inspect(changeset.errors)}")}
+          update_collection(socket, repo, changeset)
       end
     end
 
@@ -182,13 +194,38 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     def handle_event("delete_collection", %{"id" => id}, socket) do
       repo = socket.assigns.repo
 
-      case repo.get(Collection, id) do
+      case fetch_allowed_collection(socket, id) do
         nil ->
           {:noreply, assign(socket, confirm_delete_collection: nil)}
 
         collection ->
           repo.delete!(collection)
           {:noreply, socket |> assign(confirm_delete_collection: nil) |> load_data()}
+      end
+    end
+
+    defp update_collection(socket, repo, changeset) do
+      case repo.update(changeset) do
+        {:ok, _updated} ->
+          {:noreply, socket |> assign(editing_collection: nil) |> load_data()}
+
+        {:error, changeset} ->
+          {:noreply, put_flash(socket, :error, "Failed to update: #{inspect(changeset.errors)}")}
+      end
+    end
+
+    # Fetches a collection by id only when its name is inside the allowed
+    # set. Forged ids pointing at collections outside the scope resolve to
+    # nil, the same as a missing row.
+    defp fetch_allowed_collection(socket, id) do
+      case socket.assigns.repo.get(Collection, id) do
+        nil ->
+          nil
+
+        collection ->
+          if allowed_collection?(socket.assigns.allowed_collections, collection.name),
+            do: collection,
+            else: nil
       end
     end
 

--- a/lib/arcana_web/live/dashboard_components.ex
+++ b/lib/arcana_web/live/dashboard_components.ex
@@ -147,8 +147,27 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     def error_to_string(:not_accepted), do: "File type not supported"
     def error_to_string(err), do: "Error: #{inspect(err)}"
 
+    # Collection scoping helpers. `allowed` is :all (unrestricted, the
+    # default) or a list of collection names resolved by the router's
+    # :collections MFA. An empty list is a valid restriction meaning
+    # "no collections at all".
+    def allowed_collection?(:all, _name), do: true
+    def allowed_collection?(allowed, name) when is_list(allowed), do: name in allowed
+
+    @doc """
+    Filters a list of collection maps (anything with a `:name` key) down to
+    the allowed set. `:all` passes everything through untouched.
+    """
+    def filter_allowed_collections(collections, :all), do: collections
+
+    def filter_allowed_collections(collections, allowed) when is_list(allowed) do
+      Enum.filter(collections, &(&1.name in allowed))
+    end
+
     # Shared data loading functions
-    def load_stats(repo) do
+    def load_stats(repo, allowed \\ :all)
+
+    def load_stats(repo, :all) do
       import Ecto.Query
 
       doc_count = repo.aggregate(Arcana.Document, :count)
@@ -158,14 +177,46 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
       # Add graph stats if GraphRAG is available
       if Arcana.Graph.enabled?() do
-        graph_stats = load_graph_stats(repo)
+        graph_stats = load_graph_stats(repo, :all)
         Map.merge(base_stats, graph_stats)
       else
         base_stats
       end
     end
 
-    defp load_graph_stats(repo) do
+    def load_stats(repo, allowed) when is_list(allowed) do
+      import Ecto.Query
+
+      doc_count =
+        repo.one(
+          from(d in Arcana.Document,
+            join: c in assoc(d, :collection),
+            where: c.name in ^allowed,
+            select: count(d.id)
+          )
+        ) || 0
+
+      chunk_count =
+        repo.one(
+          from(ch in Arcana.Chunk,
+            join: d in Arcana.Document,
+            on: ch.document_id == d.id,
+            join: c in assoc(d, :collection),
+            where: c.name in ^allowed,
+            select: count(ch.id)
+          )
+        ) || 0
+
+      base_stats = %{documents: doc_count, chunks: chunk_count}
+
+      if Arcana.Graph.enabled?() do
+        Map.merge(base_stats, load_graph_stats(repo, allowed))
+      else
+        base_stats
+      end
+    end
+
+    defp load_graph_stats(repo, :all) do
       import Ecto.Query
 
       entity_count = repo.one(from(e in Arcana.Graph.Entity, select: count(e.id))) || 0
@@ -181,10 +232,48 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       _ -> %{}
     end
 
-    def load_collections(repo) do
+    defp load_graph_stats(repo, allowed) when is_list(allowed) do
       import Ecto.Query
 
-      repo.all(
+      collection_ids = from(c in Arcana.Collection, where: c.name in ^allowed, select: c.id)
+
+      entity_count =
+        repo.one(
+          from(e in Arcana.Graph.Entity,
+            where: e.collection_id in subquery(collection_ids),
+            select: count(e.id)
+          )
+        ) || 0
+
+      # Relationships carry no collection_id; scope through the source entity
+      relationship_count =
+        repo.one(
+          from(r in Arcana.Graph.Relationship,
+            join: e in Arcana.Graph.Entity,
+            on: r.source_id == e.id,
+            where: e.collection_id in subquery(collection_ids),
+            select: count(r.id)
+          )
+        ) || 0
+
+      community_count =
+        repo.one(
+          from(c in Arcana.Graph.Community,
+            where: c.collection_id in subquery(collection_ids),
+            select: count(c.id)
+          )
+        ) || 0
+
+      %{entities: entity_count, relationships: relationship_count, communities: community_count}
+    rescue
+      # Tables might not exist if GraphRAG not installed
+      _ -> %{}
+    end
+
+    def load_collections(repo, allowed \\ :all) do
+      import Ecto.Query
+
+      query =
         from(c in Arcana.Collection,
           left_join: d in Arcana.Document,
           on: d.collection_id == c.id,
@@ -197,19 +286,36 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             document_count: count(d.id)
           }
         )
-      )
+
+      query =
+        case allowed do
+          :all -> query
+          names when is_list(names) -> where(query, [c], c.name in ^names)
+        end
+
+      repo.all(query)
     end
 
-    def load_source_ids(repo) do
+    def load_source_ids(repo, allowed \\ :all) do
       import Ecto.Query
 
-      repo.all(
+      query =
         from(d in Arcana.Document,
           where: not is_nil(d.source_id),
           distinct: d.source_id,
           select: d.source_id
         )
-      )
+
+      query =
+        case allowed do
+          :all ->
+            query
+
+          names when is_list(names) ->
+            from(d in query, join: c in assoc(d, :collection), where: c.name in ^names)
+        end
+
+      repo.all(query)
     end
 
     def get_repo_from_session(session) do

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -48,14 +48,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_data(socket) do
       repo = socket.assigns.repo
+      allowed = socket.assigns.allowed_collections
 
       socket
-      |> assign(stats: load_stats(repo))
-      |> assign(collections: load_collections(repo))
+      |> assign(stats: load_stats(repo, allowed))
+      |> assign(collections: load_collections(repo, allowed))
       |> load_documents()
     end
 
-    defp load_documents(socket) do
+    defp load_documents(%{assigns: %{allowed_collections: :all}} = socket) do
       page = socket.assigns.page
       per_page = socket.assigns.per_page
 
@@ -77,30 +78,91 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       )
     end
 
+    # Restricted listing: Arcana.list_documents/1 only takes a single
+    # :collection, so scope by the allowed name list here. Ordering mirrors
+    # Arcana.Documents so pagination behaves identically across modes.
+    defp load_documents(%{assigns: %{allowed_collections: allowed}} = socket) do
+      repo = socket.assigns.repo
+      page = socket.assigns.page
+      per_page = socket.assigns.per_page
+
+      names =
+        case socket.assigns.filter_collection do
+          nil -> allowed
+          name -> Enum.filter([name], &(&1 in allowed))
+        end
+
+      base = from(d in Document, join: c in assoc(d, :collection), where: c.name in ^names)
+
+      total_count = repo.aggregate(base, :count)
+      total_pages = max(1, ceil(total_count / per_page))
+
+      documents =
+        base
+        |> order_by([d], desc: d.inserted_at, desc: d.id)
+        |> limit(^per_page)
+        |> offset(^((page - 1) * per_page))
+        |> preload([:collection])
+        |> repo.all()
+
+      assign(socket,
+        documents: documents,
+        total_pages: total_pages,
+        total_count: total_count
+      )
+    end
+
     defp load_document_detail(socket, doc_id) do
       repo = socket.assigns.repo
 
-      document =
-        repo.one(
-          from(d in Document,
-            where: d.id == ^doc_id,
-            preload: [:collection]
-          )
-        )
+      query = from(d in Document, where: d.id == ^doc_id, preload: [:collection])
+
+      # Forged or bookmarked ids pointing outside the allowed collections
+      # resolve to nothing, same as a missing document.
+      query =
+        case socket.assigns.allowed_collections do
+          :all ->
+            query
+
+          names when is_list(names) ->
+            from(d in query, join: c in assoc(d, :collection), where: c.name in ^names)
+        end
+
+      document = repo.one(query)
 
       if document do
-        chunks =
-          repo.all(
-            from(c in Arcana.Chunk,
-              where: c.document_id == ^doc_id,
-              order_by: c.chunk_index
-            )
-          )
-
-        assign(socket, viewing_document: %{document: document, chunks: chunks})
+        load_document_chunks(socket, document, doc_id)
       else
         socket
       end
+    end
+
+    defp load_document_chunks(socket, document, doc_id) do
+      repo = socket.assigns.repo
+
+      chunks =
+        repo.all(
+          from(c in Arcana.Chunk,
+            where: c.document_id == ^doc_id,
+            order_by: c.chunk_index
+          )
+        )
+
+      assign(socket, viewing_document: %{document: document, chunks: chunks})
+    end
+
+    defp document_in_allowed_collections?(%{assigns: %{allowed_collections: :all}}, _id),
+      do: true
+
+    defp document_in_allowed_collections?(socket, id) do
+      allowed = socket.assigns.allowed_collections
+
+      socket.assigns.repo.exists?(
+        from(d in Document,
+          join: c in assoc(d, :collection),
+          where: d.id == ^id and c.name in ^allowed
+        )
+      )
     end
 
     @impl true
@@ -124,16 +186,79 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       collection = normalize_collection(params["collection"])
       graph = params["graph"] == "true"
 
-      {:ok, _doc} =
-        Arcana.ingest(content, repo: repo, format: format, collection: collection, graph: graph)
+      if allowed_collection?(socket.assigns.allowed_collections, collection) do
+        {:ok, _doc} =
+          Arcana.ingest(content, repo: repo, format: format, collection: collection, graph: graph)
 
-      {:noreply, load_data(socket)}
+        {:noreply, load_data(socket)}
+      else
+        {:noreply, put_flash(socket, :error, "Collection #{inspect(collection)} is not allowed")}
+      end
     end
 
     def handle_event("upload_files", params, socket) do
-      repo = socket.assigns.repo
       collection = normalize_collection(params["collection"])
-      graph = params["graph"] == "true"
+
+      if allowed_collection?(socket.assigns.allowed_collections, collection) do
+        {:noreply, ingest_uploads(socket, collection, params["graph"] == "true")}
+      else
+        {:noreply,
+         assign(socket, upload_error: "Collection #{inspect(collection)} is not allowed")}
+      end
+    end
+
+    def handle_event("cancel_upload", %{"ref" => ref}, socket) do
+      {:noreply, cancel_upload(socket, :files, ref)}
+    end
+
+    def handle_event("validate_upload", _params, socket) do
+      {:noreply, socket}
+    end
+
+    def handle_event("delete", %{"id" => id}, socket) do
+      repo = socket.assigns.repo
+
+      if document_in_allowed_collections?(socket, id) do
+        case Arcana.delete(id, repo: repo) do
+          :ok -> {:noreply, load_data(socket)}
+          {:error, _reason} -> {:noreply, socket}
+        end
+      else
+        {:noreply, socket}
+      end
+    end
+
+    def handle_event("filter_by_collection", %{"collection" => collection_name}, socket) do
+      if allowed_collection?(socket.assigns.allowed_collections, collection_name) do
+        {:noreply,
+         socket |> assign(filter_collection: collection_name, page: 1) |> load_documents()}
+      else
+        {:noreply, socket}
+      end
+    end
+
+    def handle_event("clear_collection_filter", _params, socket) do
+      {:noreply, socket |> assign(filter_collection: nil, page: 1) |> load_documents()}
+    end
+
+    def handle_event("build_graph", _params, socket) do
+      %{document: document, chunks: chunks} = socket.assigns.viewing_document
+      collection = document.collection
+      repo = socket.assigns.repo
+      parent = self()
+
+      socket = assign(socket, graph_indexing: true)
+
+      ArcanaWeb.TaskSupervisor.start_child(fn ->
+        result = Arcana.Graph.build_and_persist(chunks, collection, repo, [])
+        send(parent, {:graph_complete, result})
+      end)
+
+      {:noreply, socket}
+    end
+
+    defp ingest_uploads(socket, collection, graph) do
+      repo = socket.assigns.repo
 
       uploaded_files =
         consume_uploaded_entries(socket, :files, fn %{path: path}, entry ->
@@ -161,49 +286,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           assign(socket, upload_error: "Some files failed: #{error_msg}")
         end
 
-      {:noreply, load_data(socket)}
-    end
-
-    def handle_event("cancel_upload", %{"ref" => ref}, socket) do
-      {:noreply, cancel_upload(socket, :files, ref)}
-    end
-
-    def handle_event("validate_upload", _params, socket) do
-      {:noreply, socket}
-    end
-
-    def handle_event("delete", %{"id" => id}, socket) do
-      repo = socket.assigns.repo
-
-      case Arcana.delete(id, repo: repo) do
-        :ok -> {:noreply, load_data(socket)}
-        {:error, _reason} -> {:noreply, socket}
-      end
-    end
-
-    def handle_event("filter_by_collection", %{"collection" => collection_name}, socket) do
-      {:noreply,
-       socket |> assign(filter_collection: collection_name, page: 1) |> load_documents()}
-    end
-
-    def handle_event("clear_collection_filter", _params, socket) do
-      {:noreply, socket |> assign(filter_collection: nil, page: 1) |> load_documents()}
-    end
-
-    def handle_event("build_graph", _params, socket) do
-      %{document: document, chunks: chunks} = socket.assigns.viewing_document
-      collection = document.collection
-      repo = socket.assigns.repo
-      parent = self()
-
-      socket = assign(socket, graph_indexing: true)
-
-      ArcanaWeb.TaskSupervisor.start_child(fn ->
-        result = Arcana.Graph.build_and_persist(chunks, collection, repo, [])
-        send(parent, {:graph_complete, result})
-      end)
-
-      {:noreply, socket}
+      load_data(socket)
     end
 
     @impl true
@@ -273,7 +356,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
                     <label>
                       Collection
                       <select name="collection">
-                        <option value="">default</option>
+                        <%= if allowed_collection?(@allowed_collections, "default") do %>
+                          <option value="">default</option>
+                        <% end %>
                         <%= for collection <- @collections do %>
                           <option value={collection.name}><%= collection.name %></option>
                         <% end %>
@@ -310,7 +395,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
                 <label>
                   Collection
                   <select name="collection">
-                    <option value="">default</option>
+                    <%= if allowed_collection?(@allowed_collections, "default") do %>
+                      <option value="">default</option>
+                    <% end %>
                     <%= for collection <- @collections do %>
                       <option value={collection.name}><%= collection.name %></option>
                     <% end %>

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -151,18 +151,41 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       assign(socket, viewing_document: %{document: document, chunks: chunks})
     end
 
-    defp document_in_allowed_collections?(%{assigns: %{allowed_collections: :all}}, _id),
-      do: true
+    # A forged id that isn't a UUID can't match anything, so it's rejected
+    # before it reaches a query that would raise on the cast.
+    defp delete_document(socket, id) do
+      case Ecto.UUID.cast(id) do
+        {:ok, uuid} -> delete_document(socket, uuid, socket.assigns.allowed_collections)
+        :error -> :error
+      end
+    end
 
-    defp document_in_allowed_collections?(socket, id) do
-      allowed = socket.assigns.allowed_collections
+    defp delete_document(socket, uuid, :all) do
+      case Arcana.delete(uuid, repo: socket.assigns.repo) do
+        :ok -> :ok
+        {:error, _reason} -> :error
+      end
+    end
 
-      socket.assigns.repo.exists?(
+    # Restricted deletes are a single statement: the allowed-collection
+    # predicate rides inside the DELETE, so a rename that moves the
+    # collection out of scope between the allow-check and the delete can't
+    # slip through a stale decision. Zero rows affected means the document
+    # wasn't in scope (or never existed) and the event is rejected. Chunks
+    # and graph rows cascade at the database level, same as
+    # `Arcana.delete/2`.
+    defp delete_document(socket, uuid, allowed) do
+      allowed_ids = from(c in Arcana.Collection, where: c.name in ^allowed, select: c.id)
+
+      query =
         from(d in Document,
-          join: c in assoc(d, :collection),
-          where: d.id == ^id and c.name in ^allowed
+          where: d.id == ^uuid and d.collection_id in subquery(allowed_ids)
         )
-      )
+
+      case socket.assigns.repo.delete_all(query) do
+        {0, _} -> :error
+        {_count, _} -> :ok
+      end
     end
 
     @impl true
@@ -216,15 +239,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     def handle_event("delete", %{"id" => id}, socket) do
-      repo = socket.assigns.repo
-
-      if document_in_allowed_collections?(socket, id) do
-        case Arcana.delete(id, repo: repo) do
-          :ok -> {:noreply, load_data(socket)}
-          {:error, _reason} -> {:noreply, socket}
-        end
-      else
-        {:noreply, socket}
+      case delete_document(socket, id) do
+        :ok -> {:noreply, load_data(socket)}
+        :error -> {:noreply, socket}
       end
     end
 

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -195,7 +195,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     def handle_event("view_document", %{"id" => id}, socket) do
-      {:noreply, load_document_detail(socket, id)}
+      case Ecto.UUID.cast(id) do
+        {:ok, uuid} -> {:noreply, load_document_detail(socket, uuid)}
+        :error -> {:noreply, socket}
+      end
     end
 
     def handle_event("close_detail", _params, socket) do
@@ -256,6 +259,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     def handle_event("clear_collection_filter", _params, socket) do
       {:noreply, socket |> assign(filter_collection: nil, page: 1) |> load_documents()}
+    end
+
+    # Only reachable from the open document detail panel; a forged event
+    # with no document open has nothing to build a graph from.
+    def handle_event("build_graph", _params, %{assigns: %{viewing_document: nil}} = socket) do
+      {:noreply, socket}
     end
 
     def handle_event("build_graph", _params, socket) do

--- a/lib/arcana_web/live/evaluation_live.ex
+++ b/lib/arcana_web/live/evaluation_live.ex
@@ -51,10 +51,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_evaluation_data(socket) do
       repo = socket.assigns.repo
+      opts = eval_opts(socket)
 
-      test_cases = Evaluation.list_test_cases(repo: repo)
-      runs = Evaluation.list_runs(repo: repo, limit: 10)
-      test_case_count = Evaluation.count_test_cases(repo: repo)
+      test_cases = Evaluation.list_test_cases(opts)
+      runs = Evaluation.list_runs(Keyword.put(opts, :limit, 10))
+      test_case_count = Evaluation.count_test_cases(opts)
       collections = load_collections(repo, socket.assigns.allowed_collections)
 
       assign(socket,
@@ -65,13 +66,22 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       )
     end
 
+    # Evaluation data (test cases, runs, counts) is scoped through the
+    # allow-list: test cases reach a collection through their chunks, runs
+    # through the scope they recorded when they ran.
+    defp eval_opts(socket) do
+      case socket.assigns.allowed_collections do
+        :all -> [repo: socket.assigns.repo]
+        allowed when is_list(allowed) -> [repo: socket.assigns.repo, collections: allowed]
+      end
+    end
+
     @impl true
     def handle_event("eval_switch_view", %{"view" => view}, socket) do
       {:noreply, assign(socket, eval_view: parse_eval_view(view))}
     end
 
     def handle_event("eval_run", params, socket) do
-      repo = socket.assigns.repo
       mode = parse_mode(params["mode"])
       retriever_name = params["retriever"] || "pipeline"
       evaluate_answers = params["evaluate_answers"] == "true"
@@ -80,53 +90,21 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       llm = Arcana.Config.get_env(:llm)
       needs_llm? = evaluate_answers or retriever_name == "loop"
 
-      if needs_llm? and is_nil(llm) do
-        {:noreply,
-         assign(socket,
-           eval_message: {:error, "No LLM configured. Set :arcana, :llm in your config."}
-         )}
-      else
-        socket =
-          assign(socket,
-            eval_running: true,
-            eval_message: nil,
-            eval_progress: %{
-              done: 0,
-              total: socket.assigns.eval_test_case_count,
-              started_at: System.monotonic_time(:millisecond)
-            }
-          )
+      cond do
+        # An empty allow-list has no collection to retrieve from, and an
+        # empty `:collections` option means "everything" downstream, so the
+        # run is refused outright rather than scoped to nothing.
+        socket.assigns.allowed_collections == [] ->
+          {:noreply, assign(socket, eval_message: {:error, "No collections are available"})}
 
-        opts = build_run_opts(repo, mode, evaluate_answers, llm, retriever_name)
+        needs_llm? and is_nil(llm) ->
+          {:noreply,
+           assign(socket,
+             eval_message: {:error, "No LLM configured. Set :arcana, :llm in your config."}
+           )}
 
-        parent = self()
-        handler_id = "eval-progress-#{inspect(parent)}"
-
-        :telemetry.attach_many(
-          handler_id,
-          [
-            [:arcana, :evaluation, :test_case, :start],
-            [:arcana, :evaluation, :test_case, :complete]
-          ],
-          fn event, measurements, metadata, _config ->
-            send(parent, {:eval_progress, event, measurements, metadata})
-          end,
-          nil
-        )
-
-        Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
-          result = Evaluation.run(opts)
-          :telemetry.detach(handler_id)
-          send(parent, {:eval_run_complete, result})
-        end)
-
-        # Self-tick every second so the elapsed-time counter updates live
-        # while a test case is in flight. LiveView only re-renders on
-        # messages; without a tick the elapsed-time label freezes at
-        # whatever it was when the last telemetry event fired.
-        Process.send_after(self(), :eval_tick, 1000)
-
-        {:noreply, socket}
+        true ->
+          {:noreply, start_eval_run(socket, mode, evaluate_answers, llm, retriever_name)}
       end
     end
 
@@ -143,28 +121,89 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       end
     end
 
+    # Only test cases the scoped listing already returned can be expanded:
+    # the detail view renders the reference answer and raw chunk text, so a
+    # forged id has to be a no-op rather than a read.
     def handle_event("toggle_test_case", %{"id" => id}, socket) do
-      current = socket.assigns.expanded_test_case_id
-      next = if current == id, do: nil, else: id
-      {:noreply, assign(socket, expanded_test_case_id: next)}
+      cond do
+        socket.assigns.expanded_test_case_id == id ->
+          {:noreply, assign(socket, expanded_test_case_id: nil)}
+
+        Enum.any?(socket.assigns.eval_test_cases, &(&1.id == id)) ->
+          {:noreply, assign(socket, expanded_test_case_id: id)}
+
+        true ->
+          {:noreply, socket}
+      end
     end
 
     def handle_event("eval_delete_test_case", %{"id" => id}, socket) do
-      repo = socket.assigns.repo
-
-      case Evaluation.delete_test_case(id, repo: repo) do
+      case Evaluation.delete_test_case(id, eval_opts(socket)) do
         {:ok, _} -> {:noreply, load_evaluation_data(socket)}
         {:error, _} -> {:noreply, socket}
       end
     end
 
     def handle_event("eval_delete_run", %{"id" => id}, socket) do
-      repo = socket.assigns.repo
-
-      case Evaluation.delete_run(id, repo: repo) do
+      case Evaluation.delete_run(id, eval_opts(socket)) do
         {:ok, _} -> {:noreply, load_evaluation_data(socket)}
         {:error, _} -> {:noreply, socket}
       end
+    end
+
+    defp start_eval_run(socket, mode, evaluate_answers, llm, retriever_name) do
+      socket =
+        assign(socket,
+          eval_running: true,
+          eval_message: nil,
+          eval_progress: %{
+            done: 0,
+            total: socket.assigns.eval_test_case_count,
+            started_at: System.monotonic_time(:millisecond),
+            # The progress handler updates :current with map-update syntax,
+            # which needs the key to exist from the start.
+            current: nil
+          }
+        )
+
+      # Telemetry handlers are global: without a ref to match on, a
+      # dashboard's progress panel echoes the questions of every evaluation
+      # running anywhere in the VM, including other tenants' dashboards and
+      # mix tasks.
+      run_ref = make_ref()
+      opts = build_run_opts(socket, mode, evaluate_answers, llm, retriever_name)
+      opts = Keyword.put(opts, :run_ref, run_ref)
+
+      parent = self()
+      handler_id = "eval-progress-#{inspect(parent)}"
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:arcana, :evaluation, :test_case, :start],
+          [:arcana, :evaluation, :test_case, :complete]
+        ],
+        fn event, measurements, metadata, _config ->
+          if metadata[:run_ref] == run_ref do
+            send(parent, {:eval_progress, event, measurements, metadata})
+          end
+        end,
+        nil
+      )
+
+      Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
+        result = Evaluation.run(opts)
+        :telemetry.detach(handler_id)
+        send(parent, {:eval_run_complete, result})
+      end)
+
+      # Self-tick every second so the elapsed-time counter updates live
+      # while a test case is in flight. LiveView only re-renders on
+      # messages; without a tick the elapsed-time label freezes at
+      # whatever it was when the last telemetry event fired.
+      Process.send_after(self(), :eval_tick, 1000)
+
+      socket
     end
 
     # nil means "sample from every collection", which restricted dashboards
@@ -294,14 +333,25 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       {:noreply, socket}
     end
 
-    defp build_run_opts(repo, mode, evaluate_answers, llm, retriever_name) do
-      base =
-        [repo: repo, mode: mode]
-        |> maybe_put_evaluate_answers(evaluate_answers, llm)
-        |> maybe_put_retriever(retriever_name, repo, llm)
+    defp build_run_opts(socket, mode, evaluate_answers, llm, retriever_name) do
+      repo = socket.assigns.repo
+      allowed = socket.assigns.allowed_collections
 
-      base
+      [repo: repo, mode: mode]
+      |> maybe_put_eval_scope(allowed)
+      |> maybe_put_evaluate_answers(evaluate_answers, llm)
+      |> maybe_put_retriever(retriever_name, repo, llm, allowed)
     end
+
+    # Running an evaluation is retrieval over the whole corpus by default:
+    # every test case searches every collection. A restricted dashboard
+    # confines both the test case set and the searches to its allow-list,
+    # strictly, so an allowed name with no collection row fails the search
+    # instead of widening it.
+    defp maybe_put_eval_scope(opts, :all), do: opts
+
+    defp maybe_put_eval_scope(opts, allowed) when is_list(allowed),
+      do: Keyword.merge(opts, collections: allowed, strict_collections: true)
 
     defp maybe_put_evaluate_answers(opts, false, _llm), do: opts
 
@@ -310,10 +360,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     # Pipeline is the default — no :retriever needed, Arcana.Evaluation.run/1
-    # falls back to &Arcana.search/2.
-    defp maybe_put_retriever(opts, "pipeline", _repo, _llm), do: opts
+    # falls back to &Arcana.search/2 with the run's scope opts.
+    defp maybe_put_retriever(opts, "pipeline", _repo, _llm, _allowed), do: opts
 
-    defp maybe_put_retriever(opts, "loop", repo, llm) do
+    defp maybe_put_retriever(opts, "loop", repo, llm, allowed) do
       # Loop retriever: run a full Arcana.Loop.run/2 per test case and
       # return the 3-tuple {:ok, chunks, answer}. The answer is the one
       # the loop produced, so when evaluate_answers: true is on, the
@@ -321,9 +371,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       runner = loop_runner()
 
       retriever = fn question, _opts ->
-        ctx = Arcana.Loop.new(question, repo: repo)
+        ctx = Arcana.Loop.new(question, loop_new_opts(repo, allowed))
 
-        case runner.(ctx, controller_llm: llm) do
+        case runner.(ctx, loop_run_opts(llm, allowed)) do
           {:ok, %Arcana.Loop.Context{} = result_ctx} ->
             {:ok, result_ctx.chunks, result_ctx.answer}
 
@@ -334,6 +384,20 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
       Keyword.put(opts, :retriever, retriever)
     end
+
+    # An unscoped Arcana.Loop.new/2 leaves ctx.collections as [nil], which
+    # is the whole corpus. The Loop reaches Arcana.search/2 through its
+    # search tool, which merges :search_opts over the collection opts it
+    # derives from the context — same wiring ask_live uses.
+    defp loop_new_opts(repo, :all), do: [repo: repo]
+
+    defp loop_new_opts(repo, allowed) when is_list(allowed),
+      do: [repo: repo, collections: allowed]
+
+    defp loop_run_opts(llm, :all), do: [controller_llm: llm]
+
+    defp loop_run_opts(llm, allowed) when is_list(allowed),
+      do: [controller_llm: llm, search_opts: [strict_collections: true]]
 
     # Testability seam — same pattern used in ask_live.ex so tests can
     # stub Loop execution without spinning up a real controller.

--- a/lib/arcana_web/live/evaluation_live.ex
+++ b/lib/arcana_web/live/evaluation_live.ex
@@ -45,7 +45,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       repo = socket.assigns.repo
 
       socket
-      |> assign(stats: load_stats(repo))
+      |> assign(stats: load_stats(repo, socket.assigns.allowed_collections))
       |> load_evaluation_data()
     end
 
@@ -55,7 +55,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       test_cases = Evaluation.list_test_cases(repo: repo)
       runs = Evaluation.list_runs(repo: repo, limit: 10)
       test_case_count = Evaluation.count_test_cases(repo: repo)
-      collections = load_collections(repo)
+      collections = load_collections(repo, socket.assigns.allowed_collections)
 
       assign(socket,
         eval_test_cases: test_cases,
@@ -135,25 +135,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       sample_size = parse_int(params["sample_size"], 10)
       collection = blank_to_nil(params["collection"])
 
-      case Arcana.Config.get_env(:llm) do
-        nil ->
-          {:noreply,
-           assign(socket,
-             eval_message: {:error, "No LLM configured. Set :arcana, :llm in your config."}
-           )}
-
-        llm ->
-          socket = assign(socket, eval_generating: true, eval_message: nil)
-
-          parent = self()
-          opts = build_generate_opts(repo, llm, sample_size, collection)
-
-          Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
-            result = Evaluation.generate_test_cases(opts)
-            send(parent, {:eval_generate_complete, result})
-          end)
-
-          {:noreply, socket}
+      if eval_collection_allowed?(socket, collection) do
+        generate_test_cases(socket, repo, sample_size, collection)
+      else
+        {:noreply,
+         assign(socket, eval_message: {:error, "The selected collection is not allowed"})}
       end
     end
 
@@ -178,6 +164,38 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       case Evaluation.delete_run(id, repo: repo) do
         {:ok, _} -> {:noreply, load_evaluation_data(socket)}
         {:error, _} -> {:noreply, socket}
+      end
+    end
+
+    # nil means "sample from every collection", which restricted dashboards
+    # must not do; they need a concrete allowed collection.
+    defp eval_collection_allowed?(socket, collection) do
+      case socket.assigns.allowed_collections do
+        :all -> true
+        allowed -> is_binary(collection) and collection in allowed
+      end
+    end
+
+    defp generate_test_cases(socket, repo, sample_size, collection) do
+      case Arcana.Config.get_env(:llm) do
+        nil ->
+          {:noreply,
+           assign(socket,
+             eval_message: {:error, "No LLM configured. Set :arcana, :llm in your config."}
+           )}
+
+        llm ->
+          socket = assign(socket, eval_generating: true, eval_message: nil)
+
+          parent = self()
+          opts = build_generate_opts(repo, llm, sample_size, collection)
+
+          Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
+            result = Evaluation.generate_test_cases(opts)
+            send(parent, {:eval_generate_complete, result})
+          end)
+
+          {:noreply, socket}
       end
     end
 
@@ -425,6 +443,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
                 test_cases={@eval_test_cases}
                 generating={@eval_generating}
                 collections={@collections}
+                all_collections_allowed={@allowed_collections == :all}
                 expanded_id={@expanded_test_case_id}
               />
             <% :run -> %>
@@ -449,12 +468,16 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             <div class="arcana-eval-field">
               <label class="arcana-eval-field-label" for="eval-collection">Collection</label>
               <select name="collection" id="eval-collection" class="arcana-eval-select">
-                <option value="">All collections</option>
+                <%= if @all_collections_allowed do %>
+                  <option value="">All collections</option>
+                <% end %>
                 <%= for col <- @collections do %>
                   <option value={col.name}><%= col.name %></option>
                 <% end %>
               </select>
-              <small class="arcana-eval-hint">Leave blank to sample from every collection.</small>
+              <%= if @all_collections_allowed do %>
+                <small class="arcana-eval-hint">Leave blank to sample from every collection.</small>
+              <% end %>
             </div>
 
             <div class="arcana-eval-field">

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -97,7 +97,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       repo = socket.assigns.repo
 
       socket
-      |> assign(stats: load_stats(repo))
+      |> assign(stats: load_stats(repo, socket.assigns.allowed_collections))
       |> load_collections_with_graph_status()
       |> load_subtab_data()
     end
@@ -135,45 +135,47 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       assign(socket, collections: collections)
     end
 
-    # Restricted mode always queries a concrete allowed collection. When no
-    # selection resolves to a collection id (empty allowed set, or an allowed
-    # name with no matching collection row) render nothing rather than fall
-    # through to the unscoped "all collections" queries.
-    defp load_subtab_data(%{assigns: %{allowed_collections: allowed}} = socket)
-         when is_list(allowed) do
-      if get_selected_collection_id(socket) do
-        dispatch_subtab_data(socket)
-      else
-        assign(socket,
-          entities: [],
-          entities_total: 0,
-          entity_types: [],
-          relationships: [],
-          relationships_total: 0,
-          relationship_types: [],
-          communities: [],
-          communities_total: 0
-        )
-      end
-    end
-
-    defp load_subtab_data(socket), do: dispatch_subtab_data(socket)
-
-    defp dispatch_subtab_data(%{assigns: %{current_subtab: :entities}} = socket) do
+    defp load_subtab_data(%{assigns: %{current_subtab: :entities}} = socket) do
       load_entities(socket)
     end
 
-    defp dispatch_subtab_data(%{assigns: %{current_subtab: :relationships}} = socket) do
+    defp load_subtab_data(%{assigns: %{current_subtab: :relationships}} = socket) do
       load_relationships(socket)
     end
 
-    defp dispatch_subtab_data(%{assigns: %{current_subtab: :communities}} = socket) do
+    defp load_subtab_data(%{assigns: %{current_subtab: :communities}} = socket) do
       load_communities(socket)
     end
 
+    # The one place every loader resolves its scope. Restricted mode always
+    # queries a concrete allowed collection: when the selection resolves to
+    # no collection id (empty allowed set, or an allowed name with no
+    # matching collection row) the loaders bail out with empty results
+    # rather than fall through to the unscoped "all collections" queries.
+    #
+    # This has to live in the loaders, not in handle_params: forged filter
+    # and pagination events call the loaders directly and would otherwise
+    # skip the normalization entirely.
+    defp scoped_collection_id(%{assigns: %{allowed_collections: :all}} = socket) do
+      {:ok, get_selected_collection_id(socket)}
+    end
+
+    defp scoped_collection_id(socket) do
+      case get_selected_collection_id(socket) do
+        nil -> :error
+        collection_id -> {:ok, collection_id}
+      end
+    end
+
     defp load_entities(socket) do
+      case scoped_collection_id(socket) do
+        {:ok, collection_id} -> load_entities(socket, collection_id)
+        :error -> assign(socket, entities: [], entities_total: 0, entity_types: [])
+      end
+    end
+
+    defp load_entities(socket, collection_id) do
       repo = socket.assigns.repo
-      collection_id = get_selected_collection_id(socket)
       name_filter = socket.assigns.entity_filter || ""
       type_filter = socket.assigns.entity_type_filter
       page = socket.assigns.entities_page
@@ -254,8 +256,21 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     defp load_relationships(socket) do
+      case scoped_collection_id(socket) do
+        {:ok, collection_id} ->
+          load_relationships(socket, collection_id)
+
+        :error ->
+          assign(socket,
+            relationships: [],
+            relationships_total: 0,
+            relationship_types: []
+          )
+      end
+    end
+
+    defp load_relationships(socket, collection_id) do
       repo = socket.assigns.repo
-      collection_id = get_selected_collection_id(socket)
       search_filter = socket.assigns.relationship_filter
       type_filter = socket.assigns.relationship_type_filter
       strength_filter = socket.assigns.relationship_strength_filter
@@ -332,8 +347,14 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     defp load_communities(socket) do
+      case scoped_collection_id(socket) do
+        {:ok, collection_id} -> load_communities(socket, collection_id)
+        :error -> assign(socket, communities: [], communities_total: 0)
+      end
+    end
+
+    defp load_communities(socket, collection_id) do
       repo = socket.assigns.repo
-      collection_id = get_selected_collection_id(socket)
       search_filter = socket.assigns.community_filter
       level_filter = socket.assigns.community_level_filter
       page = socket.assigns.communities_page

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -69,12 +69,28 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           _ -> :entities
         end
 
-      selected_collection = params["collection"]
+      selected_collection =
+        normalize_selected_collection(params["collection"], socket.assigns.allowed_collections)
 
       {:noreply,
        socket
        |> assign(current_subtab: subtab, selected_collection: selected_collection)
        |> load_data()}
+    end
+
+    # Unrestricted dashboards keep the param as-is (nil means "all
+    # collections"). Restricted ones must never query unscoped, so a missing
+    # or disallowed name is forced to the first allowed collection instead
+    # of falling through to nil. This runs before load_data/1 so a forged
+    # collection param can't resolve to an unscoped query.
+    defp normalize_selected_collection(selected, :all), do: selected
+
+    defp normalize_selected_collection(selected, allowed) do
+      if is_binary(selected) and selected in allowed do
+        selected
+      else
+        List.first(allowed)
+      end
     end
 
     defp load_data(socket) do
@@ -89,21 +105,29 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp load_collections_with_graph_status(socket) do
       repo = socket.assigns.repo
 
-      collections =
-        repo.all(
-          from(c in Arcana.Collection,
-            left_join: e in Entity,
-            on: e.collection_id == c.id,
-            group_by: c.id,
-            order_by: c.name,
-            select: %{
-              id: c.id,
-              name: c.name,
-              description: c.description,
-              entity_count: count(e.id, :distinct)
-            }
-          )
+      query =
+        from(c in Arcana.Collection,
+          left_join: e in Entity,
+          on: e.collection_id == c.id,
+          group_by: c.id,
+          order_by: c.name,
+          select: %{
+            id: c.id,
+            name: c.name,
+            description: c.description,
+            entity_count: count(e.id, :distinct)
+          }
         )
+
+      query =
+        case socket.assigns.allowed_collections do
+          :all -> query
+          names when is_list(names) -> where(query, [c], c.name in ^names)
+        end
+
+      collections =
+        query
+        |> repo.all()
         |> Enum.map(fn c ->
           Map.put(c, :graph_enabled, c.entity_count > 0)
         end)
@@ -111,15 +135,39 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       assign(socket, collections: collections)
     end
 
-    defp load_subtab_data(%{assigns: %{current_subtab: :entities}} = socket) do
+    # Restricted mode always queries a concrete allowed collection. When no
+    # selection resolves to a collection id (empty allowed set, or an allowed
+    # name with no matching collection row) render nothing rather than fall
+    # through to the unscoped "all collections" queries.
+    defp load_subtab_data(%{assigns: %{allowed_collections: allowed}} = socket)
+         when is_list(allowed) do
+      if get_selected_collection_id(socket) do
+        dispatch_subtab_data(socket)
+      else
+        assign(socket,
+          entities: [],
+          entities_total: 0,
+          entity_types: [],
+          relationships: [],
+          relationships_total: 0,
+          relationship_types: [],
+          communities: [],
+          communities_total: 0
+        )
+      end
+    end
+
+    defp load_subtab_data(socket), do: dispatch_subtab_data(socket)
+
+    defp dispatch_subtab_data(%{assigns: %{current_subtab: :entities}} = socket) do
       load_entities(socket)
     end
 
-    defp load_subtab_data(%{assigns: %{current_subtab: :relationships}} = socket) do
+    defp dispatch_subtab_data(%{assigns: %{current_subtab: :relationships}} = socket) do
       load_relationships(socket)
     end
 
-    defp load_subtab_data(%{assigns: %{current_subtab: :communities}} = socket) do
+    defp dispatch_subtab_data(%{assigns: %{current_subtab: :communities}} = socket) do
       load_communities(socket)
     end
 
@@ -361,7 +409,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     def handle_event("select_entity", %{"id" => id}, socket) do
       details = load_entity_details(socket.assigns.repo, id)
-      {:noreply, assign(socket, selected_entity: id, entity_details: details)}
+
+      if entity_allowed?(socket, details.entity) do
+        {:noreply, assign(socket, selected_entity: id, entity_details: details)}
+      else
+        {:noreply, socket}
+      end
     end
 
     def handle_event("close_entity_detail", _params, socket) do
@@ -386,7 +439,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     def handle_event("select_relationship", %{"id" => id}, socket) do
       details = load_relationship_details(socket.assigns.repo, id)
-      {:noreply, assign(socket, selected_relationship: id, relationship_details: details)}
+
+      if relationship_allowed?(socket, details.relationship) do
+        {:noreply, assign(socket, selected_relationship: id, relationship_details: details)}
+      else
+        {:noreply, socket}
+      end
     end
 
     def handle_event("close_relationship_detail", _params, socket) do
@@ -409,7 +467,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     def handle_event("select_community", %{"id" => id}, socket) do
       details = load_community_details(socket.assigns.repo, id)
-      {:noreply, assign(socket, selected_community: id, community_details: details)}
+
+      if community_allowed?(socket, details.community) do
+        {:noreply, assign(socket, selected_community: id, community_details: details)}
+      else
+        {:noreply, socket}
+      end
     end
 
     def handle_event("close_community_detail", _params, socket) do
@@ -515,6 +578,37 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       Enum.any?(collections, & &1.graph_enabled)
     end
 
+    # Guards for detail panels opened by id: forged ids pointing at graph
+    # data outside the allowed collections are ignored. Unrestricted
+    # dashboards keep today's behavior, including nil records for unknown
+    # ids. The @collections assign is already filtered to the allowed set,
+    # so membership by collection_id is the whole check.
+    defp entity_allowed?(%{assigns: %{allowed_collections: :all}}, _entity), do: true
+    defp entity_allowed?(_socket, nil), do: false
+
+    defp entity_allowed?(socket, entity) do
+      Enum.any?(socket.assigns.collections, &(&1.id == entity.collection_id))
+    end
+
+    defp relationship_allowed?(%{assigns: %{allowed_collections: :all}}, _rel), do: true
+    defp relationship_allowed?(_socket, nil), do: false
+
+    # Relationships carry no collection_id, so scope through the source
+    # entity, mirroring how the relationship listings are scoped.
+    defp relationship_allowed?(socket, relationship) do
+      case GraphStore.get_entity(relationship.source_id, repo: socket.assigns.repo) do
+        {:ok, entity} -> entity_allowed?(socket, entity)
+        {:error, :not_found} -> false
+      end
+    end
+
+    defp community_allowed?(%{assigns: %{allowed_collections: :all}}, _community), do: true
+    defp community_allowed?(_socket, nil), do: false
+
+    defp community_allowed?(socket, community) do
+      Enum.any?(socket.assigns.collections, &(&1.id == community.collection_id))
+    end
+
     defp get_selected_collection_id(socket) do
       selected_name = socket.assigns.selected_collection
 
@@ -550,7 +644,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           <div class="arcana-collection-selector">
             <label>Collection:</label>
             <select phx-change="select_collection" name="collection">
-              <option value="">All Collections</option>
+              <%= if @allowed_collections == :all do %>
+                <option value="">All Collections</option>
+              <% end %>
               <%= for coll <- @collections do %>
                 <option value={coll.name} selected={@selected_collection == coll.name}>
                   <%= coll.name %>

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -429,13 +429,13 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     def handle_event("select_entity", %{"id" => id}, socket) do
-      details = load_entity_details(socket.assigns.repo, id)
+      with_uuid(socket, id, fn uuid ->
+        details = load_entity_details(socket.assigns.repo, uuid)
 
-      if entity_allowed?(socket, details.entity) do
-        {:noreply, assign(socket, selected_entity: id, entity_details: details)}
-      else
-        {:noreply, socket}
-      end
+        if entity_allowed?(socket, details.entity),
+          do: assign(socket, selected_entity: uuid, entity_details: details),
+          else: socket
+      end)
     end
 
     def handle_event("close_entity_detail", _params, socket) do
@@ -459,13 +459,13 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     def handle_event("select_relationship", %{"id" => id}, socket) do
-      details = load_relationship_details(socket.assigns.repo, id)
+      with_uuid(socket, id, fn uuid ->
+        details = load_relationship_details(socket.assigns.repo, uuid)
 
-      if relationship_allowed?(socket, details.relationship) do
-        {:noreply, assign(socket, selected_relationship: id, relationship_details: details)}
-      else
-        {:noreply, socket}
-      end
+        if relationship_allowed?(socket, details.relationship),
+          do: assign(socket, selected_relationship: uuid, relationship_details: details),
+          else: socket
+      end)
     end
 
     def handle_event("close_relationship_detail", _params, socket) do
@@ -487,13 +487,13 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     def handle_event("select_community", %{"id" => id}, socket) do
-      details = load_community_details(socket.assigns.repo, id)
+      with_uuid(socket, id, fn uuid ->
+        details = load_community_details(socket.assigns.repo, uuid)
 
-      if community_allowed?(socket, details.community) do
-        {:noreply, assign(socket, selected_community: id, community_details: details)}
-      else
-        {:noreply, socket}
-      end
+        if community_allowed?(socket, details.community),
+          do: assign(socket, selected_community: uuid, community_details: details),
+          else: socket
+      end)
     end
 
     def handle_event("close_community_detail", _params, socket) do
@@ -597,6 +597,16 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp has_any_graph_data?(collections) do
       Enum.any?(collections, & &1.graph_enabled)
+    end
+
+    # A forged id that isn't a UUID can't match any row, so it's rejected
+    # before it reaches a query that would raise an Ecto.Query.CastError
+    # (a 500) while casting it.
+    defp with_uuid(socket, id, fun) do
+      case Ecto.UUID.cast(id) do
+        {:ok, uuid} -> {:noreply, fun.(uuid)}
+        :error -> {:noreply, socket}
+      end
     end
 
     # Guards for detail panels opened by id: forged ids pointing at graph

--- a/lib/arcana_web/live/info_live.ex
+++ b/lib/arcana_web/live/info_live.ex
@@ -31,7 +31,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       repo = socket.assigns.repo
 
       socket
-      |> assign(stats: load_stats(repo))
+      |> assign(stats: load_stats(repo, socket.assigns.allowed_collections))
     end
 
     defp get_config_info do

--- a/lib/arcana_web/live/maintenance_live.ex
+++ b/lib/arcana_web/live/maintenance_live.ex
@@ -46,19 +46,41 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_data(socket) do
       repo = socket.assigns.repo
-      collections = fetch_collections(repo)
+      allowed = socket.assigns.allowed_collections
+      collections = fetch_collections(repo, allowed)
 
       socket
-      |> assign(stats: load_stats(repo))
+      |> assign(stats: load_stats(repo, allowed))
       |> assign(collections: Enum.map(collections, & &1.name))
       |> assign(collections_for_assign: collections)
       |> assign(orphaned_stats: count_orphaned_graph_data(repo))
     end
 
-    defp fetch_collections(repo) do
-      repo.all(from(c in Arcana.Collection, select: %{id: c.id, name: c.name}, order_by: c.name))
+    defp fetch_collections(repo, allowed) do
+      query = from(c in Arcana.Collection, select: %{id: c.id, name: c.name}, order_by: c.name)
+
+      query =
+        case allowed do
+          :all -> query
+          names when is_list(names) -> where(query, [c], c.name in ^names)
+        end
+
+      repo.all(query)
     rescue
       _ -> []
+    end
+
+    # Maintenance actions take a collection selection where nil means "all
+    # collections". Restricted dashboards must never run a global action, so
+    # nil (and any name outside the allowed set) is rejected.
+    defp validate_maintenance_collection(socket, collection) do
+      allowed = socket.assigns.allowed_collections
+
+      cond do
+        allowed == :all -> {:ok, collection}
+        is_binary(collection) and collection in allowed -> {:ok, collection}
+        true -> :error
+      end
     end
 
     defp count_orphaned_graph_data(repo) do
@@ -99,12 +121,125 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     @impl true
     def handle_event("select_reembed_collection", %{"collection" => collection}, socket) do
       collection = if collection == "", do: nil, else: collection
-      {:noreply, assign(socket, reembed_collection: collection)}
+
+      case validate_maintenance_collection(socket, collection) do
+        {:ok, collection} -> {:noreply, assign(socket, reembed_collection: collection)}
+        :error -> {:noreply, socket}
+      end
     end
 
     def handle_event("reembed", _params, socket) do
+      case validate_maintenance_collection(socket, socket.assigns.reembed_collection) do
+        {:ok, collection} -> {:noreply, start_reembed(socket, collection)}
+        :error -> {:noreply, put_flash(socket, :error, "Select an allowed collection first")}
+      end
+    end
+
+    def handle_event("select_rebuild_collection", %{"collection" => collection}, socket) do
+      collection = if collection == "", do: nil, else: collection
+
+      case validate_maintenance_collection(socket, collection) do
+        {:ok, collection} -> {:noreply, assign(socket, rebuild_graph_collection: collection)}
+        :error -> {:noreply, socket}
+      end
+    end
+
+    def handle_event("rebuild_graph", _params, socket) do
+      case validate_maintenance_collection(socket, socket.assigns.rebuild_graph_collection) do
+        {:ok, collection} -> {:noreply, start_rebuild_graph(socket, collection)}
+        :error -> {:noreply, put_flash(socket, :error, "Select an allowed collection first")}
+      end
+    end
+
+    def handle_event(
+          "select_detect_communities_collection",
+          %{"collection" => collection},
+          socket
+        ) do
+      collection = if collection == "", do: nil, else: collection
+
+      case validate_maintenance_collection(socket, collection) do
+        {:ok, collection} ->
+          {:noreply, assign(socket, detect_communities_collection: collection)}
+
+        :error ->
+          {:noreply, socket}
+      end
+    end
+
+    def handle_event("detect_communities", _params, socket) do
+      case validate_maintenance_collection(
+             socket,
+             socket.assigns.detect_communities_collection
+           ) do
+        {:ok, collection} -> {:noreply, start_detect_communities(socket, collection)}
+        :error -> {:noreply, put_flash(socket, :error, "Select an allowed collection first")}
+      end
+    end
+
+    def handle_event("select_assign_collection", %{"collection" => collection}, socket) do
+      collection = if collection == "", do: nil, else: collection
+      {:noreply, assign(socket, assign_orphans_collection: collection)}
+    end
+
+    # Orphaned graph data belongs to no collection, so assigning or deleting
+    # it is inherently a cross-collection operation: restricted dashboards
+    # can't run it at all.
+    def handle_event("assign_orphans", _params, socket) do
       repo = socket.assigns.repo
-      collection = socket.assigns.reembed_collection
+      collection_name = socket.assigns.assign_orphans_collection
+
+      cond do
+        socket.assigns.allowed_collections != :all ->
+          {:noreply, socket}
+
+        is_nil(collection_name) ->
+          {:noreply, put_flash(socket, :error, "Please select a collection")}
+
+        true ->
+          assign_orphans_to_named_collection(socket, repo, collection_name)
+      end
+    end
+
+    def handle_event("delete_orphans", _params, socket) do
+      if socket.assigns.allowed_collections == :all do
+        repo = socket.assigns.repo
+        {entities_deleted, relationships_deleted} = delete_orphaned_graph_data(repo)
+
+        socket =
+          socket
+          |> load_data()
+          |> put_flash(
+            :info,
+            "Deleted #{entities_deleted} orphaned entities and #{relationships_deleted} orphaned relationships"
+          )
+
+        {:noreply, socket}
+      else
+        {:noreply, socket}
+      end
+    end
+
+    defp assign_orphans_to_named_collection(socket, repo, collection_name) do
+      collection =
+        Enum.find(socket.assigns.collections_for_assign, &(&1.name == collection_name))
+
+      if collection do
+        assign_orphaned_to_collection(repo, collection.id)
+
+        socket =
+          socket
+          |> load_data()
+          |> put_flash(:info, "Assigned orphaned graph data to #{collection_name}")
+
+        {:noreply, socket}
+      else
+        {:noreply, put_flash(socket, :error, "Collection not found")}
+      end
+    end
+
+    defp start_reembed(socket, collection) do
+      repo = socket.assigns.repo
       parent = self()
 
       socket = assign(socket, reembed_running: true, reembed_progress: %{current: 0, total: 0})
@@ -120,17 +255,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         send(parent, {:reembed_complete, result})
       end)
 
-      {:noreply, socket}
+      socket
     end
 
-    def handle_event("select_rebuild_collection", %{"collection" => collection}, socket) do
-      collection = if collection == "", do: nil, else: collection
-      {:noreply, assign(socket, rebuild_graph_collection: collection)}
-    end
-
-    def handle_event("rebuild_graph", _params, socket) do
+    defp start_rebuild_graph(socket, collection) do
       repo = socket.assigns.repo
-      collection = socket.assigns.rebuild_graph_collection
       parent = self()
 
       socket =
@@ -150,21 +279,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         send(parent, {:rebuild_graph_complete, result})
       end)
 
-      {:noreply, socket}
+      socket
     end
 
-    def handle_event(
-          "select_detect_communities_collection",
-          %{"collection" => collection},
-          socket
-        ) do
-      collection = if collection == "", do: nil, else: collection
-      {:noreply, assign(socket, detect_communities_collection: collection)}
-    end
-
-    def handle_event("detect_communities", _params, socket) do
+    defp start_detect_communities(socket, collection) do
       repo = socket.assigns.repo
-      collection = socket.assigns.detect_communities_collection
       parent = self()
 
       socket =
@@ -184,52 +303,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         send(parent, {:detect_communities_complete, result})
       end)
 
-      {:noreply, socket}
-    end
-
-    def handle_event("select_assign_collection", %{"collection" => collection}, socket) do
-      collection = if collection == "", do: nil, else: collection
-      {:noreply, assign(socket, assign_orphans_collection: collection)}
-    end
-
-    def handle_event("assign_orphans", _params, socket) do
-      repo = socket.assigns.repo
-      collection_name = socket.assigns.assign_orphans_collection
-
-      if collection_name do
-        collection =
-          Enum.find(socket.assigns.collections_for_assign, &(&1.name == collection_name))
-
-        if collection do
-          assign_orphaned_to_collection(repo, collection.id)
-
-          socket =
-            socket
-            |> load_data()
-            |> put_flash(:info, "Assigned orphaned graph data to #{collection_name}")
-
-          {:noreply, socket}
-        else
-          {:noreply, put_flash(socket, :error, "Collection not found")}
-        end
-      else
-        {:noreply, put_flash(socket, :error, "Please select a collection")}
-      end
-    end
-
-    def handle_event("delete_orphans", _params, socket) do
-      repo = socket.assigns.repo
-      {entities_deleted, relationships_deleted} = delete_orphaned_graph_data(repo)
-
-      socket =
-        socket
-        |> load_data()
-        |> put_flash(
-          :info,
-          "Deleted #{entities_deleted} orphaned entities and #{relationships_deleted} orphaned relationships"
-        )
-
-      {:noreply, socket}
+      socket
     end
 
     defp assign_orphaned_to_collection(repo, collection_id) do
@@ -397,7 +471,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
                   name="collection"
                   style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
                 >
-                  <option value="">All Collections</option>
+                  <%= if @allowed_collections == :all do %>
+                    <option value="">All Collections</option>
+                  <% end %>
                   <%= for collection <- @collections do %>
                     <option value={collection} selected={@reembed_collection == collection}>
                       <%= collection %>
@@ -468,7 +544,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
                   name="collection"
                   style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
                 >
-                  <option value="">All Collections</option>
+                  <%= if @allowed_collections == :all do %>
+                    <option value="">All Collections</option>
+                  <% end %>
                   <%= for collection <- @collections do %>
                     <option value={collection} selected={@rebuild_graph_collection == collection}>
                       <%= collection %>
@@ -514,7 +592,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
                   name="collection"
                   style="padding: 0.5rem 0.75rem; border: 1px solid #d1d5db; border-radius: 0.375rem; font-size: 0.875rem; background: white; min-width: 160px;"
                 >
-                  <option value="">All Collections</option>
+                  <%= if @allowed_collections == :all do %>
+                    <option value="">All Collections</option>
+                  <% end %>
                   <%= for collection <- @collections do %>
                     <option value={collection} selected={@detect_communities_collection == collection}>
                       <%= collection %>
@@ -531,7 +611,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             <% end %>
           </div>
 
-          <%= if @orphaned_stats.entities > 0 or @orphaned_stats.relationships > 0 do %>
+          <%= if @allowed_collections == :all and
+                (@orphaned_stats.entities > 0 or @orphaned_stats.relationships > 0) do %>
             <div class="arcana-maintenance-section arcana-orphan-section">
               <h3>Orphaned Graph Data</h3>
               <p style="color: #6b7280; margin-bottom: 1rem; font-size: 0.875rem;">

--- a/lib/arcana_web/live/maintenance_live.ex
+++ b/lib/arcana_web/live/maintenance_live.ex
@@ -249,8 +249,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           send(parent, {:reembed_progress, current, total})
         end
 
-        opts = [batch_size: 50, progress: progress_fn]
-        opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
+        opts = maintenance_collection_opts([batch_size: 50, progress: progress_fn], collection)
         result = Arcana.Maintenance.reembed(repo, opts)
         send(parent, {:reembed_complete, result})
       end)
@@ -273,8 +272,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           send(parent, {:rebuild_graph_progress, current, total})
         end
 
-        opts = [progress: progress_fn]
-        opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
+        opts = maintenance_collection_opts([progress: progress_fn], collection)
         result = Arcana.Maintenance.rebuild_graph(repo, opts)
         send(parent, {:rebuild_graph_complete, result})
       end)
@@ -297,14 +295,27 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           send(parent, {:detect_communities_progress, current, total})
         end
 
-        opts = [progress: progress_fn]
-        opts = if collection, do: Keyword.put(opts, :collection, collection), else: opts
+        opts = maintenance_collection_opts([progress: progress_fn], collection)
         result = Arcana.Maintenance.detect_communities(repo, opts)
         send(parent, {:detect_communities_complete, result})
       end)
 
       socket
     end
+
+    # A collection name with no row resolves to "no filter", which silently
+    # turns a per-collection action into a global one: re-embedding every
+    # document in the database, rebuilding every graph. Strict resolution
+    # turns that into {:error, {:unknown_collection, name}}, which the
+    # completion handlers already render as a flash. The name can go missing
+    # on any dashboard (never ingested yet, or deleted from another tab), so
+    # this holds for restricted and unrestricted mounts alike. nil is the
+    # explicit "all collections" choice and stays unstrict — restricted
+    # dashboards never get that far (see validate_maintenance_collection/2).
+    defp maintenance_collection_opts(opts, nil), do: opts
+
+    defp maintenance_collection_opts(opts, collection) when is_binary(collection),
+      do: Keyword.merge(opts, collection: collection, strict_collections: true)
 
     defp assign_orphaned_to_collection(repo, collection_id) do
       # Only entities have collection_id - relationships reference entities

--- a/lib/arcana_web/live/search_live.ex
+++ b/lib/arcana_web/live/search_live.ex
@@ -38,17 +38,18 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_data(socket) do
       repo = socket.assigns.repo
+      allowed = socket.assigns.allowed_collections
 
       socket
-      |> assign(stats: load_stats(repo))
-      |> assign(collections: load_collections(repo))
-      |> assign(source_ids: load_source_ids(repo))
+      |> assign(stats: load_stats(repo, allowed))
+      |> assign(collections: load_collections(repo, allowed))
+      |> assign(source_ids: load_source_ids(repo, allowed))
     end
 
     @impl true
     def handle_event("search", params, socket) do
       query = params["query"] || ""
-      results = run_search(query, params, socket.assigns.repo)
+      results = run_search(query, params, socket.assigns.repo, socket.assigns.allowed_collections)
 
       {:noreply,
        assign(socket, search_results: results, search_query: query, expanded_result_id: nil)}
@@ -64,33 +65,75 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       repo = socket.assigns.repo
       import Ecto.Query
 
-      document = repo.get(Document, id)
+      document_query = from(d in Document, where: d.id == ^id)
 
-      chunks =
-        repo.all(
-          from(c in Arcana.Chunk,
-            where: c.document_id == ^id,
-            order_by: c.chunk_index
-          )
-        )
+      # Forged ids pointing outside the allowed collections resolve to
+      # nothing, same as a missing document.
+      document_query =
+        case socket.assigns.allowed_collections do
+          :all ->
+            document_query
 
-      {:noreply, assign(socket, viewing_document: %{document: document, chunks: chunks})}
+          names when is_list(names) ->
+            from(d in document_query, join: c in assoc(d, :collection), where: c.name in ^names)
+        end
+
+      case repo.one(document_query) do
+        nil ->
+          {:noreply, socket}
+
+        document ->
+          chunks =
+            repo.all(
+              from(c in Arcana.Chunk,
+                where: c.document_id == ^id,
+                order_by: c.chunk_index
+              )
+            )
+
+          {:noreply, assign(socket, viewing_document: %{document: document, chunks: chunks})}
+      end
     end
 
     def handle_event("close_search_document", _params, socket) do
       {:noreply, assign(socket, viewing_document: nil)}
     end
 
-    defp run_search("", _params, _repo), do: []
+    defp run_search("", _params, _repo, _allowed), do: []
 
-    defp run_search(query, params, repo) do
-      case params |> build_search_opts(repo) |> then(&Arcana.search(query, &1)) do
-        {:ok, results} -> results
-        {:error, _reason} -> []
+    defp run_search(query, params, repo, allowed) do
+      requested = normalize_collections(params["collections"])
+
+      # Fail closed: a request naming any collection outside the allowed set
+      # refuses the whole search instead of silently narrowing it, and an
+      # empty allowed set never reaches Arcana.search/2 (where an empty
+      # collections option would mean "search everything").
+      case resolve_search_collections(requested, allowed) do
+        {:ok, collections} ->
+          opts = build_search_opts(params, repo, collections)
+
+          case Arcana.search(query, opts) do
+            {:ok, results} -> results
+            {:error, _reason} -> []
+          end
+
+        :error ->
+          []
       end
     end
 
-    defp build_search_opts(params, repo) do
+    # Unrestricted: requested collections pass through untouched, [] keeps
+    # today's "search everything" behavior via add_collection_opt/2.
+    defp resolve_search_collections(requested, :all), do: {:ok, requested}
+
+    defp resolve_search_collections([], []), do: :error
+    defp resolve_search_collections([], allowed), do: {:ok, allowed}
+
+    defp resolve_search_collections(requested, allowed) do
+      if Enum.all?(requested, &(&1 in allowed)), do: {:ok, requested}, else: :error
+    end
+
+    defp build_search_opts(params, repo, collections) do
       [
         repo: repo,
         limit: parse_int(params["limit"], 10),
@@ -98,7 +141,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         mode: parse_mode(params["mode"])
       ]
       |> add_source_id_opt(params["source_id"])
-      |> add_collection_opt(normalize_collections(params["collections"]))
+      |> add_collection_opt(collections)
     end
 
     defp add_source_id_opt(opts, nil), do: opts

--- a/lib/arcana_web/live/search_live.ex
+++ b/lib/arcana_web/live/search_live.ex
@@ -110,7 +110,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       # collections option would mean "search everything").
       case resolve_search_collections(requested, allowed) do
         {:ok, collections} ->
-          opts = build_search_opts(params, repo, collections)
+          opts = build_search_opts(params, repo, collections, allowed)
 
           case Arcana.search(query, opts) do
             {:ok, results} -> results
@@ -133,7 +133,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       if Enum.all?(requested, &(&1 in allowed)), do: {:ok, requested}, else: :error
     end
 
-    defp build_search_opts(params, repo, collections) do
+    defp build_search_opts(params, repo, collections, allowed) do
       [
         repo: repo,
         limit: parse_int(params["limit"], 10),
@@ -142,7 +142,19 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       ]
       |> add_source_id_opt(params["source_id"])
       |> add_collection_opt(collections)
+      |> add_strict_opt(allowed)
     end
+
+    # Restricted dashboards search strictly. Without it an allowed name with
+    # no collection row (never created, or deleted mid-session) resolves to
+    # "no filter" and the search widens to every collection; strict turns
+    # that into {:error, {:unknown_collection, _}}, which run_search/4
+    # already renders as no results. Unrestricted dashboards keep the
+    # library default.
+    defp add_strict_opt(opts, :all), do: opts
+
+    defp add_strict_opt(opts, allowed) when is_list(allowed),
+      do: Keyword.put(opts, :strict_collections, true)
 
     defp add_source_id_opt(opts, nil), do: opts
     defp add_source_id_opt(opts, ""), do: opts

--- a/lib/arcana_web/live/search_live.ex
+++ b/lib/arcana_web/live/search_live.ex
@@ -61,7 +61,20 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       {:noreply, assign(socket, expanded_result_id: new_id)}
     end
 
+    # A forged id that isn't a UUID can't match a document, so it's rejected
+    # before the query would raise an Ecto.Query.CastError on the cast.
     def handle_event("view_search_document", %{"id" => id}, socket) do
+      case Ecto.UUID.cast(id) do
+        {:ok, uuid} -> view_search_document(socket, uuid)
+        :error -> {:noreply, socket}
+      end
+    end
+
+    def handle_event("close_search_document", _params, socket) do
+      {:noreply, assign(socket, viewing_document: nil)}
+    end
+
+    defp view_search_document(socket, id) do
       repo = socket.assigns.repo
       import Ecto.Query
 
@@ -93,10 +106,6 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
           {:noreply, assign(socket, viewing_document: %{document: document, chunks: chunks})}
       end
-    end
-
-    def handle_event("close_search_document", _params, socket) do
-      {:noreply, assign(socket, viewing_document: nil)}
     end
 
     defp run_search("", _params, _repo, _allowed), do: []

--- a/lib/arcana_web/router.ex
+++ b/lib/arcana_web/router.ex
@@ -29,11 +29,40 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       * `:on_mount` - Optional list of `Phoenix.LiveView.on_mount/1` callbacks
         to add to the dashboard's live_session.
 
+      * `:live_session_name` - The name of the dashboard's live_session.
+        Defaults to `:arcana_dashboard`. Phoenix requires live_session names
+        to be unique within a router, so mounting the dashboard more than
+        once (say, a superuser dashboard plus a scoped one) needs a distinct
+        name for each extra mount.
+
+      * `:collections` - Optional `{module, function}` pair that scopes the
+        dashboard to a subset of collections. At request time the function
+        receives the `%Plug.Conn{}` and must return either `:all` (no
+        restriction) or a list of collection names. Every dashboard surface
+        (listings, search, ask, ingest, maintenance, stats) is limited to
+        those collections, and events naming any other collection are
+        rejected server-side. A plain `{module, function}` tuple is required
+        (not a function capture) so the route metadata stays serializable.
+
     ## Example with options
 
         arcana_dashboard "/arcana",
           repo: MyApp.Repo,
           on_mount: [MyAppWeb.Auth]
+
+    ## Scoping collections
+
+        arcana_dashboard "/arcana",
+          collections: {MyAppWeb.ArcanaAccess, :allowed_collections}
+
+        defmodule MyAppWeb.ArcanaAccess do
+          def allowed_collections(conn) do
+            case conn.assigns.current_user do
+              %{admin: true} -> :all
+              %{tenant: tenant} -> ["\#{tenant}-docs"]
+            end
+          end
+        end
 
     """
 
@@ -98,21 +127,36 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     def __options__(options, prefix) do
       live_socket_path = Keyword.get(options, :live_socket_path, "/live")
       repo = Keyword.get(options, :repo)
+      collections = options |> Keyword.get(:collections) |> validate_collections_option!()
 
-      session_args = [repo, prefix]
+      # The collections spec is only appended when given, so dashboards
+      # without the option keep the exact session MFA they had before.
+      session_args = if collections, do: [repo, prefix, collections], else: [repo, prefix]
 
       {
-        :arcana_dashboard,
+        Keyword.get(options, :live_session_name, :arcana_dashboard),
         [
           session: {__MODULE__, :__session__, session_args},
           root_layout: {ArcanaWeb.Layouts, :root},
-          on_mount: [ArcanaWeb.Router.Prefix | List.wrap(options[:on_mount])]
+          on_mount: [ArcanaWeb.Router.Scope | List.wrap(options[:on_mount])]
         ],
         [
           private: %{live_socket_path: live_socket_path},
           as: :arcana_dashboard
         ]
       }
+    end
+
+    defp validate_collections_option!(nil), do: nil
+
+    defp validate_collections_option!({mod, fun} = spec) when is_atom(mod) and is_atom(fun),
+      do: spec
+
+    defp validate_collections_option!(other) do
+      raise ArgumentError,
+            ":collections must be a {module, function} tuple where the function " <>
+              "accepts a Plug.Conn and returns :all or a list of collection names, " <>
+              "got: #{inspect(other)}"
     end
 
     @doc false
@@ -122,16 +166,57 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         "prefix" => prefix
       }
     end
+
+    @doc false
+    def __session__(conn, repo, prefix, collections_spec) do
+      conn
+      |> __session__(repo, prefix)
+      |> Map.put("allowed_collections", resolve_allowed_collections(conn, collections_spec))
+    end
+
+    # Fail closed: anything other than :all or a list of collection names
+    # raises instead of silently widening access.
+    defp resolve_allowed_collections(conn, {mod, fun}) do
+      case apply(mod, fun, [conn]) do
+        :all ->
+          :all
+
+        names when is_list(names) ->
+          validate_collection_names!(names, {mod, fun})
+
+        other ->
+          raise ArgumentError,
+                "#{inspect(mod)}.#{fun}/1 must return :all or a list of collection " <>
+                  "names, got: #{inspect(other)}"
+      end
+    end
+
+    defp validate_collection_names!(names, {mod, fun}) do
+      if Enum.all?(names, &is_binary/1) do
+        names
+      else
+        raise ArgumentError,
+              "#{inspect(mod)}.#{fun}/1 returned a list with non-string entries: " <>
+                inspect(names)
+      end
+    end
   end
 
-  defmodule ArcanaWeb.Router.Prefix do
+  defmodule ArcanaWeb.Router.Scope do
     @moduledoc false
 
     # Assigns the dashboard's mount prefix (e.g. "/admin/arcana") to every
     # dashboard LiveView so links and asset hrefs are built from the actual
-    # mount point instead of assuming "/arcana".
+    # mount point instead of assuming "/arcana", plus the allowed collections
+    # resolved by the router's :collections MFA (:all when the option is
+    # absent). An empty list is a valid restriction and must not collapse to
+    # :all, so only a missing session key falls back.
     def on_mount(:default, _params, session, socket) do
-      {:cont, Phoenix.Component.assign(socket, :prefix, session["prefix"] || "/arcana")}
+      {:cont,
+       Phoenix.Component.assign(socket,
+         prefix: session["prefix"] || "/arcana",
+         allowed_collections: session["allowed_collections"] || :all
+       )}
     end
   end
 else

--- a/lib/arcana_web/router.ex
+++ b/lib/arcana_web/router.ex
@@ -36,13 +36,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         name for each extra mount.
 
       * `:collections` - Optional `{module, function}` pair that scopes the
-        dashboard to a subset of collections. At request time the function
-        receives the `%Plug.Conn{}` and must return either `:all` (no
+        dashboard to a subset of collections. The function receives the
+        `%Plug.Conn{}` of the page request and must return either `:all` (no
         restriction) or a list of collection names. Every dashboard surface
-        (listings, search, ask, ingest, maintenance, stats) is limited to
-        those collections, and events naming any other collection are
-        rejected server-side. A plain `{module, function}` tuple is required
-        (not a function capture) so the route metadata stays serializable.
+        (listings, search, ask, ingest, evaluation, maintenance, stats) is
+        limited to those collections, and events naming any other collection
+        are rejected server-side. A plain `{module, function}` tuple is
+        required (not a function capture) so the route metadata stays
+        serializable. See "Scoping collections" for when the decision is
+        re-evaluated.
 
     ## Example with options
 
@@ -63,6 +65,32 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             end
           end
         end
+
+    ### When the decision is made
+
+    The function runs while the page request is being served, and its result
+    is **snapshotted into the LiveView session**: Phoenix signs it into the
+    rendered `data-phx-session` payload, which stays valid for the session's
+    max age (14 days by default). The websocket connect, every reconnect,
+    and every `live_patch`/`live_redirect` inside the dashboard read back
+    that snapshot instead of calling the function again. Only a full page
+    request re-runs it.
+
+    So narrowing a user's permissions does not narrow an already-rendered
+    dashboard. Until the user loads a fresh page, they keep the scope they
+    mounted with. The `on_mount` hook cannot close that gap on its own —
+    there is no `%Plug.Conn{}` in a LiveView mount to re-resolve from.
+
+    The mitigation is to cut the socket when permissions change. Set a
+    `live_socket_id` per user in your session (Phoenix's
+    `put_session(conn, :live_socket_id, "users_socket:\#{user.id}")`), then
+    broadcast a disconnect when their access changes:
+
+        MyAppWeb.Endpoint.broadcast("users_socket:\#{user.id}", "disconnect", %{})
+
+    The client reconnects through a full request, which re-runs the MFA with
+    the current `%Plug.Conn{}`. Pair it with a short session max age if you
+    need a hard upper bound on how long a stale scope can live.
 
     """
 
@@ -211,6 +239,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     # resolved by the router's :collections MFA (:all when the option is
     # absent). An empty list is a valid restriction and must not collapse to
     # :all, so only a missing session key falls back.
+    #
+    # The list is read back from the signed session, not re-resolved: a
+    # LiveView mount has no %Plug.Conn{} to hand the MFA. See the
+    # "Scoping collections" section of ArcanaWeb.Router for what that means
+    # for permission changes mid-session, and how to force a re-resolve.
     def on_mount(:default, _params, session, socket) do
       {:cont,
        Phoenix.Component.assign(socket,

--- a/test/arcana/pipeline/reason_test.exs
+++ b/test/arcana/pipeline/reason_test.exs
@@ -4,6 +4,29 @@ defmodule Arcana.Pipeline.ReasonTest do
   alias Arcana.Pipeline
   alias Arcana.Pipeline.Context
 
+  # Asks for one follow-up search, then accepts. Anything that isn't the
+  # sufficiency prompt gets a throwaway answer.
+  defp insufficient_then_sufficient_llm do
+    call_count = :counters.new(1, [:atomics])
+
+    fn prompt ->
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      cond do
+        count == 0 and prompt =~ "sufficient" ->
+          {:ok,
+           ~s({"sufficient": false, "missing": "concurrency model", "follow_up_query": "Elixir concurrency actors"})}
+
+        prompt =~ "sufficient" ->
+          {:ok, ~s({"sufficient": true, "reasoning": "Now has concurrency info"})}
+
+        true ->
+          {:ok, "response"}
+      end
+    end
+  end
+
   describe "reason/2" do
     test "accepts results when LLM says sufficient" do
       llm = fn prompt ->
@@ -232,6 +255,51 @@ defmodule Arcana.Pipeline.ReasonTest do
       ctx = Pipeline.reason(ctx)
 
       assert MapSet.member?(ctx.queries_tried, "my question")
+    end
+
+    # A caller that scopes retrieval by handing search/2 a tenant searcher
+    # would silently get the default (unscoped) searcher back for the
+    # follow-up searches if reason/2 didn't inherit it, which hands the
+    # caller chunks from outside the tenant.
+    test "inherits the searcher from search/2 without repeating the option" do
+      test_pid = self()
+
+      searcher = fn question, _collection, _opts ->
+        send(test_pid, {:searched, question})
+        {:ok, [%{id: "1", text: "scoped chunk", score: 0.9}]}
+      end
+
+      ctx =
+        "How does Elixir handle concurrency?"
+        |> Pipeline.new(repo: Arcana.TestRepo, llm: insufficient_then_sufficient_llm())
+        |> Pipeline.search(searcher: searcher, collection: "inherit-searcher-test")
+        |> Pipeline.reason()
+
+      assert ctx.reason_iterations == 1
+      assert_received {:searched, "How does Elixir handle concurrency?"}
+      assert_received {:searched, "Elixir concurrency actors"}
+    end
+
+    test "an explicit searcher on reason/2 beats the inherited one" do
+      test_pid = self()
+
+      search_searcher = fn _question, _collection, _opts ->
+        {:ok, [%{id: "1", text: "from search", score: 0.9}]}
+      end
+
+      reason_searcher = fn question, _collection, _opts ->
+        send(test_pid, {:reason_searched, question})
+        {:ok, [%{id: "2", text: "from reason", score: 0.9}]}
+      end
+
+      ctx =
+        "How does Elixir handle concurrency?"
+        |> Pipeline.new(repo: Arcana.TestRepo, llm: insufficient_then_sufficient_llm())
+        |> Pipeline.search(searcher: search_searcher, collection: "explicit-searcher-test")
+        |> Pipeline.reason(searcher: reason_searcher)
+
+      assert ctx.reason_iterations == 1
+      assert_received {:reason_searched, "Elixir concurrency actors"}
     end
 
     test "skips reasoning when skip_retrieval is true" do

--- a/test/arcana/pipeline/reason_test.exs
+++ b/test/arcana/pipeline/reason_test.exs
@@ -27,6 +27,43 @@ defmodule Arcana.Pipeline.ReasonTest do
     end
   end
 
+  # Says "insufficient" once per follow-up query, in order, then accepts.
+  # The queries have to differ: reason/2 stops as soon as a follow-up
+  # repeats one that queries_tried already holds.
+  defp insufficient_llm(follow_ups) do
+    call_count = :counters.new(1, [:atomics])
+
+    fn prompt ->
+      if prompt =~ "sufficient" do
+        index = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        case Enum.at(follow_ups, index) do
+          nil ->
+            {:ok, ~s({"sufficient": true, "reasoning": "good enough"})}
+
+          query ->
+            {:ok,
+             JSON.encode!(%{
+               "sufficient" => false,
+               "missing" => "more detail",
+               "follow_up_query" => query
+             })}
+        end
+      else
+        {:ok, "response"}
+      end
+    end
+  end
+
+  defp searched_collections(acc \\ []) do
+    receive do
+      {:searched_collection, collection} -> searched_collections([collection | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
   describe "reason/2" do
     test "accepts results when LLM says sufficient" do
       llm = fn prompt ->
@@ -300,6 +337,58 @@ defmodule Arcana.Pipeline.ReasonTest do
 
       assert ctx.reason_iterations == 1
       assert_received {:reason_searched, "Elixir concurrency actors"}
+    end
+
+    # search/2 resolved ["tenant-a"], so every follow-up has to stay there.
+    # Before search/2 recorded its collections, the first follow-up rode
+    # hd(ctx.results).collection and the second — after merge_results
+    # dropped the dry result — fell through to "default". That reads as a
+    # narrow scope but isn't: strict_collections defaults to false, so an
+    # unknown name resolves to no collection filter at all, i.e. the whole
+    # corpus for a caller that named one tenant.
+    test "follow-up searches stay in the collections search/2 resolved" do
+      test_pid = self()
+
+      searcher = fn _question, collection, _opts ->
+        send(test_pid, {:searched_collection, collection})
+        {:ok, []}
+      end
+
+      llm = insufficient_llm(["tenant policy details", "tenant policy exceptions"])
+
+      ctx =
+        "What is the tenant policy?"
+        |> Pipeline.new(repo: Arcana.TestRepo, llm: llm)
+        |> Pipeline.search(searcher: searcher, collections: ["tenant-a"])
+        |> Pipeline.reason()
+
+      assert ctx.reason_iterations == 2
+      assert searched_collections() == ["tenant-a", "tenant-a", "tenant-a"]
+    end
+
+    # Same leak against a real repo and the default searcher: an empty
+    # collection makes every follow-up run dry, which used to hand the last
+    # one an unscoped search over the whole corpus.
+    test "follow-up searches never return chunks outside the caller's collection" do
+      {:ok, _} = Arcana.Collection.get_or_create("probe-tenant-a", Arcana.TestRepo)
+
+      other_tenant_text = "Zorblax quantum flux capacitor blueprint"
+
+      {:ok, _} =
+        Arcana.ingest(other_tenant_text, repo: Arcana.TestRepo, collection: "probe-tenant-b")
+
+      llm = insufficient_llm(["wumpus grommet sprocket", other_tenant_text])
+
+      ctx =
+        "What is the Zorblax blueprint?"
+        |> Pipeline.new(repo: Arcana.TestRepo, llm: llm, threshold: 0.1)
+        |> Pipeline.search(collections: ["probe-tenant-a"])
+        |> Pipeline.reason()
+
+      assert Enum.all?(ctx.results, &(&1.collection == "probe-tenant-a"))
+
+      chunks = Enum.flat_map(ctx.results, & &1.chunks)
+      refute Enum.any?(chunks, &(&1.text =~ "Zorblax"))
     end
 
     test "skips reasoning when skip_retrieval is true" do

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -665,10 +665,14 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
     # test case searches every collection, so the run's stored results hand
     # back chunk ids the tenant may not read.
     test "a restricted evaluation run only retrieves from allowed collections", %{conn: conn} do
+      # Both documents share the question's term, so an unscoped search
+      # retrieves both; only the collection filter can keep the other
+      # tenant's chunk out of the run's results.
       {_tc, _chunks} =
-        seed_test_case("tenant-a", "AllowedEvalChunkZulu", "AllowedEvalQuestionZulu")
+        seed_test_case("tenant-a", "AllowedEvalChunkZulu zulutopic", "zulutopic")
 
-      {:ok, secret_doc} = Arcana.ingest("SecretEvalChunkZulu", repo: Repo, collection: "other")
+      {:ok, secret_doc} =
+        Arcana.ingest("SecretEvalChunkZulu zulutopic", repo: Repo, collection: "other")
 
       secret_ids =
         Repo.all(from(c in Arcana.Chunk, where: c.document_id == ^secret_doc.id, select: c.id))
@@ -685,8 +689,9 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
         |> Map.values()
         |> Enum.flat_map(&(&1["retrieved_chunk_ids"] || []))
 
-      assert run.config["collections"] == ["tenant-a"]
+      assert secret_ids != []
       assert Enum.all?(secret_ids, &(&1 not in retrieved))
+      assert run.config["collections"] == ["tenant-a"]
     end
 
     # Telemetry handlers are global, so an unfiltered progress handler

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -1,0 +1,254 @@
+defmodule ArcanaWeb.AllowedCollectionsTest do
+  use ArcanaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Arcana.Collection
+
+  # These tests exercise the /scoped dashboard from the test router, whose
+  # :collections MFA reads the allowed list from the conn's session. Each
+  # test seeds its own restriction via init_test_session, so the suite
+  # stays async-safe.
+
+  defp restrict(conn, allowed) do
+    Plug.Test.init_test_session(conn, allowed_collections: allowed)
+  end
+
+  describe "collections page" do
+    test "lists only allowed collections", %{conn: conn} do
+      {:ok, _} = Collection.get_or_create("tenant-a", Repo)
+      {:ok, _} = Collection.get_or_create("other", Repo)
+
+      {:ok, _view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/collections")
+
+      assert html =~ "tenant-a"
+      refute html =~ "other"
+    end
+
+    test "rejects creating a collection outside the allowed set", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/collections")
+
+      view
+      |> form("#new-collection-form", %{"collection" => %{"name" => "evil"}})
+      |> render_submit()
+
+      refute Repo.get_by(Collection, name: "evil")
+    end
+
+    test "allows creating a collection inside the allowed set", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/collections")
+
+      view
+      |> form("#new-collection-form", %{"collection" => %{"name" => "tenant-a"}})
+      |> render_submit()
+
+      assert Repo.get_by(Collection, name: "tenant-a")
+    end
+
+    test "rejects deleting a collection outside the allowed set by forged id", %{conn: conn} do
+      {:ok, other} = Collection.get_or_create("other", Repo)
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/collections")
+
+      render_click(view, "delete_collection", %{"id" => other.id})
+
+      assert Repo.get(Collection, other.id)
+    end
+  end
+
+  describe "documents page" do
+    test "lists only documents from allowed collections", %{conn: conn} do
+      {:ok, _} = Arcana.ingest("Allowed tenant content", repo: Repo, collection: "tenant-a")
+      {:ok, _} = Arcana.ingest("Hidden tenant content", repo: Repo, collection: "other")
+
+      {:ok, _view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      assert html =~ "Allowed tenant content"
+      refute html =~ "Hidden tenant content"
+      # filter bar and ingest select only offer allowed collections
+      refute html =~ "filter-collection-other"
+      refute html =~ ~s(<option value="">default</option>)
+    end
+
+    test "rejects a forged ingest event naming a disallowed collection", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      render_submit(view, "ingest", %{
+        "content" => "smuggled",
+        "format" => "plaintext",
+        "collection" => "other"
+      })
+
+      assert {:ok, []} = Arcana.list_documents(repo: Repo)
+    end
+
+    test "rejects ingest into the default collection when it is not allowed", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      render_submit(view, "ingest", %{"content" => "smuggled", "format" => "plaintext"})
+
+      assert {:ok, []} = Arcana.list_documents(repo: Repo)
+    end
+
+    test "rejects deleting a document outside the allowed collections", %{conn: conn} do
+      {:ok, doc} = Arcana.ingest("Hidden tenant content", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      render_click(view, "delete", %{"id" => doc.id})
+
+      assert {:ok, _doc} = Arcana.get_document(doc.id, repo: Repo)
+    end
+
+    test "does not show documents from other collections via forged view event", %{conn: conn} do
+      {:ok, doc} = Arcana.ingest("Hidden tenant content", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      html = render_click(view, "view_document", %{"id" => doc.id})
+
+      refute html =~ "Hidden tenant content"
+    end
+  end
+
+  describe "search page" do
+    test "only offers and searches allowed collections", %{conn: conn} do
+      {:ok, _} = Arcana.ingest("Elixir content for tenant a", repo: Repo, collection: "tenant-a")
+      {:ok, _} = Arcana.ingest("Elixir content for others", repo: Repo, collection: "other")
+
+      {:ok, view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/search")
+
+      refute html =~ ~s(value="other")
+
+      # no selection means "all allowed collections", never everything
+      html = render_submit(view, "search", %{"query" => "Elixir"})
+
+      assert html =~ "Elixir content for tenant a"
+      refute html =~ "Elixir content for others"
+    end
+
+    test "refuses a search naming a disallowed collection", %{conn: conn} do
+      {:ok, _} = Arcana.ingest("Elixir content for others", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/search")
+
+      html =
+        render_submit(view, "search", %{"query" => "Elixir", "collections" => ["other"]})
+
+      refute html =~ "Elixir content for others"
+    end
+
+    test "an empty allowed set never searches anything", %{conn: conn} do
+      {:ok, _} = Arcana.ingest("Elixir content for others", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict([]) |> live("/scoped/search")
+
+      html = render_submit(view, "search", %{"query" => "Elixir"})
+
+      refute html =~ "Elixir content for others"
+    end
+  end
+
+  describe "ask page" do
+    test "rejects a forged ask naming a disallowed collection before any retrieval",
+         %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/ask")
+
+      html =
+        render_submit(view, "ask_submit", %{
+          "question" => "What is hidden?",
+          "sub_tab" => "advanced",
+          "collections" => ["other"]
+        })
+
+      assert html =~ "not allowed"
+    end
+
+    test "an empty allowed set refuses every ask", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict([]) |> live("/scoped/ask")
+
+      html =
+        render_submit(view, "ask_submit", %{
+          "question" => "anything",
+          "sub_tab" => "advanced"
+        })
+
+      assert html =~ "not allowed"
+    end
+
+    test "only renders allowed collection checkboxes", %{conn: conn} do
+      {:ok, _} = Collection.get_or_create("tenant-a", Repo)
+      {:ok, _} = Collection.get_or_create("other", Repo)
+
+      {:ok, _view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/ask")
+
+      assert html =~ "tenant-a"
+      refute html =~ ~s(value="other")
+    end
+  end
+
+  describe "graph page" do
+    test "restricted dashboards get no All Collections option", %{conn: conn} do
+      {:ok, _} = Collection.get_or_create("tenant-a", Repo)
+      {:ok, _} = Collection.get_or_create("other", Repo)
+
+      {:ok, _view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/graph")
+
+      refute html =~ "All Collections"
+      refute html =~ ~s(value="other")
+    end
+  end
+
+  describe "maintenance page" do
+    test "restricted dashboards cannot run collection-wide actions", %{conn: conn} do
+      {:ok, _} = Collection.get_or_create("tenant-a", Repo)
+
+      {:ok, view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/maintenance")
+
+      refute html =~ "All Collections"
+
+      # no collection selected: the action is refused instead of running
+      # globally, so the progress UI never appears
+      html = render_click(view, "reembed", %{})
+      refute html =~ "Re-embedding..."
+    end
+
+    test "a forged selection outside the allowed set does not stick", %{conn: conn} do
+      {:ok, _} = Collection.get_or_create("tenant-a", Repo)
+      {:ok, _} = Collection.get_or_create("other", Repo)
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/maintenance")
+
+      render_change(view, "select_reembed_collection", %{"collection" => "other"})
+
+      html = render_click(view, "reembed", %{})
+      refute html =~ "Re-embedding..."
+    end
+  end
+
+  describe "header stats" do
+    test "counts only allowed collections", %{conn: conn} do
+      {:ok, _} = Arcana.ingest("one", repo: Repo, collection: "tenant-a")
+      {:ok, _} = Arcana.ingest("two", repo: Repo, collection: "other")
+      {:ok, _} = Arcana.ingest("three", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      assert has_element?(view, ".arcana-stat-value", "1")
+      refute has_element?(view, ".arcana-stat-value", "3")
+    end
+  end
+
+  describe "unrestricted scoped mount (:all)" do
+    test "behaves like a normal dashboard when the MFA returns :all", %{conn: conn} do
+      {:ok, _} = Collection.get_or_create("tenant-a", Repo)
+      {:ok, _} = Collection.get_or_create("other", Repo)
+
+      # no session key set: the MFA falls back to :all
+      {:ok, _view, html} = live(conn, "/scoped/collections")
+
+      assert html =~ "tenant-a"
+      assert html =~ "other"
+    end
+  end
+end

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -56,8 +56,17 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
     run
   end
 
-  defp latest_run do
-    Repo.one!(from(r in Evaluation.Run, order_by: [desc: r.inserted_at, desc: r.id], limit: 1))
+  defp run_ids do
+    Repo.all(from(r in Evaluation.Run, select: r.id))
+  end
+
+  # A "newest row" lookup would happily return a run this test never made:
+  # `inserted_at` has second granularity, so its `id` tiebreak is a random
+  # UUID, and the shared test database can still hold committed leftovers
+  # from a crashed run. Diffing against the ids seen before the submit
+  # pins the assertion to the run the test actually created.
+  defp run_created_since(ids_before) do
+    Repo.one!(from(r in Evaluation.Run, where: r.id not in ^ids_before))
   end
 
   # The ask flow answers asynchronously, so poll the render instead of
@@ -679,10 +688,12 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
       {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
 
+      ids_before = run_ids()
+
       render_submit(view, "eval_run", %{"mode" => "vector", "retriever" => "pipeline"})
       render_until(view, "Evaluation completed!")
 
-      run = latest_run()
+      run = run_created_since(ids_before)
 
       retrieved =
         run.results

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -25,6 +25,24 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       )
   end
 
+  # The ask flow answers asynchronously, so poll the render instead of
+  # sleeping a magic number of milliseconds.
+  defp render_until(view, expected, attempts \\ 50) do
+    html = render(view)
+
+    cond do
+      html =~ expected ->
+        html
+
+      attempts <= 0 ->
+        html
+
+      true ->
+        Process.sleep(20)
+        render_until(view, expected, attempts - 1)
+    end
+  end
+
   describe "collections page" do
     test "lists only allowed collections", %{conn: conn} do
       {:ok, _} = Collection.get_or_create("tenant-a", Repo)
@@ -320,8 +338,7 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
         "sub_tab" => "advanced"
       })
 
-      :timer.sleep(200)
-      html = render(view)
+      html = render_until(view, "unknown_collection")
 
       assert html =~ "unknown_collection"
       refute html =~ "Elixir content for others"

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -4,6 +4,7 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
   import Phoenix.LiveViewTest
 
   alias Arcana.Collection
+  alias Arcana.Graph.{Community, Entity, Relationship}
 
   # These tests exercise the /scoped dashboard from the test router, whose
   # :collections MFA reads the allowed list from the conn's session. Each
@@ -12,6 +13,16 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
   defp restrict(conn, allowed) do
     Plug.Test.init_test_session(conn, allowed_collections: allowed)
+  end
+
+  defp seed_entity(collection, entity_name) do
+    {:ok, _} =
+      Arcana.ingest("#{entity_name} shows up in #{collection}",
+        repo: Repo,
+        graph: true,
+        entity_extractor: fn _text, _opts -> {:ok, [%{name: entity_name, type: "concept"}]} end,
+        collection: collection
+      )
   end
 
   describe "collections page" do
@@ -53,6 +64,50 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       render_click(view, "delete_collection", %{"id" => other.id})
 
       assert Repo.get(Collection, other.id)
+    end
+
+    test "graph stat columns stay hidden when only disallowed collections have graph data",
+         %{conn: conn} do
+      {:ok, _} = Collection.get_or_create("tenant-a", Repo)
+      seed_entity("other", "SecretEntity")
+
+      {:ok, _view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/collections")
+
+      refute html =~ "<th>Entities</th>"
+    end
+
+    test "rejects renaming a collection under a restriction", %{conn: conn} do
+      {:ok, collection} = Collection.get_or_create("tenant-a", Repo)
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/collections")
+
+      render_submit(view, "update_collection", %{
+        "id" => collection.id,
+        "collection" => %{"name" => "landgrab", "description" => "mine now"}
+      })
+
+      assert Repo.get(Collection, collection.id).name == "tenant-a"
+    end
+
+    test "still allows editing a description under a restriction", %{conn: conn} do
+      {:ok, collection} = Collection.get_or_create("tenant-a", Repo)
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/collections")
+
+      render_submit(view, "update_collection", %{
+        "id" => collection.id,
+        "collection" => %{"description" => "tenant notes"}
+      })
+
+      assert Repo.get(Collection, collection.id).description == "tenant notes"
+    end
+
+    test "an empty allowed set hides the create form", %{conn: conn} do
+      {:ok, view, html} = conn |> restrict([]) |> live("/scoped/collections")
+
+      refute has_element?(view, "#new-collection-form")
+      assert html =~ "No collections are available"
+      refute html =~ "Create one above"
     end
   end
 
@@ -109,6 +164,40 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
       refute html =~ "Hidden tenant content"
     end
+
+    # The delete carries the allowed-collection predicate in the DELETE
+    # itself, so a collection renamed out of scope after the page rendered
+    # can't be deleted through a stale allow-check.
+    test "a collection renamed out of scope blocks the delete", %{conn: conn} do
+      {:ok, doc} = Arcana.ingest("Allowed tenant content", repo: Repo, collection: "tenant-a")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      collection = Repo.get_by!(Collection, name: "tenant-a")
+      Repo.update!(Collection.changeset(collection, %{name: "renamed-away"}))
+
+      render_click(view, "delete", %{"id" => doc.id})
+
+      assert {:ok, _doc} = Arcana.get_document(doc.id, repo: Repo)
+    end
+
+    test "still deletes a document inside the allowed collections", %{conn: conn} do
+      {:ok, doc} = Arcana.ingest("Allowed tenant content", repo: Repo, collection: "tenant-a")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      render_click(view, "delete", %{"id" => doc.id})
+
+      assert {:error, :not_found} = Arcana.get_document(doc.id, repo: Repo)
+    end
+
+    test "a malformed document id is rejected instead of crashing", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
+
+      render_click(view, "delete", %{"id" => "not-a-uuid"})
+
+      assert render(view) =~ "Documents"
+    end
   end
 
   describe "search page" do
@@ -147,6 +236,34 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
       refute html =~ "Elixir content for others"
     end
+
+    # An allowed name with no collection row (never created, or deleted
+    # between the mount and the submit) has to fail the search, not widen
+    # it to every collection.
+    test "a restricted search does not widen when the allowed collection is missing",
+         %{conn: conn} do
+      {:ok, _} = Arcana.ingest("Elixir content for others", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["ghost"]) |> live("/scoped/search")
+
+      html = render_submit(view, "search", %{"query" => "Elixir"})
+
+      refute html =~ "Elixir content for others"
+    end
+
+    test "a restricted search does not widen when the allowed collection is deleted mid-session",
+         %{conn: conn} do
+      {:ok, _} = Collection.get_or_create("tenant-a", Repo)
+      {:ok, _} = Arcana.ingest("Elixir content for others", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/search")
+
+      Repo.delete!(Repo.get_by!(Collection, name: "tenant-a"))
+
+      html = render_submit(view, "search", %{"query" => "Elixir"})
+
+      refute html =~ "Elixir content for others"
+    end
   end
 
   describe "ask page" do
@@ -176,6 +293,53 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       assert html =~ "not allowed"
     end
 
+    test "rejects a forged non-list collections selection", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/ask")
+
+      html =
+        render_submit(view, "ask_submit", %{
+          "question" => "What is hidden?",
+          "sub_tab" => "advanced",
+          "collections" => "other"
+        })
+
+      assert html =~ "not allowed"
+    end
+
+    # Under :strict_collections the search fails before the LLM is ever
+    # called, so this needs no real model behind the placeholder.
+    test "a restricted advanced ask fails closed when the allowed collection is missing",
+         %{conn: conn} do
+      put_arcana_env(:llm, "zai:test-stub")
+      {:ok, _} = Arcana.ingest("Elixir content for others", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["ghost"]) |> live("/scoped/ask")
+
+      render_submit(view, "ask_submit", %{
+        "question" => "What is hidden?",
+        "sub_tab" => "advanced"
+      })
+
+      :timer.sleep(200)
+      html = render(view)
+
+      assert html =~ "unknown_collection"
+      refute html =~ "Elixir content for others"
+    end
+
+    test "rejects a forged map collections selection", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/ask")
+
+      html =
+        render_submit(view, "ask_submit", %{
+          "question" => "What is hidden?",
+          "sub_tab" => "advanced",
+          "collections" => %{"0" => "other"}
+        })
+
+      assert html =~ "not allowed"
+    end
+
     test "only renders allowed collection checkboxes", %{conn: conn} do
       {:ok, _} = Collection.get_or_create("tenant-a", Repo)
       {:ok, _} = Collection.get_or_create("other", Repo)
@@ -196,6 +360,107 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
       refute html =~ "All Collections"
       refute html =~ ~s(value="other")
+    end
+
+    test "header stats count only allowed collections", %{conn: conn} do
+      {:ok, _} = Arcana.ingest("one", repo: Repo, collection: "tenant-a")
+      {:ok, _} = Arcana.ingest("two", repo: Repo, collection: "other")
+      {:ok, _} = Arcana.ingest("three", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/graph")
+
+      assert has_element?(view, ".arcana-stat-value", "1")
+      refute has_element?(view, ".arcana-stat-value", "3")
+    end
+
+    # "ghost" is allowed but has no collection row, so it resolves to no
+    # collection id. It sorts first in the allowed list, so the selection
+    # normalization picks it and every loader has to refuse rather than
+    # fall through to an unscoped read. tenant-a supplies the graph data
+    # that keeps the entity table (and its forgeable events) rendered.
+    test "a forged filter event cannot read entities outside the allowed set", %{conn: conn} do
+      seed_entity("tenant-a", "AllowedEntity")
+      seed_entity("other", "SecretEntity")
+
+      {:ok, view, html} = conn |> restrict(["ghost", "tenant-a"]) |> live("/scoped/graph")
+
+      refute html =~ "SecretEntity"
+
+      html = render_change(view, "filter_entities", %{"name" => ""})
+
+      refute html =~ "SecretEntity"
+    end
+
+    test "still browses entities when the selection resolves to an allowed collection",
+         %{conn: conn} do
+      seed_entity("tenant-a", "AllowedEntity")
+      seed_entity("other", "SecretEntity")
+
+      {:ok, view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/graph")
+
+      assert html =~ "AllowedEntity"
+      refute html =~ "SecretEntity"
+
+      html = render_change(view, "filter_entities", %{"name" => "Allowed"})
+
+      assert html =~ "AllowedEntity"
+      refute html =~ "SecretEntity"
+    end
+
+    test "a forged pagination event cannot read entities outside the allowed set", %{conn: conn} do
+      seed_entity("tenant-a", "AllowedEntity")
+      seed_entity("other", "SecretEntity")
+
+      {:ok, view, _html} = conn |> restrict(["ghost", "tenant-a"]) |> live("/scoped/graph")
+
+      html = render_click(view, "entities_page", %{"page" => "1"})
+
+      refute html =~ "SecretEntity"
+    end
+
+    test "a forged relationship filter event cannot escape the allowed set", %{conn: conn} do
+      seed_entity("tenant-a", "AllowedEntity")
+      seed_entity("other", "SecretSource")
+      seed_entity("other", "SecretTarget")
+
+      other = Repo.get_by!(Collection, name: "other")
+      source = Repo.get_by!(Entity, name: "SecretSource", collection_id: other.id)
+      target = Repo.get_by!(Entity, name: "SecretTarget", collection_id: other.id)
+
+      Repo.insert!(%Relationship{
+        source_id: source.id,
+        target_id: target.id,
+        type: "knows",
+        strength: 8
+      })
+
+      {:ok, view, _html} =
+        conn |> restrict(["ghost", "tenant-a"]) |> live("/scoped/graph?tab=relationships")
+
+      html = render_change(view, "filter_relationships", %{"search" => ""})
+
+      refute html =~ "SecretSource"
+    end
+
+    test "a forged community filter event cannot escape the allowed set", %{conn: conn} do
+      seed_entity("tenant-a", "AllowedEntity")
+      seed_entity("other", "SecretEntity")
+
+      other = Repo.get_by!(Collection, name: "other")
+
+      Repo.insert!(%Community{
+        collection_id: other.id,
+        level: 0,
+        summary: "SecretCommunity summary",
+        entity_ids: []
+      })
+
+      {:ok, view, _html} =
+        conn |> restrict(["ghost", "tenant-a"]) |> live("/scoped/graph?tab=communities")
+
+      html = render_change(view, "filter_communities", %{"search" => ""})
+
+      refute html =~ "SecretCommunity"
     end
   end
 

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -1,9 +1,11 @@
 defmodule ArcanaWeb.AllowedCollectionsTest do
   use ArcanaWeb.ConnCase, async: true
 
+  import Ecto.Query
   import Phoenix.LiveViewTest
 
   alias Arcana.Collection
+  alias Arcana.Evaluation
   alias Arcana.Graph.{Community, Entity, Relationship}
 
   # These tests exercise the /scoped dashboard from the test router, whose
@@ -23,6 +25,39 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
         entity_extractor: fn _text, _opts -> {:ok, [%{name: entity_name, type: "concept"}]} end,
         collection: collection
       )
+  end
+
+  # Evaluation test cases reach a collection through their chunks, so the
+  # seed ingests a document and links every chunk it produced. The tokens
+  # callers pass in must survive HTML escaping untouched (no apostrophes),
+  # otherwise a `refute html =~ token` passes for the wrong reason.
+  defp seed_test_case(collection, text, question, reference_answer \\ nil) do
+    {:ok, doc} = Arcana.ingest(text, repo: Repo, collection: collection)
+
+    chunks = Repo.all(from(c in Arcana.Chunk, where: c.document_id == ^doc.id))
+
+    {:ok, test_case} =
+      Evaluation.create_test_case(
+        repo: Repo,
+        question: question,
+        relevant_chunk_ids: Enum.map(chunks, & &1.id),
+        reference_answer: reference_answer
+      )
+
+    {test_case, chunks}
+  end
+
+  defp insert_run(config) do
+    {:ok, run} =
+      %Evaluation.Run{}
+      |> Evaluation.Run.changeset(%{status: :completed, config: config, test_case_count: 4242})
+      |> Repo.insert()
+
+    run
+  end
+
+  defp latest_run do
+    Repo.one!(from(r in Evaluation.Run, order_by: [desc: r.inserted_at, desc: r.id], limit: 1))
   end
 
   # The ask flow answers asynchronously, so poll the render instead of
@@ -120,6 +155,19 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       assert Repo.get(Collection, collection.id).description == "tenant notes"
     end
 
+    test "a malformed collection id is rejected instead of crashing", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/collections")
+
+      render_click(view, "delete_collection", %{"id" => "not-a-uuid"})
+
+      render_submit(view, "update_collection", %{
+        "id" => "not-a-uuid",
+        "collection" => %{"description" => "nope"}
+      })
+
+      assert render(view) =~ "Collections"
+    end
+
     test "an empty allowed set hides the create form", %{conn: conn} do
       {:ok, view, html} = conn |> restrict([]) |> live("/scoped/collections")
 
@@ -213,6 +261,8 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
 
       render_click(view, "delete", %{"id" => "not-a-uuid"})
+      render_click(view, "view_document", %{"id" => "not-a-uuid"})
+      render_click(view, "build_graph", %{})
 
       assert render(view) =~ "Documents"
     end
@@ -243,6 +293,14 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
         render_submit(view, "search", %{"query" => "Elixir", "collections" => ["other"]})
 
       refute html =~ "Elixir content for others"
+    end
+
+    test "a malformed document id is rejected instead of crashing", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/search")
+
+      render_click(view, "view_search_document", %{"id" => "not-a-uuid"})
+
+      assert render(view) =~ "Search"
     end
 
     test "an empty allowed set never searches anything", %{conn: conn} do
@@ -424,6 +482,16 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       refute html =~ "SecretEntity"
     end
 
+    test "malformed selection ids are rejected instead of crashing", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/graph")
+
+      render_click(view, "select_entity", %{"id" => "not-a-uuid"})
+      render_click(view, "select_relationship", %{"id" => "not-a-uuid"})
+      render_click(view, "select_community", %{"id" => "not-a-uuid"})
+
+      assert render(view) =~ "Graph"
+    end
+
     test "a forged pagination event cannot read entities outside the allowed set", %{conn: conn} do
       seed_entity("tenant-a", "AllowedEntity")
       seed_entity("other", "SecretEntity")
@@ -481,6 +549,217 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
     end
   end
 
+  describe "evaluation page" do
+    test "lists only test cases whose chunks live in allowed collections", %{conn: conn} do
+      seed_test_case("other", "SecretEvalChunkZulu", "SecretEvalQuestionZulu")
+      seed_test_case("tenant-a", "AllowedEvalChunkZulu", "AllowedEvalQuestionZulu")
+
+      {:ok, _view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      assert html =~ "AllowedEvalQuestionZulu"
+      refute html =~ "SecretEvalQuestionZulu"
+      assert html =~ "Test Cases (1)"
+    end
+
+    test "hides a test case that straddles an allowed and a disallowed collection",
+         %{conn: conn} do
+      {_tc, [allowed_chunk]} = seed_test_case("tenant-a", "AllowedEvalChunkZulu", "allowed")
+      {_tc, [secret_chunk]} = seed_test_case("other", "SecretEvalChunkZulu", "secret")
+
+      {:ok, straddler} =
+        Evaluation.create_test_case(
+          repo: Repo,
+          question: "StraddlingEvalQuestionZulu",
+          relevant_chunk_ids: [allowed_chunk.id, secret_chunk.id]
+        )
+
+      {:ok, view, html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      refute html =~ "StraddlingEvalQuestionZulu"
+
+      html = render_click(view, "toggle_test_case", %{"id" => straddler.id})
+
+      refute html =~ "SecretEvalChunkZulu"
+    end
+
+    test "a forged toggle cannot expand a test case outside the allowed collections",
+         %{conn: conn} do
+      {secret, _chunks} =
+        seed_test_case(
+          "other",
+          "SecretEvalChunkZulu",
+          "SecretEvalQuestionZulu",
+          "SecretEvalAnswerZulu"
+        )
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      html = render_click(view, "toggle_test_case", %{"id" => secret.id})
+
+      refute html =~ "SecretEvalAnswerZulu"
+      refute html =~ "SecretEvalChunkZulu"
+    end
+
+    test "rejects deleting a test case outside the allowed collections", %{conn: conn} do
+      {secret, _chunks} = seed_test_case("other", "SecretEvalChunkZulu", "SecretEvalQuestionZulu")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      render_click(view, "eval_delete_test_case", %{"id" => secret.id})
+
+      assert Repo.get(Evaluation.TestCase, secret.id)
+    end
+
+    test "still deletes a test case inside the allowed collections", %{conn: conn} do
+      {allowed, _chunks} =
+        seed_test_case("tenant-a", "AllowedEvalChunkZulu", "AllowedEvalQuestionZulu")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      render_click(view, "eval_delete_test_case", %{"id" => allowed.id})
+
+      refute Repo.get(Evaluation.TestCase, allowed.id)
+    end
+
+    test "a malformed test case id is rejected instead of crashing", %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      render_click(view, "eval_delete_test_case", %{"id" => "not-a-uuid"})
+
+      assert render(view) =~ "Evaluation"
+    end
+
+    test "hides and refuses to delete runs that are not scoped to the allowed collections",
+         %{conn: conn} do
+      global_run = insert_run(%{"mode" => "vector"})
+      foreign_run = insert_run(%{"mode" => "vector", "collections" => ["other"]})
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      html = render_click(view, "eval_switch_view", %{"view" => "history"})
+
+      refute html =~ "4242 test cases"
+
+      render_click(view, "eval_delete_run", %{"id" => global_run.id})
+      render_click(view, "eval_delete_run", %{"id" => foreign_run.id})
+
+      assert Repo.get(Evaluation.Run, global_run.id)
+      assert Repo.get(Evaluation.Run, foreign_run.id)
+    end
+
+    test "still shows and deletes a run scoped to the allowed collections", %{conn: conn} do
+      run = insert_run(%{"mode" => "vector", "collections" => ["tenant-a"]})
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      html = render_click(view, "eval_switch_view", %{"view" => "history"})
+
+      assert html =~ "4242 test cases"
+
+      render_click(view, "eval_delete_run", %{"id" => run.id})
+
+      refute Repo.get(Evaluation.Run, run.id)
+    end
+
+    # Running an evaluation is a retrieval primitive: without scoping every
+    # test case searches every collection, so the run's stored results hand
+    # back chunk ids the tenant may not read.
+    test "a restricted evaluation run only retrieves from allowed collections", %{conn: conn} do
+      {_tc, _chunks} =
+        seed_test_case("tenant-a", "AllowedEvalChunkZulu", "AllowedEvalQuestionZulu")
+
+      {:ok, secret_doc} = Arcana.ingest("SecretEvalChunkZulu", repo: Repo, collection: "other")
+
+      secret_ids =
+        Repo.all(from(c in Arcana.Chunk, where: c.document_id == ^secret_doc.id, select: c.id))
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      render_submit(view, "eval_run", %{"mode" => "vector", "retriever" => "pipeline"})
+      render_until(view, "Evaluation completed!")
+
+      run = latest_run()
+
+      retrieved =
+        run.results
+        |> Map.values()
+        |> Enum.flat_map(&(&1["retrieved_chunk_ids"] || []))
+
+      assert run.config["collections"] == ["tenant-a"]
+      assert Enum.all?(secret_ids, &(&1 not in retrieved))
+    end
+
+    # Telemetry handlers are global, so an unfiltered progress handler
+    # renders whatever question any other evaluation is on right now.
+    test "the progress panel ignores telemetry from other evaluation runs", %{conn: conn} do
+      seed_test_case("tenant-a", "AllowedEvalChunkZulu", "AllowedEvalQuestionZulu")
+      put_arcana_env(:llm, "zai:test-stub")
+
+      put_arcana_env(:loop_runner, fn ctx, _opts ->
+        Process.sleep(300)
+
+        {:ok,
+         %Arcana.Loop.Context{
+           question: ctx.question,
+           answer: "stubbed",
+           tool_history: [],
+           iterations: 1,
+           terminated_by: :answered,
+           chunks: [],
+           grounding: nil
+         }}
+      end)
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      render_submit(view, "eval_run", %{"mode" => "vector", "retriever" => "loop"})
+
+      :telemetry.execute(
+        [:arcana, :evaluation, :test_case, :start],
+        %{index: 1},
+        %{
+          run_id: Ecto.UUID.generate(),
+          run_ref: make_ref(),
+          index: 1,
+          total: 1,
+          question: "ForeignProgressQuestionZulu"
+        }
+      )
+
+      refute render(view) =~ "ForeignProgressQuestionZulu"
+    end
+
+    test "a restricted Loop evaluation runs scoped and strict", %{conn: conn} do
+      seed_test_case("tenant-a", "AllowedEvalChunkZulu", "AllowedEvalQuestionZulu")
+      put_arcana_env(:llm, "zai:test-stub")
+
+      test_pid = self()
+
+      put_arcana_env(:loop_runner, fn ctx, opts ->
+        send(test_pid, {:loop_scope, ctx.collections, opts[:search_opts]})
+
+        {:ok,
+         %Arcana.Loop.Context{
+           question: ctx.question,
+           answer: "stubbed",
+           tool_history: [],
+           iterations: 1,
+           terminated_by: :answered,
+           chunks: [],
+           grounding: nil
+         }}
+      end)
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/evaluation")
+
+      render_submit(view, "eval_run", %{"mode" => "vector", "retriever" => "loop"})
+
+      assert_receive {:loop_scope, collections, search_opts}, 2_000
+      assert collections == ["tenant-a"]
+      assert search_opts[:strict_collections] == true
+    end
+  end
+
   describe "maintenance page" do
     test "restricted dashboards cannot run collection-wide actions", %{conn: conn} do
       {:ok, _} = Collection.get_or_create("tenant-a", Repo)
@@ -505,6 +784,31 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
       html = render_click(view, "reembed", %{})
       refute html =~ "Re-embedding..."
+    end
+
+    # An allowed name with no collection row resolves to "no filter", which
+    # would re-chunk and re-embed every document in the database. The
+    # re-embed has to fail instead.
+    test "a restricted re-embed fails closed when the allowed collection is missing",
+         %{conn: conn} do
+      {:ok, _} = Arcana.ingest("Other tenant content", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["ghost"]) |> live("/scoped/maintenance")
+
+      test_pid = self()
+
+      put_arcana_env(:embedder, fn text ->
+        send(test_pid, {:embedded, text})
+        {:ok, List.duplicate(0.1, 384)}
+      end)
+
+      render_change(view, "select_reembed_collection", %{"collection" => "ghost"})
+      render_click(view, "reembed", %{})
+
+      # The stub embedder is the probe: unscoped, the re-embed walks every
+      # chunk in the database and calls it.
+      refute_receive {:embedded, _}, 500
+      assert render(view) =~ "Maintenance"
     end
   end
 

--- a/test/arcana_web/router_test.exs
+++ b/test/arcana_web/router_test.exs
@@ -58,12 +58,77 @@ defmodule ArcanaWeb.RouterTest do
     assert session_mfa == {ArcanaWeb.Router, :__session__, [Arcana.TestRepo, ""]}
   end
 
-  # Phoenix accepts a bare module for :on_mount, so prepending our Prefix
-  # hook must not build an improper list like [Prefix | Module].
+  # Phoenix accepts a bare module for :on_mount, so prepending our Scope
+  # hook must not build an improper list like [Scope | Module].
   test "__options__ wraps a single on_mount module into a proper list" do
     {_name, session_opts, _route_opts} =
       ArcanaWeb.Router.__options__([on_mount: SomeHook], "/arcana")
 
-    assert session_opts[:on_mount] == [ArcanaWeb.Router.Prefix, SomeHook]
+    assert session_opts[:on_mount] == [ArcanaWeb.Router.Scope, SomeHook]
+  end
+
+  describe ":collections option" do
+    defmodule Access do
+      def restricted(_conn), do: ["tenant-a", "tenant-b"]
+      def open(_conn), do: :all
+      def broken(_conn), do: {:ok, ["tenant-a"]}
+      def mixed(_conn), do: ["tenant-a", :oops]
+    end
+
+    test "appends the MFA to the session args when given" do
+      {_name, session_opts, _route_opts} =
+        ArcanaWeb.Router.__options__(
+          [repo: Arcana.TestRepo, collections: {Access, :restricted}],
+          "/arcana"
+        )
+
+      assert session_opts[:session] ==
+               {ArcanaWeb.Router, :__session__,
+                [Arcana.TestRepo, "/arcana", {Access, :restricted}]}
+    end
+
+    test "rejects anything that is not a {module, function} tuple" do
+      for bad <- [&String.length/1, "collections", {Access, :restricted, []}] do
+        assert_raise ArgumentError, ~r/:collections must be a \{module, function\} tuple/, fn ->
+          ArcanaWeb.Router.__options__([collections: bad], "/arcana")
+        end
+      end
+    end
+
+    test "__session__/4 resolves the MFA into allowed_collections" do
+      session =
+        ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/arcana", {Access, :restricted})
+
+      assert session["allowed_collections"] == ["tenant-a", "tenant-b"]
+      assert session["prefix"] == "/arcana"
+      assert session["repo"] == Arcana.TestRepo
+    end
+
+    test "__session__/4 keeps :all unrestricted" do
+      session = ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/arcana", {Access, :open})
+
+      assert session["allowed_collections"] == :all
+    end
+
+    test "__session__/4 fails closed on invalid returns" do
+      assert_raise ArgumentError, ~r/must return :all or a list/, fn ->
+        ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/arcana", {Access, :broken})
+      end
+
+      assert_raise ArgumentError, ~r/non-string entries/, fn ->
+        ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/arcana", {Access, :mixed})
+      end
+    end
+
+    test "option absent keeps the session MFA and content unchanged" do
+      {_name, session_opts, _route_opts} =
+        ArcanaWeb.Router.__options__([repo: Arcana.TestRepo], "/arcana")
+
+      assert session_opts[:session] ==
+               {ArcanaWeb.Router, :__session__, [Arcana.TestRepo, "/arcana"]}
+
+      session = ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/arcana")
+      refute Map.has_key?(session, "allowed_collections")
+    end
   end
 end

--- a/test/support/test_router.ex
+++ b/test/support/test_router.ex
@@ -6,6 +6,17 @@ defmodule ArcanaWeb.TestRouter do
   import Phoenix.LiveView.Router
   import ArcanaWeb.Router
 
+  defmodule Allowed do
+    @moduledoc false
+
+    # Collections MFA for the /scoped dashboard below. Reads the allowed
+    # list from the conn's session so each test can set its own restriction
+    # via Plug.Test.init_test_session/2 — per-conn state, async-safe.
+    def for_conn(conn) do
+      Plug.Conn.get_session(conn, :allowed_collections) || :all
+    end
+  end
+
   pipeline :browser do
     plug(:accepts, ["html"])
     plug(:fetch_session)
@@ -18,5 +29,15 @@ defmodule ArcanaWeb.TestRouter do
     pipe_through(:browser)
 
     arcana_dashboard("/arcana", repo: Arcana.TestRepo)
+  end
+
+  scope "/" do
+    pipe_through(:browser)
+
+    arcana_dashboard("/scoped",
+      repo: Arcana.TestRepo,
+      live_session_name: :arcana_dashboard_scoped,
+      collections: {ArcanaWeb.TestRouter.Allowed, :for_conn}
+    )
   end
 end


### PR DESCRIPTION
#94 item 9: the dashboard saw and could mutate every collection, making it superuser-only. New `arcana_dashboard` option:

```elixir
arcana_dashboard "/arcana",
  collections: {MyApp.Tenancy, :allowed_collections}
```

a serializable MFA called at request time with the `%Plug.Conn{}`, returning `:all` or a list of allowed collection names (anything else raises — fail closed). The result rides the live session and an on_mount hook assigns `:allowed_collections` to every dashboard LiveView.

**Enforcement is UI + server-side**: every surface filters its rendering AND rejects forged params — collections CRUD, documents listing/detail/ingest/upload/delete, search (empty allowed set short-circuits; the pre-existing `collections: []`-drops-the-opt clause would have failed open), ask across all three sub-tabs (including the forged `llm_select` hole; Loop pins its collections, Pipeline.select's universe is the filtered list), graph views (forced concrete selection, detail panels reject forged ids), maintenance (orphan tools hidden and blocked under restriction — orphans belong to no collection), and the header stats count only allowed collections. Absent option = byte-identical current behavior; `[]` is a real restriction.

**Also adds** `live_session_name:` (needed because Phoenix rejects duplicate live_session names, so a second dashboard mount couldn't compile; default unchanged). Evaluation run/test-case listings stay global — that schema isn't collection-scoped, so scoping it is a library change, not a dashboard hook.

33 new tests (router MFA resolution + LiveView scoping via a second scoped mount in the test router, per-conn and async-safe). Documented in the router moduledoc and the dashboard guide next to Authentication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds host-controlled collection scoping to the dashboard and closes bypasses. Previously any dashboard could read and mutate all collections; now a router-provided scope limits each request to `:all` or a named list, and every surface enforces that scope, including follow-up pipeline searches.

- Router: `collections: {Module, function}` gets `%Plug.Conn{}` and returns `:all` or collection names; saved as `:allowed_collections` in the LiveView session. `live_session_name:` lets you mount multiple dashboards in one router. Default behavior is unchanged.
- Enforcement: collections CRUD; documents list/detail/ingest/upload/delete (DELETE carries the allowed predicate); search and ask run under strict collections; forged params rejected. Graph selection normalizes to allowed; maintenance hides/blocks orphaned tools; header stats filtered; renaming disabled under restriction; non-UUID ids rejected; empty allow-lists show a no-access state.
- Pipeline: `search/2` records its searcher and resolved collections on the context; `reason/2` inherits both and uses the same resolver, preventing fallback widening. Explicit nil `:searcher` fails fast.
- Evaluation: `list_test_cases/1`, `count_test_cases/1`, and `get_test_case/1` accept `:collections` and include only cases whose chunks resolve entirely within the allowed set (and at least one does). Runs record their scope; listings/deletes show runs whose recorded scope is a non-empty subset of the allow-list; unscoped runs stay hidden. `run/1` forwards `:collections` with `strict_collections: true` and uses `:run_ref` to scope telemetry.

**Rollout**
- Scope is resolved during the page request and signed into the LiveView session; narrowing permissions does not shrink an open dashboard. Mitigate with a per-user `live_socket_id` and a disconnect broadcast.
- No migration required.

<sup>Written for commit ea2f73beb1d3c28d2e082fbcd53111081a34a9a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

