### PR TITLE
feat!: General file parser registry and chunk source offsets

### DIFF
--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -69,6 +69,12 @@ defmodule Arcana do
   """
   defdelegate ingest_file(path, opts), to: Arcana.Ingest
 
+  @doc """
+  Ingests in-memory bytes, routing on the required `:filename` option's
+  extension. See `Arcana.Ingest.ingest_binary/2` for options.
+  """
+  defdelegate ingest_binary(binary, opts), to: Arcana.Ingest
+
   # === Search ===
 
   @doc """

--- a/lib/arcana/chunker.ex
+++ b/lib/arcana/chunker.ex
@@ -100,4 +100,30 @@ defmodule Arcana.Chunker do
     merged_opts = Keyword.merge(default_opts, extra_opts)
     module.chunk(text, merged_opts)
   end
+
+  # Keys that live in their own `Arcana.Chunk` column rather than in
+  # metadata.
+  @chunk_fields [:text, :chunk_index, :token_count, :metadata, :embedding, :id, :document_id]
+
+  @doc """
+  Builds the metadata to store for a chunk map.
+
+  A chunker's own `:metadata` map is the canonical place for extra keys
+  (that's what `Arcana.Chunker.Default` uses for its byte offsets), and
+  anything else it hands back is folded in too, as the behaviour
+  promises. Keys are stringified since chunk metadata round-trips
+  through JSONB; a declared `:metadata` entry wins over a top-level one.
+
+  Every path that inserts chunks goes through here, so a document
+  recovered by `Arcana.Maintenance.reembed/2` carries the same metadata
+  the original ingest would have given it.
+  """
+  def metadata_for(chunk) do
+    extras = chunk |> Map.drop([:__struct__ | @chunk_fields]) |> stringify_keys()
+    declared = chunk |> Map.get(:metadata) |> Kernel.||(%{}) |> stringify_keys()
+
+    Map.merge(extras, declared)
+  end
+
+  defp stringify_keys(map), do: Map.new(map, fn {key, value} -> {to_string(key), value} end)
 end

--- a/lib/arcana/chunker.ex
+++ b/lib/arcana/chunker.ex
@@ -53,8 +53,15 @@ defmodule Arcana.Chunker do
     * `:text` - The chunk text content (required)
     * `:chunk_index` - Zero-based index of this chunk (required)
     * `:token_count` - Estimated token count (required)
+    * `:metadata` - Optional map stored on the chunk as-is
 
-  Additional keys may be included and will be passed through to storage.
+  Any other key is folded into the stored metadata too. Metadata
+  round-trips through JSONB, so keys are stringified on the way in:
+  a chunk of `%{text: ..., chunk_index: 0, token_count: 8, page: 3}`
+  reads back as `metadata["page"] == 3`.
+
+  `Arcana.Chunker.Default` uses this to report each chunk's
+  `"start_byte"`/`"end_byte"` range in the source text.
   """
 
   @doc """

--- a/lib/arcana/chunker/default.ex
+++ b/lib/arcana/chunker/default.ex
@@ -55,14 +55,21 @@ defmodule Arcana.Chunker.Default do
 
     text
     |> TextChunker.split(text_chunker_opts)
-    |> Enum.map(& &1.text)
-    |> Enum.reject(&blank?/1)
+    |> Enum.reject(&blank?(&1.text))
     |> Enum.with_index()
-    |> Enum.map(fn {text, index} ->
+    |> Enum.map(fn {chunk, index} ->
       %{
-        text: text,
+        text: chunk.text,
         chunk_index: index,
-        token_count: estimate_tokens(text)
+        token_count: estimate_tokens(chunk.text),
+        # Byte offsets into the source text, carried through to chunk
+        # metadata so citations can point back at the original document.
+        # chunk_index is renumbered after blanks are dropped, so offsets
+        # are the only reliable position key.
+        metadata: %{
+          "start_byte" => chunk.start_byte,
+          "end_byte" => chunk.end_byte
+        }
       }
     end)
   end

--- a/lib/arcana/config.ex
+++ b/lib/arcana/config.ex
@@ -488,6 +488,50 @@ defmodule Arcana.Config do
     )
   end
 
+  @doc """
+  Returns the configured file parsers as a map of extension to
+  `{module, opts}`.
+
+  Extensions are normalized to lowercase with a leading dot, so
+  `%{"docx" => ...}` and `%{".DOCX" => ...}` both register `".docx"`.
+
+      config :arcana, file_parsers: %{".docx" => {MyApp.DocxParser, []}}
+
+  """
+  def file_parsers do
+    get_env(:file_parsers, %{})
+    |> Map.new(fn {extension, value} ->
+      {normalize_extension(extension), parse_file_parser_config(value)}
+    end)
+  end
+
+  @doc """
+  Returns the configured fallback parser as `{module, opts}`, or `nil`.
+
+  Consulted for any extension without a native or registered parser:
+
+      config :arcana, fallback_parser: {MyApp.ExtractionService, []}
+
+  """
+  def fallback_parser do
+    case get_env(:fallback_parser) do
+      nil -> nil
+      value -> parse_file_parser_config(value)
+    end
+  end
+
+  @doc false
+  def parse_file_parser_config(value) do
+    parse_pluggable(value, name: "file parser")
+  end
+
+  @doc false
+  def normalize_extension(extension) do
+    extension = extension |> to_string() |> String.downcase()
+
+    if String.starts_with?(extension, "."), do: extension, else: "." <> extension
+  end
+
   @doc false
   def parse_entity_matcher_config(value) do
     parse_pluggable(value,

--- a/lib/arcana/config.ex
+++ b/lib/arcana/config.ex
@@ -441,7 +441,10 @@ defmodule Arcana.Config do
   defp custom_function_result(fun, nil), do: {fun, []}
   defp custom_function_result(fun, module), do: {module, [fun: fun]}
 
-  defp plain_module?(value), do: is_atom(value) and not is_nil(value)
+  # `true`/`false` are atoms but never module names: letting them through
+  # here produced `function false.parse/2` at call time instead of a
+  # config error (or, for components that accept it, a disabled component).
+  defp plain_module?(value), do: is_atom(value) and not is_boolean(value) and not is_nil(value)
 
   defp module_opts_tuple?(value) do
     is_tuple(value) and tuple_size(value) == 2 and
@@ -497,6 +500,12 @@ defmodule Arcana.Config do
 
       config :arcana, file_parsers: %{".docx" => {MyApp.DocxParser, []}}
 
+  Mapping an extension to `false` disables it: nothing parses it, not the
+  built-in route and not the `:fallback_parser`. Such entries come back
+  as `nil`.
+
+      config :arcana, file_parsers: %{".pdf" => false}
+
   """
   def file_parsers do
     get_env(:file_parsers, %{})
@@ -512,17 +521,15 @@ defmodule Arcana.Config do
 
       config :arcana, fallback_parser: {MyApp.ExtractionService, []}
 
+  `nil` and `false` both mean "no fallback".
   """
   def fallback_parser do
-    case get_env(:fallback_parser) do
-      nil -> nil
-      value -> parse_file_parser_config(value)
-    end
+    get_env(:fallback_parser) |> parse_file_parser_config()
   end
 
   @doc false
   def parse_file_parser_config(value) do
-    parse_pluggable(value, name: "file parser")
+    parse_pluggable(value, name: "file parser", allow_nil?: true)
   end
 
   @doc false

--- a/lib/arcana/config.ex
+++ b/lib/arcana/config.ex
@@ -446,9 +446,12 @@ defmodule Arcana.Config do
   # config error (or, for components that accept it, a disabled component).
   defp plain_module?(value), do: is_atom(value) and not is_boolean(value) and not is_nil(value)
 
+  # The head has to pass the same test a bare module does: `{false, opts}`
+  # and `{nil, opts}` look like a {module, opts} pair but land on
+  # `function false.parse/2` at call time, exactly like bare `false` did.
   defp module_opts_tuple?(value) do
     is_tuple(value) and tuple_size(value) == 2 and
-      is_atom(elem(value, 0)) and is_list(elem(value, 1))
+      plain_module?(elem(value, 0)) and is_list(elem(value, 1))
   end
 
   @doc false

--- a/lib/arcana/file_parser.ex
+++ b/lib/arcana/file_parser.ex
@@ -33,7 +33,9 @@ defmodule Arcana.FileParser do
 
         # Optional: accept binary content, enabling `Arcana.ingest_binary/2`
         # for this format (default: false, path only). Path-only parsers
-        # make ingest_binary/2 return {:error, {:binary_unsupported, mod}}.
+        # make ingest_binary/2 return {:error, {:binary_unsupported, mod}},
+        # unless they are unavailable too — then unavailability is what
+        # gets reported, since a path retry would fail just the same.
         @impl true
         def supports_binary?, do: true
 

--- a/lib/arcana/file_parser.ex
+++ b/lib/arcana/file_parser.ex
@@ -90,6 +90,13 @@ defmodule Arcana.FileParser do
   Parsers predating positional metadata return `{:ok, text}`; those come
   back here as `{:ok, text, %{}}` so callers only handle one shape.
 
+  Metadata that isn't a map, or whose `:pages` aren't
+  `%{number: _, start: integer, end: integer}` maps, comes back as
+  `{:error, {:invalid_parser_metadata, module, meta}}`. Ingestion reads
+  those offsets long after the document row is inserted, so catching the
+  shape here is what keeps a misbehaving parser from raising out of
+  library internals and orphaning a `:processing` document.
+
   A parser reporting itself unavailable (`available?/0`) is never
   invoked: this returns `{:error, unavailable_reason(parser)}` instead.
   The check lives here rather than in a caller so that every route into
@@ -111,7 +118,11 @@ defmodule Arcana.FileParser do
         {:ok, text, %{}}
 
       {:ok, text, meta} when is_map(meta) ->
-        {:ok, text, meta}
+        if valid_pages?(Map.get(meta, :pages)) do
+          {:ok, text, meta}
+        else
+          {:error, {:invalid_parser_metadata, module, meta}}
+        end
 
       # Metadata is documented as a map (`%{pages: [...]}`); a keyword list
       # is the easy slip. Report it rather than raising CaseClauseError from
@@ -126,6 +137,25 @@ defmodule Arcana.FileParser do
         {:error, {:invalid_parser_return, module, other}}
     end
   end
+
+  # `:pages` is the one metadata key ingestion reads, and it reads it deep
+  # inside chunking — after the document row exists. String-keyed entries
+  # (`%{"start" => 0}`) or bare numbers (`[1, 2]`) raise KeyError/BadMapError
+  # from there, leaving a `:processing` document behind and naming no
+  # parser. Checking the shape here keeps a bad parser to an error tuple
+  # that says which module it was, before anything is written.
+  #
+  # Absent or empty pages are fine: those mean "this parser doesn't report
+  # positions", which is the documented default.
+  defp valid_pages?(nil), do: true
+  defp valid_pages?(pages) when is_list(pages), do: Enum.all?(pages, &valid_page?/1)
+  defp valid_pages?(_pages), do: false
+
+  defp valid_page?(%{number: _number, start: start_byte, end: end_byte})
+       when is_integer(start_byte) and is_integer(end_byte),
+       do: true
+
+  defp valid_page?(_page), do: false
 
   @doc """
   Whether a `{module, opts}` parser accepts binary content.

--- a/lib/arcana/file_parser.ex
+++ b/lib/arcana/file_parser.ex
@@ -151,8 +151,12 @@ defmodule Arcana.FileParser do
   defp valid_pages?(pages) when is_list(pages), do: Enum.all?(pages, &valid_page?/1)
   defp valid_pages?(_pages), do: false
 
+  # A negative or reversed range is as malformed as a missing key, and it
+  # fails worse: page_at/2 would fall back rather than raise, so the chunk
+  # gets a page citation pointing somewhere the text isn't.
   defp valid_page?(%{number: _number, start: start_byte, end: end_byte})
-       when is_integer(start_byte) and is_integer(end_byte),
+       when is_integer(start_byte) and is_integer(end_byte) and
+              start_byte >= 0 and end_byte >= start_byte,
        do: true
 
   defp valid_page?(_page), do: false

--- a/lib/arcana/file_parser.ex
+++ b/lib/arcana/file_parser.ex
@@ -45,6 +45,12 @@ defmodule Arcana.FileParser do
         def available?, do: true
       end
 
+  The gate lives in `parse/3`, so every dispatch path gets it: this
+  module, `Arcana.FileParser.PDF.parse/3`, and everything routed through
+  `Arcana.Parser`. The one exception to the error shape is the built-in
+  `Arcana.FileParser.PDF.Poppler`, which reports `:poppler_not_available`
+  for backwards compatibility — see `unavailable_reason/1`.
+
   ## Positional metadata
 
   `parse/2` may return `{:ok, text, meta}` instead of `{:ok, text}`.
@@ -81,8 +87,21 @@ defmodule Arcana.FileParser do
 
   Parsers predating positional metadata return `{:ok, text}`; those come
   back here as `{:ok, text, %{}}` so callers only handle one shape.
+
+  A parser reporting itself unavailable (`available?/0`) is never
+  invoked: this returns `{:error, unavailable_reason(parser)}` instead.
+  The check lives here rather than in a caller so that every route into
+  a parser carries the same guarantee.
   """
-  def parse({module, parser_opts}, input, call_opts \\ []) do
+  def parse({_module, _parser_opts} = parser, input, call_opts \\ []) do
+    if available?(parser) do
+      invoke(parser, input, call_opts)
+    else
+      {:error, unavailable_reason(parser)}
+    end
+  end
+
+  defp invoke({module, parser_opts}, input, call_opts) do
     opts = Keyword.merge(parser_opts, call_opts)
 
     case module.parse(input, opts) do
@@ -133,4 +152,18 @@ defmodule Arcana.FileParser do
       true -> true
     end
   end
+
+  @doc """
+  The error reported for a parser that can't run.
+
+  `{:parser_unavailable, module}` for every parser but the built-in
+  Poppler one, which has reported `:poppler_not_available` since before
+  this gate existed and whose callers match on it.
+
+  Callers that decide between several failure reasons (`Arcana.Parser`
+  weighing this against `:binary_unsupported`, say) need the reason
+  without invoking the parser, which is why this is public.
+  """
+  def unavailable_reason({Arcana.FileParser.PDF.Poppler, _opts}), do: :poppler_not_available
+  def unavailable_reason({module, _opts}), do: {:parser_unavailable, module}
 end

--- a/lib/arcana/file_parser.ex
+++ b/lib/arcana/file_parser.ex
@@ -18,7 +18,8 @@ defmodule Arcana.FileParser do
 
   Exact extension matches win over the fallback, and the built-in
   handling for `.txt`/`.md`/`.pdf` can be overridden by registering
-  those extensions explicitly.
+  those extensions explicitly. Registering one as `false` disables it
+  outright, fallback included.
 
   ## Implementing a parser
 
@@ -30,8 +31,9 @@ defmodule Arcana.FileParser do
           {:ok, extracted_text}
         end
 
-        # Optional: accept binary content, enabling Arcana.ingest_binary/2
-        # for this format (default: false, path only)
+        # Optional: accept binary content, enabling `Arcana.ingest_binary/2`
+        # for this format (default: false, path only). Path-only parsers
+        # make ingest_binary/2 return {:error, {:binary_unsupported, mod}}.
         @impl true
         def supports_binary?, do: true
 
@@ -45,9 +47,20 @@ defmodule Arcana.FileParser do
 
   `parse/2` may return `{:ok, text, meta}` instead of `{:ok, text}`.
   Arcana understands `%{pages: [%{number: 1, start: 0, end: 1234}, ...]}`,
-  where the offsets are byte positions **in the returned text**, and uses
-  them to attach page numbers to chunks. Parsers that don't know about
-  pages return `{:ok, text}` as before.
+  where the offsets are byte positions **in the returned text**. Parsers
+  that don't know about pages return `{:ok, text}` as before.
+
+  During ingestion Arcana intersects those ranges with each chunk's own
+  byte range and stores the result as `"page_start"`/`"page_end"` in the
+  chunk's metadata, where `Arcana.search/2` surfaces it:
+
+      {:ok, _doc} = Arcana.ingest_file("manual.pdf", repo: Repo)
+
+      [result | _] = Arcana.search("warranty", repo: Repo)
+      result.metadata["page_start"]
+      #=> 12
+
+  A chunk straddling a page break reports the two different pages.
   """
 
   @type meta :: map()

--- a/lib/arcana/file_parser.ex
+++ b/lib/arcana/file_parser.ex
@@ -38,7 +38,9 @@ defmodule Arcana.FileParser do
         def supports_binary?, do: true
 
         # Optional: report whether the parser can run right now, e.g. a
-        # required CLI is installed (default: true)
+        # required CLI is installed (default: true). A parser reporting
+        # `false` is not invoked at all: parsing returns
+        # `{:error, {:parser_unavailable, module}}`.
         @impl true
         def available?, do: true
       end
@@ -84,9 +86,23 @@ defmodule Arcana.FileParser do
     opts = Keyword.merge(parser_opts, call_opts)
 
     case module.parse(input, opts) do
-      {:ok, text} -> {:ok, text, %{}}
-      {:ok, text, meta} when is_map(meta) -> {:ok, text, meta}
-      {:error, reason} -> {:error, reason}
+      {:ok, text} ->
+        {:ok, text, %{}}
+
+      {:ok, text, meta} when is_map(meta) ->
+        {:ok, text, meta}
+
+      # Metadata is documented as a map (`%{pages: [...]}`); a keyword list
+      # is the easy slip. Report it rather than raising CaseClauseError from
+      # inside the library with no hint of which parser misbehaved.
+      {:ok, _text, meta} ->
+        {:error, {:invalid_parser_metadata, module, meta}}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      other ->
+        {:error, {:invalid_parser_return, module, other}}
     end
   end
 
@@ -104,15 +120,17 @@ defmodule Arcana.FileParser do
   @doc """
   Whether a `{module, opts}` parser can run right now.
 
-  Defaults to `true` for parsers that don't implement `available?/0`.
+  Defaults to `true` for parsers that don't implement `available?/0`, but
+  a module that can't be loaded (a typo in config) or doesn't implement
+  `parse/2` is never available: reporting `true` there only postpones the
+  failure to an `UndefinedFunctionError` at parse time.
   """
   def available?({module, _opts}) do
-    Code.ensure_loaded(module)
-
-    if function_exported?(module, :available?, 0) do
-      module.available?()
-    else
-      true
+    cond do
+      not match?({:module, _}, Code.ensure_loaded(module)) -> false
+      not function_exported?(module, :parse, 2) -> false
+      function_exported?(module, :available?, 0) -> module.available?()
+      true -> true
     end
   end
 end

--- a/lib/arcana/file_parser.ex
+++ b/lib/arcana/file_parser.ex
@@ -1,0 +1,105 @@
+defmodule Arcana.FileParser do
+  @moduledoc """
+  Behaviour for extracting text from files of any format.
+
+  Arcana ships native handling for plain text and markdown, and a
+  Poppler-backed PDF parser. Any other format works by registering a
+  parser for its extension:
+
+      config :arcana,
+        file_parsers: %{
+          ".docx" => {MyApp.DocxParser, endpoint: "http://extract.internal"}
+        }
+
+  A single parser can also handle everything Arcana doesn't natively
+  support — useful for extraction services that cover many formats:
+
+      config :arcana, fallback_parser: {MyApp.ExtractionService, []}
+
+  Exact extension matches win over the fallback, and the built-in
+  handling for `.txt`/`.md`/`.pdf` can be overridden by registering
+  those extensions explicitly.
+
+  ## Implementing a parser
+
+      defmodule MyApp.DocxParser do
+        @behaviour Arcana.FileParser
+
+        @impl true
+        def parse(path_or_binary, opts) do
+          {:ok, extracted_text}
+        end
+
+        # Optional: accept binary content, enabling Arcana.ingest_binary/2
+        # for this format (default: false, path only)
+        @impl true
+        def supports_binary?, do: true
+
+        # Optional: report whether the parser can run right now, e.g. a
+        # required CLI is installed (default: true)
+        @impl true
+        def available?, do: true
+      end
+
+  ## Positional metadata
+
+  `parse/2` may return `{:ok, text, meta}` instead of `{:ok, text}`.
+  Arcana understands `%{pages: [%{number: 1, start: 0, end: 1234}, ...]}`,
+  where the offsets are byte positions **in the returned text**, and uses
+  them to attach page numbers to chunks. Parsers that don't know about
+  pages return `{:ok, text}` as before.
+  """
+
+  @type meta :: map()
+
+  @callback parse(input :: binary(), opts :: keyword()) ::
+              {:ok, String.t()} | {:ok, String.t(), meta()} | {:error, term()}
+
+  @callback supports_binary?() :: boolean()
+  @callback available?() :: boolean()
+
+  @optional_callbacks supports_binary?: 0, available?: 0
+
+  @doc """
+  Invokes a `{module, opts}` parser, normalizing its return to
+  `{:ok, text, meta}`.
+
+  Parsers predating positional metadata return `{:ok, text}`; those come
+  back here as `{:ok, text, %{}}` so callers only handle one shape.
+  """
+  def parse({module, parser_opts}, input, call_opts \\ []) do
+    opts = Keyword.merge(parser_opts, call_opts)
+
+    case module.parse(input, opts) do
+      {:ok, text} -> {:ok, text, %{}}
+      {:ok, text, meta} when is_map(meta) -> {:ok, text, meta}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Whether a `{module, opts}` parser accepts binary content.
+
+  Defaults to `false`: a parser that doesn't say otherwise is assumed to
+  need a file path.
+  """
+  def supports_binary?({module, _opts}) do
+    Code.ensure_loaded(module)
+    function_exported?(module, :supports_binary?, 0) and module.supports_binary?()
+  end
+
+  @doc """
+  Whether a `{module, opts}` parser can run right now.
+
+  Defaults to `true` for parsers that don't implement `available?/0`.
+  """
+  def available?({module, _opts}) do
+    Code.ensure_loaded(module)
+
+    if function_exported?(module, :available?, 0) do
+      module.available?()
+    else
+      true
+    end
+  end
+end

--- a/lib/arcana/file_parser/pdf.ex
+++ b/lib/arcana/file_parser/pdf.ex
@@ -67,10 +67,20 @@ defmodule Arcana.FileParser.PDF do
 
   The parser is a `{module, opts}` tuple where module implements
   this behaviour.
+
+  Always returns `{:ok, text}`: parsers that also report positional
+  metadata (see `Arcana.FileParser`) have it dropped here, so this
+  function's contract is unchanged. Use `Arcana.FileParser.parse/3` or
+  `Arcana.Parser.parse_file/2` to receive it.
   """
   def parse({module, opts}, path_or_binary, call_opts \\ []) when is_atom(module) do
     merged_opts = Keyword.merge(opts, call_opts)
-    module.parse(path_or_binary, merged_opts)
+
+    case module.parse(path_or_binary, merged_opts) do
+      {:ok, text} -> {:ok, text}
+      {:ok, text, _meta} -> {:ok, text}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """

--- a/lib/arcana/file_parser/pdf.ex
+++ b/lib/arcana/file_parser/pdf.ex
@@ -77,12 +77,14 @@ defmodule Arcana.FileParser.PDF do
   metadata (see `Arcana.FileParser`) have it dropped here, so this
   function's contract is unchanged. Use `Arcana.FileParser.parse/3` or
   `Arcana.Parser.parse_file/2` to receive it.
-  """
-  def parse({module, opts}, path_or_binary, call_opts \\ []) when is_atom(module) do
-    merged_opts = Keyword.merge(opts, call_opts)
 
-    case module.parse(path_or_binary, merged_opts) do
-      {:ok, text} -> {:ok, text}
+  Dispatch itself goes through `Arcana.FileParser.parse/3`, so a PDF
+  parser reporting itself unavailable (`available?/0`) is not invoked
+  and a parser returning something malformed comes back as an error
+  tuple rather than a `CaseClauseError` from inside the library.
+  """
+  def parse({module, _opts} = parser, path_or_binary, call_opts \\ []) when is_atom(module) do
+    case Arcana.FileParser.parse(parser, path_or_binary, call_opts) do
       {:ok, text, _meta} -> {:ok, text}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/arcana/file_parser/pdf.ex
+++ b/lib/arcana/file_parser/pdf.ex
@@ -5,6 +5,11 @@ defmodule Arcana.FileParser.PDF do
   Arcana accepts any module that implements this behaviour for PDF text extraction.
   The built-in implementation uses poppler's `pdftotext` command.
 
+  This behaviour is a narrower spelling of `Arcana.FileParser`, which is
+  what the built-in `Arcana.FileParser.PDF.Poppler` declares (a module
+  can't declare both without a conflicting-behaviours warning, since each
+  defines `parse/2`). Either one works as a `:pdf_parser`.
+
   ## Configuration
 
   Configure your PDF parser in `config.exs`:

--- a/lib/arcana/file_parser/pdf.ex
+++ b/lib/arcana/file_parser/pdf.ex
@@ -60,7 +60,7 @@ defmodule Arcana.FileParser.PDF do
 
   """
   @callback parse(path_or_binary :: binary(), opts :: keyword()) ::
-              {:ok, String.t()} | {:error, term()}
+              {:ok, String.t()} | {:ok, String.t(), map()} | {:error, term()}
 
   @doc """
   Parses a PDF using the configured parser.

--- a/lib/arcana/file_parser/pdf.ex
+++ b/lib/arcana/file_parser/pdf.ex
@@ -97,12 +97,10 @@ defmodule Arcana.FileParser.PDF do
   parsing binary content directly.
   """
   def supports_binary?({module, _opts}) when is_atom(module) do
-    # Check if the module explicitly declares binary support
-    # Default to false for safety
-    if function_exported?(module, :supports_binary?, 0) do
-      module.supports_binary?()
-    else
-      false
-    end
+    # Load the module first: one that hasn't been loaded yet exports
+    # nothing, so skipping this reports false for a parser that does
+    # support binaries. Everything else defaults to false for safety.
+    Code.ensure_loaded(module)
+    function_exported?(module, :supports_binary?, 0) and module.supports_binary?()
   end
 end

--- a/lib/arcana/file_parser/pdf/poppler.ex
+++ b/lib/arcana/file_parser/pdf/poppler.ex
@@ -20,9 +20,16 @@ defmodule Arcana.FileParser.PDF.Poppler do
 
     * `:layout` - Preserve original text layout (default: true)
 
+  ## Return shape
+
+  `parse/2` returns `{:ok, text, %{pages: [...]}}` — the three-element
+  form `Arcana.FileParser` allows — so callers can map chunks back to
+  page numbers. Code that only wants the text should go through
+  `Arcana.FileParser.PDF.parse/3` or `Arcana.Parser.parse/1`, both of
+  which normalize to `{:ok, text}`.
   """
 
-  @behaviour Arcana.FileParser.PDF
+  @behaviour Arcana.FileParser
 
   @doc """
   Checks if `pdftotext` is available on the system.
@@ -33,6 +40,7 @@ defmodule Arcana.FileParser.PDF.Poppler do
       true  # or false if poppler not installed
 
   """
+  @impl true
   def available? do
     case System.find_executable("pdftotext") do
       nil -> false
@@ -43,6 +51,7 @@ defmodule Arcana.FileParser.PDF.Poppler do
   @doc """
   Returns false - Poppler requires a file path, not binary content.
   """
+  @impl true
   def supports_binary?, do: false
 
   @impl true
@@ -68,17 +77,24 @@ defmodule Arcana.FileParser.PDF.Poppler do
     end
   end
 
-  # pdftotext separates pages with a form feed. Page ranges are computed
-  # from the raw output so blank leading/trailing pages keep their
-  # numbers, then shifted into the trimmed text that callers receive; a
-  # page that trimming removed entirely reports an empty range rather
-  # than disappearing and renumbering the pages after it.
+  # pdftotext terminates every page with a form feed, so an N-page PDF
+  # produces N form feeds and splitting naively would report a phantom
+  # empty page N+1. Dropping one trailing form feed before the split
+  # keeps the count honest while a genuinely blank final page (which
+  # arrives as "\f\f") still gets its own range.
+  #
+  # Ranges are computed from the raw output so blank leading/trailing
+  # pages keep their numbers, then shifted into the trimmed text that
+  # callers receive; a page that trimming removed entirely reports an
+  # empty range rather than disappearing and renumbering the pages after
+  # it.
   @doc false
   def page_ranges(raw, trimmed) do
     leading = byte_size(raw) - byte_size(String.trim_leading(raw))
     limit = byte_size(trimmed)
 
     raw
+    |> String.replace_suffix("\f", "")
     |> String.split("\f")
     |> Enum.reduce({[], 0, 1}, fn page, {acc, offset, number} ->
       raw_end = offset + byte_size(page)

--- a/lib/arcana/file_parser/pdf/poppler.ex
+++ b/lib/arcana/file_parser/pdf/poppler.ex
@@ -60,32 +60,40 @@ defmodule Arcana.FileParser.PDF.Poppler do
 
     case System.cmd("pdftotext", args, stderr_to_stdout: true) do
       {text, 0} ->
-        text = String.trim(text)
-        {:ok, text, %{pages: page_ranges(text)}}
+        trimmed = String.trim(text)
+        {:ok, trimmed, %{pages: page_ranges(text, trimmed)}}
 
       {error_output, _code} ->
         {:error, {:pdftotext_failed, error_output}}
     end
   end
 
-  # pdftotext separates pages with a form feed, so page byte ranges fall
-  # out of splitting the (already trimmed) output on it. Offsets are
-  # relative to the returned text, which is what chunk positions are
-  # compared against.
+  # pdftotext separates pages with a form feed. Page ranges are computed
+  # from the raw output so blank leading/trailing pages keep their
+  # numbers, then shifted into the trimmed text that callers receive; a
+  # page that trimming removed entirely reports an empty range rather
+  # than disappearing and renumbering the pages after it.
   @doc false
-  def page_ranges(text) do
-    text
+  def page_ranges(raw, trimmed) do
+    leading = byte_size(raw) - byte_size(String.trim_leading(raw))
+    limit = byte_size(trimmed)
+
+    raw
     |> String.split("\f")
     |> Enum.reduce({[], 0, 1}, fn page, {acc, offset, number} ->
-      page_end = offset + byte_size(page)
-      page_info = %{number: number, start: offset, end: page_end}
+      raw_end = offset + byte_size(page)
+
+      page_start = offset |> Kernel.-(leading) |> clamp(limit)
+      page_end = raw_end |> Kernel.-(leading) |> clamp(limit)
 
       # +1 skips the form feed separating this page from the next
-      {[page_info | acc], page_end + 1, number + 1}
+      {[%{number: number, start: page_start, end: page_end} | acc], raw_end + 1, number + 1}
     end)
     |> elem(0)
     |> Enum.reverse()
   end
+
+  defp clamp(value, limit), do: value |> max(0) |> min(limit)
 
   defp build_args(path, layout) do
     base_args = if layout, do: ["-layout"], else: []

--- a/lib/arcana/file_parser/pdf/poppler.ex
+++ b/lib/arcana/file_parser/pdf/poppler.ex
@@ -60,11 +60,31 @@ defmodule Arcana.FileParser.PDF.Poppler do
 
     case System.cmd("pdftotext", args, stderr_to_stdout: true) do
       {text, 0} ->
-        {:ok, String.trim(text)}
+        text = String.trim(text)
+        {:ok, text, %{pages: page_ranges(text)}}
 
       {error_output, _code} ->
         {:error, {:pdftotext_failed, error_output}}
     end
+  end
+
+  # pdftotext separates pages with a form feed, so page byte ranges fall
+  # out of splitting the (already trimmed) output on it. Offsets are
+  # relative to the returned text, which is what chunk positions are
+  # compared against.
+  @doc false
+  def page_ranges(text) do
+    text
+    |> String.split("\f")
+    |> Enum.reduce({[], 0, 1}, fn page, {acc, offset, number} ->
+      page_end = offset + byte_size(page)
+      page_info = %{number: number, start: offset, end: page_end}
+
+      # +1 skips the form feed separating this page from the next
+      {[page_info | acc], page_end + 1, number + 1}
+    end)
+    |> elem(0)
+    |> Enum.reverse()
   end
 
   defp build_args(path, layout) do

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -372,7 +372,7 @@ defmodule Arcana.Ingest do
     Enum.map(chunks, fn chunk ->
       metadata = Map.get(chunk, :metadata) || %{}
 
-      case {metadata["start_byte"], metadata["end_byte"]} do
+      case {chunk_offset(chunk, metadata, :start_byte), chunk_offset(chunk, metadata, :end_byte)} do
         {start_byte, end_byte} when is_integer(start_byte) and is_integer(end_byte) ->
           last_byte = max(end_byte - 1, start_byte)
 
@@ -390,6 +390,23 @@ defmodule Arcana.Ingest do
   end
 
   defp attach_pages(chunks, _pages), do: chunks
+
+  # Keys are only stringified at insert time (see `chunk_metadata/1`), so
+  # this runs against whatever shape the chunker used. `Arcana.Chunker`
+  # accepts offsets under `:metadata` or as top-level extras, with atom or
+  # string keys; reading just one shape drops pages silently for every
+  # chunker but the built-in one. Precedence mirrors chunk_metadata/1:
+  # a declared :metadata entry wins over a top-level extra.
+  defp chunk_offset(chunk, metadata, key) do
+    fetch_either(metadata, key) || fetch_either(chunk, key)
+  end
+
+  defp fetch_either(map, key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, to_string(key))
+    end
+  end
 
   # Pages that trimming emptied out have start == end and can't contain
   # anything, so they never match; a byte past the last page's end (the

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -161,6 +161,10 @@ defmodule Arcana.Ingest do
   shells out to `pdftotext` and needs a real file, so ingesting PDF bytes
   returns `{:error, {:binary_unsupported, Arcana.FileParser.PDF.Poppler}}`
   — write them to a temp file and use `ingest_file/2` instead.
+
+  A parser that is *also* unavailable reports that instead, since a retry
+  through `ingest_file/2` would fail just the same: with `pdftotext`
+  missing, PDF bytes come back as `{:error, :poppler_not_available}`.
   """
   def ingest_binary(binary, opts) when is_binary(binary) do
     filename =

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -270,7 +270,7 @@ defmodule Arcana.Ingest do
             embedding: embedding,
             chunk_index: chunk.chunk_index,
             token_count: chunk.token_count,
-            metadata: chunk_metadata(chunk),
+            metadata: Chunker.metadata_for(chunk),
             document_id: document.id
           })
           |> repo.insert!()
@@ -285,22 +285,6 @@ defmodule Arcana.Ingest do
         {:halt, {:error, {:embedding_failed, reason}}}
     end
   end
-
-  # `Arcana.Chunker` promises that keys beyond :text/:chunk_index/
-  # :token_count reach storage. A chunker's own `:metadata` map is the
-  # canonical place for them (that's what Arcana.Chunker.Default uses for
-  # its byte offsets); anything else it hands back is folded in with
-  # string keys, since chunk metadata round-trips through JSONB.
-  @chunk_fields [:text, :chunk_index, :token_count, :metadata, :embedding, :id, :document_id]
-
-  defp chunk_metadata(chunk) do
-    extras = chunk |> Map.drop([:__struct__ | @chunk_fields]) |> stringify_keys()
-    declared = chunk |> Map.get(:metadata) |> Kernel.||(%{}) |> stringify_keys()
-
-    Map.merge(extras, declared)
-  end
-
-  defp stringify_keys(map), do: Map.new(map, fn {key, value} -> {to_string(key), value} end)
 
   defp ingest_with_file_attrs(text, opts) do
     repo = require_repo!(opts)
@@ -391,11 +375,11 @@ defmodule Arcana.Ingest do
 
   defp attach_pages(chunks, _pages), do: chunks
 
-  # Keys are only stringified at insert time (see `chunk_metadata/1`), so
+  # Keys are only stringified at insert time (see `Arcana.Chunker.metadata_for/1`), so
   # this runs against whatever shape the chunker used. `Arcana.Chunker`
   # accepts offsets under `:metadata` or as top-level extras, with atom or
   # string keys; reading just one shape drops pages silently for every
-  # chunker but the built-in one. Precedence mirrors chunk_metadata/1:
+  # chunker but the built-in one. Precedence mirrors metadata_for/1:
   # a declared :metadata entry wins over a top-level extra.
   defp chunk_offset(chunk, metadata, key) do
     fetch_either(metadata, key) || fetch_either(chunk, key)

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -379,16 +379,28 @@ defmodule Arcana.Ingest do
   # this runs against whatever shape the chunker used. `Arcana.Chunker`
   # accepts offsets under `:metadata` or as top-level extras, with atom or
   # string keys; reading just one shape drops pages silently for every
-  # chunker but the built-in one. Precedence mirrors metadata_for/1:
-  # a declared :metadata entry wins over a top-level extra.
+  # chunker but the built-in one. Precedence mirrors metadata_for/1
+  # exactly: a declared :metadata entry wins over a top-level extra
+  # because it is *present*, not because it is truthy. Falling through on
+  # a nil or false value would read an offset that never reaches storage.
   defp chunk_offset(chunk, metadata, key) do
-    fetch_either(metadata, key) || fetch_either(chunk, key)
+    case fetch_either(metadata, key) do
+      {:ok, value} -> value
+      :error -> fetch_or_nil(chunk, key)
+    end
+  end
+
+  defp fetch_or_nil(map, key) do
+    case fetch_either(map, key) do
+      {:ok, value} -> value
+      :error -> nil
+    end
   end
 
   defp fetch_either(map, key) do
     case Map.fetch(map, key) do
-      {:ok, value} -> value
-      :error -> Map.get(map, to_string(key))
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(map, to_string(key))
     end
   end
 

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -389,9 +389,12 @@ defmodule Arcana.Ingest do
 
   # metadata_for/1 takes a keyword list under `:metadata` in stride
   # (`Map.new/1` accepts one), so merging the pages back in has to too.
+  # metadata_for/1 reaches for `||`, so a falsy :metadata is simply absent
+  # there. Raising here instead would put the whole ingest on its failure
+  # path over a key the storage side shrugs at.
   defp declared_metadata(chunk) do
     case Map.get(chunk, :metadata) do
-      nil -> %{}
+      falsy when falsy in [nil, false] -> %{}
       map when is_map(map) -> map
       list when is_list(list) -> Map.new(list)
     end

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -356,11 +356,19 @@ defmodule Arcana.Ingest do
   #
   # No pages, or a chunker that doesn't report offsets, leaves chunks
   # untouched rather than guessing.
+  # Offsets are read straight out of `Arcana.Chunker.metadata_for/1` — the
+  # very map that gets stored — instead of re-deriving the chunker's key
+  # shape here. `Arcana.Chunker` accepts them under `:metadata` or as
+  # top-level extras, with atom or string keys, and declared entries win
+  # over extras; going through metadata_for/1 makes those rules agree by
+  # construction rather than by two implementations staying in step.
+  # Deriving pages from anything else would cite an offset nobody can see
+  # in the stored chunk.
   defp attach_pages(chunks, pages) when is_list(pages) and pages != [] do
     Enum.map(chunks, fn chunk ->
-      metadata = Map.get(chunk, :metadata) || %{}
+      stored = Chunker.metadata_for(chunk)
 
-      case {chunk_offset(chunk, metadata, :start_byte), chunk_offset(chunk, metadata, :end_byte)} do
+      case {stored["start_byte"], stored["end_byte"]} do
         {start_byte, end_byte} when is_integer(start_byte) and is_integer(end_byte) ->
           last_byte = max(end_byte - 1, start_byte)
 
@@ -369,7 +377,7 @@ defmodule Arcana.Ingest do
             "page_end" => page_at(pages, last_byte)
           }
 
-          Map.put(chunk, :metadata, Map.merge(metadata, page_metadata))
+          Map.put(chunk, :metadata, Map.merge(declared_metadata(chunk), page_metadata))
 
         _ ->
           chunk
@@ -379,32 +387,13 @@ defmodule Arcana.Ingest do
 
   defp attach_pages(chunks, _pages), do: chunks
 
-  # Keys are only stringified at insert time (see `Arcana.Chunker.metadata_for/1`), so
-  # this runs against whatever shape the chunker used. `Arcana.Chunker`
-  # accepts offsets under `:metadata` or as top-level extras, with atom or
-  # string keys; reading just one shape drops pages silently for every
-  # chunker but the built-in one. Precedence mirrors metadata_for/1
-  # exactly: a declared :metadata entry wins over a top-level extra
-  # because it is *present*, not because it is truthy. Falling through on
-  # a nil or false value would read an offset that never reaches storage.
-  defp chunk_offset(chunk, metadata, key) do
-    case fetch_either(metadata, key) do
-      {:ok, value} -> value
-      :error -> fetch_or_nil(chunk, key)
-    end
-  end
-
-  defp fetch_or_nil(map, key) do
-    case fetch_either(map, key) do
-      {:ok, value} -> value
-      :error -> nil
-    end
-  end
-
-  defp fetch_either(map, key) do
-    case Map.fetch(map, key) do
-      {:ok, value} -> {:ok, value}
-      :error -> Map.fetch(map, to_string(key))
+  # metadata_for/1 takes a keyword list under `:metadata` in stride
+  # (`Map.new/1` accepts one), so merging the pages back in has to too.
+  defp declared_metadata(chunk) do
+    case Map.get(chunk, :metadata) do
+      nil -> %{}
+      map when is_map(map) -> map
+      list when is_list(list) -> Map.new(list)
     end
   end
 

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -95,7 +95,11 @@ defmodule Arcana.Ingest do
   @doc """
   Ingests a file, parsing its content and creating a document with embedded chunks.
 
-  Supports multiple file formats including plain text, markdown, and PDF.
+  Handles plain text, markdown, and PDF natively, plus any format with a
+  parser registered under `config :arcana, :file_parsers` — see
+  `Arcana.Parser` for resolution and `Arcana.FileParser` for the
+  behaviour. The document's `content_type` comes from the resolved
+  parser.
 
   ## Options
 
@@ -106,18 +110,71 @@ defmodule Arcana.Ingest do
     * `:chunk_overlap` - Overlap between chunks (default: 200)
     * `:collection` - Collection name to organize the document (default: "default")
 
+  ## Chunk metadata
+
+  Every chunk stores the `"start_byte"`/`"end_byte"` range it occupies in
+  the extracted text. When the parser also reports page positions (the
+  built-in PDF parser does), chunks additionally carry `"page_start"` and
+  `"page_end"`, so `Arcana.search/2` results can cite a page:
+
+      [result | _] = Arcana.search("refund policy", repo: Repo)
+      result.metadata["page_start"]
+      #=> 4
+
   """
   def ingest_file(path, opts) when is_binary(path) do
-    case Parser.parse(path) do
-      {:ok, text} ->
-        content_type = content_type_for_path(path)
+    case Parser.parse_file(path) do
+      {:ok, text, parse_meta} ->
+        opts
+        |> Keyword.put(:file_path, path)
+        |> Keyword.put(:content_type, Parser.content_type_for(path))
+        |> Keyword.put(:parse_meta, parse_meta)
+        |> then(&ingest_with_file_attrs(text, &1))
 
-        opts =
-          opts
-          |> Keyword.put(:file_path, path)
-          |> Keyword.put(:content_type, content_type)
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
 
-        ingest_with_file_attrs(text, opts)
+  @doc """
+  Ingests in-memory bytes, parsing them the same way `ingest_file/2`
+  parses a file on disk.
+
+  `:filename` is required: its extension picks the parser and its value
+  is stored as the document's `file_path` for provenance. Nothing is
+  written to disk.
+
+  ## Options
+
+    * `:filename` - Name the bytes came from, e.g. `"report.docx"` (required)
+    * `:repo` - The Ecto repo to use (required)
+    * `:source_id` - An optional identifier for grouping/filtering
+    * `:metadata` - Optional map of metadata to store with the document
+    * `:chunk_size` - Maximum chunk size in characters (default: 1024)
+    * `:chunk_overlap` - Overlap between chunks (default: 200)
+    * `:collection` - Collection name to organize the document (default: "default")
+
+  ## Parsers that need a path
+
+  A parser only handles binaries when it says so via
+  `c:Arcana.FileParser.supports_binary?/0`. The built-in PDF parser
+  shells out to `pdftotext` and needs a real file, so ingesting PDF bytes
+  returns `{:error, {:binary_unsupported, Arcana.FileParser.PDF.Poppler}}`
+  — write them to a temp file and use `ingest_file/2` instead.
+  """
+  def ingest_binary(binary, opts) when is_binary(binary) do
+    filename =
+      Keyword.get(opts, :filename) ||
+        raise ArgumentError, "ingest_binary/2 requires a :filename to route on and record"
+
+    case Parser.parse_binary(binary, filename) do
+      {:ok, text, parse_meta} ->
+        opts
+        |> Keyword.delete(:filename)
+        |> Keyword.put(:file_path, filename)
+        |> Keyword.put(:content_type, Parser.content_type_for(filename))
+        |> Keyword.put(:parse_meta, parse_meta)
+        |> then(&ingest_with_file_attrs(text, &1))
 
       {:error, reason} ->
         {:error, reason}
@@ -213,6 +270,7 @@ defmodule Arcana.Ingest do
             embedding: embedding,
             chunk_index: chunk.chunk_index,
             token_count: chunk.token_count,
+            metadata: chunk_metadata(chunk),
             document_id: document.id
           })
           |> repo.insert!()
@@ -227,6 +285,22 @@ defmodule Arcana.Ingest do
         {:halt, {:error, {:embedding_failed, reason}}}
     end
   end
+
+  # `Arcana.Chunker` promises that keys beyond :text/:chunk_index/
+  # :token_count reach storage. A chunker's own `:metadata` map is the
+  # canonical place for them (that's what Arcana.Chunker.Default uses for
+  # its byte offsets); anything else it hands back is folded in with
+  # string keys, since chunk metadata round-trips through JSONB.
+  @chunk_fields [:text, :chunk_index, :token_count, :metadata, :embedding, :id, :document_id]
+
+  defp chunk_metadata(chunk) do
+    extras = chunk |> Map.drop([:__struct__ | @chunk_fields]) |> stringify_keys()
+    declared = chunk |> Map.get(:metadata) |> Kernel.||(%{}) |> stringify_keys()
+
+    Map.merge(extras, declared)
+  end
+
+  defp stringify_keys(map), do: Map.new(map, fn {key, value} -> {to_string(key), value} end)
 
   defp ingest_with_file_attrs(text, opts) do
     repo = require_repo!(opts)
@@ -245,7 +319,8 @@ defmodule Arcana.Ingest do
         file_path: file_path,
         content_type: content_type,
         chunk_opts: chunk_opts,
-        chunker_config: chunker_config
+        chunker_config: chunker_config,
+        pages: Keyword.get(opts, :parse_meta, %{})[:pages]
       })
     end
   end
@@ -264,7 +339,11 @@ defmodule Arcana.Ingest do
       })
       |> repo.insert()
 
-    chunks = Chunker.chunk(attrs.chunker_config, text, attrs.chunk_opts)
+    chunks =
+      attrs.chunker_config
+      |> Chunker.chunk(text, attrs.chunk_opts)
+      |> attach_pages(attrs.pages)
+
     result = embed_and_store_chunks(chunks, document, repo)
 
     case result do
@@ -281,6 +360,50 @@ defmodule Arcana.Ingest do
     end
   end
 
+  # Parsers that report page positions (see `Arcana.FileParser`) give
+  # byte ranges into the extracted text; the chunker reports byte ranges
+  # for each chunk. Intersecting the two turns "chunk 7" into "pages
+  # 3-4", which is what a citation actually needs. A chunk straddling a
+  # page break reports different start and end pages.
+  #
+  # No pages, or a chunker that doesn't report offsets, leaves chunks
+  # untouched rather than guessing.
+  defp attach_pages(chunks, pages) when is_list(pages) and pages != [] do
+    Enum.map(chunks, fn chunk ->
+      metadata = Map.get(chunk, :metadata) || %{}
+
+      case {metadata["start_byte"], metadata["end_byte"]} do
+        {start_byte, end_byte} when is_integer(start_byte) and is_integer(end_byte) ->
+          last_byte = max(end_byte - 1, start_byte)
+
+          page_metadata = %{
+            "page_start" => page_at(pages, start_byte),
+            "page_end" => page_at(pages, last_byte)
+          }
+
+          Map.put(chunk, :metadata, Map.merge(metadata, page_metadata))
+
+        _ ->
+          chunk
+      end
+    end)
+  end
+
+  defp attach_pages(chunks, _pages), do: chunks
+
+  # Pages that trimming emptied out have start == end and can't contain
+  # anything, so they never match; a byte past the last page's end (the
+  # chunker counts a trailing newline the parser trimmed, say) falls back
+  # to the last page that starts at or before it.
+  defp page_at(pages, byte) do
+    page =
+      Enum.find(pages, fn page -> byte >= page.start and byte < page.end end) ||
+        pages |> Enum.filter(&(&1.start <= byte)) |> List.last() ||
+        List.first(pages)
+
+    page.number
+  end
+
   # Under strict_collections, ingest requires the collection to already
   # exist (create explicitly with Collection.get_or_create/3); otherwise
   # it is created on the fly.
@@ -289,16 +412,6 @@ defmodule Arcana.Ingest do
       Collection.fetch(name, repo)
     else
       Collection.get_or_create(name, repo, description)
-    end
-  end
-
-  defp content_type_for_path(path) do
-    case Path.extname(path) |> String.downcase() do
-      ".txt" -> "text/plain"
-      ".md" -> "text/markdown"
-      ".markdown" -> "text/markdown"
-      ".pdf" -> "application/pdf"
-      _ -> "application/octet-stream"
     end
   end
 

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -282,12 +282,18 @@ defmodule Arcana.Maintenance do
       Enum.each(chunks, fn chunk ->
         {:ok, embedding} = Embedder.embed(embedder, chunk.text, intent: :document)
 
+        # Same metadata a fresh ingest would store (byte offsets and any
+        # extra keys the chunker reports), so recovered documents aren't
+        # the only ones in the corpus missing it. Page numbers are the
+        # exception: they come from the parser at ingest time and aren't
+        # persisted anywhere, so they can't be rebuilt from the document.
         %Chunk{}
         |> Chunk.changeset(%{
           text: chunk.text,
           embedding: embedding,
           chunk_index: chunk.chunk_index,
           token_count: chunk.token_count,
+          metadata: Chunker.metadata_for(chunk),
           document_id: doc.id
         })
         |> repo.insert!()

--- a/lib/arcana/parser.ex
+++ b/lib/arcana/parser.ex
@@ -225,7 +225,7 @@ defmodule Arcana.Parser do
       case pdf_content(input, kind) do
         {:ok, content} ->
           if String.starts_with?(content, "%PDF") do
-            FileParser.parse(parser, input, opts)
+            invoke(parser, input, opts)
           else
             {:error, :invalid_pdf}
           end
@@ -234,9 +234,27 @@ defmodule Arcana.Parser do
           error
       end
     else
-      FileParser.parse(parser, input, opts)
+      invoke(parser, input, opts)
     end
   end
+
+  # A parser that reports itself unavailable (`available?/0`) doesn't get
+  # called. Poppler self-guards, so this used to be harmless for the
+  # built-in route, but a third-party parser written to the documented
+  # contract was invoked anyway.
+  defp invoke(parser, input, opts) do
+    if FileParser.available?(parser) do
+      FileParser.parse(parser, input, opts)
+    else
+      {:error, unavailable_reason(parser)}
+    end
+  end
+
+  # Poppler has reported :poppler_not_available since before this gate
+  # existed and callers match on it; keep that exact shape for the
+  # built-in and give everyone else the generic error.
+  defp unavailable_reason({Arcana.FileParser.PDF.Poppler, _opts}), do: :poppler_not_available
+  defp unavailable_reason({module, _opts}), do: {:parser_unavailable, module}
 
   defp pdf_content(binary, :binary), do: {:ok, binary}
 

--- a/lib/arcana/parser.ex
+++ b/lib/arcana/parser.ex
@@ -10,10 +10,11 @@ defmodule Arcana.Parser do
 
   For a file's extension (lowercased, with a leading dot):
 
-  1. an exact match in `config :arcana, :file_parsers`
+  1. an exact match in `config :arcana, :file_parsers` (a `false` entry
+     means the extension is disabled and resolution stops here)
   2. the built-ins: `.txt`/`.md`/`.markdown` read natively, `.pdf` via
      `config :arcana, :pdf_parser`
-  3. `config :arcana, :fallback_parser`, if set
+  3. `config :arcana, :fallback_parser`, unless it is `nil`/`false`
   4. otherwise `{:error, :unsupported_format}`
 
   ## Registering parsers
@@ -25,7 +26,8 @@ defmodule Arcana.Parser do
         fallback_parser: {MyApp.ExtractionService, []}
 
   Registering `".pdf"` in `:file_parsers` overrides the built-in PDF
-  route. See `Arcana.FileParser` for the behaviour.
+  route; registering it as `false` turns it off entirely, fallback
+  included. See `Arcana.FileParser` for the behaviour.
 
   ## PDF Support
 
@@ -51,12 +53,17 @@ defmodule Arcana.Parser do
   Returns the list of supported file extensions.
 
   Includes the natively handled formats plus any registered through
-  `:file_parsers`. When a `:fallback_parser` is configured every
-  extension is effectively supported, so this list is a lower bound.
+  `:file_parsers`, minus any disabled with `false`. When a
+  `:fallback_parser` is configured every extension is effectively
+  supported, so this list is a lower bound.
   """
   def supported_formats do
-    (@text_extensions ++ @pdf_extensions ++ Map.keys(Config.file_parsers()))
+    registered = Config.file_parsers()
+    disabled = for {extension, nil} <- registered, do: extension
+
+    (@text_extensions ++ @pdf_extensions ++ Map.keys(registered))
     |> Enum.uniq()
+    |> Enum.reject(&(&1 in disabled))
   end
 
   @doc """
@@ -169,12 +176,22 @@ defmodule Arcana.Parser do
   defp builtin_content_type(_), do: "application/octet-stream"
 
   # Resolves an extension to :native, a {module, opts} parser, or an error.
+  #
+  # A registered entry always wins, including `%{".pdf" => false}`, which
+  # arrives here as nil and means "disabled": it blocks the built-in route
+  # and the fallback rather than quietly deferring to them.
   defp resolve(extension) do
     extension = Config.normalize_extension(extension)
-    registered = Config.file_parsers()
 
+    case Map.fetch(Config.file_parsers(), extension) do
+      {:ok, nil} -> {:error, :unsupported_format}
+      {:ok, parser} -> {:ok, parser}
+      :error -> resolve_builtin(extension)
+    end
+  end
+
+  defp resolve_builtin(extension) do
     cond do
-      Map.has_key?(registered, extension) -> {:ok, Map.fetch!(registered, extension)}
       extension in @text_extensions -> {:ok, :native}
       extension in @pdf_extensions -> {:ok, Config.pdf_parser()}
       fallback = Config.fallback_parser() -> {:ok, fallback}

--- a/lib/arcana/parser.ex
+++ b/lib/arcana/parser.ex
@@ -132,7 +132,7 @@ defmodule Arcana.Parser do
 
       {:ok, {module, _} = parser} ->
         if FileParser.supports_binary?(parser) do
-          validate_and_parse(binary, extension, parser, opts)
+          validate_and_parse(binary, :binary, extension, parser, opts)
         else
           {:error, {:binary_unsupported, module}}
         end
@@ -152,26 +152,21 @@ defmodule Arcana.Parser do
   def content_type_for(path) do
     extension = Config.normalize_extension(Path.extname(path))
 
-    case extension do
-      ".txt" ->
-        "text/plain"
-
-      ext when ext in [".md", ".markdown"] ->
-        "text/markdown"
-
-      ".pdf" ->
-        "application/pdf"
+    # A registered parser's declared type wins over the built-in default,
+    # since registering an extension overrides its built-in route too.
+    case resolve(extension) do
+      {:ok, {_module, opts}} ->
+        Keyword.get(opts, :content_type) || builtin_content_type(extension)
 
       _ ->
-        case resolve(extension) do
-          {:ok, {_module, opts}} ->
-            Keyword.get(opts, :content_type, "application/octet-stream")
-
-          _ ->
-            "application/octet-stream"
-        end
+        builtin_content_type(extension)
     end
   end
+
+  defp builtin_content_type(".txt"), do: "text/plain"
+  defp builtin_content_type(ext) when ext in [".md", ".markdown"], do: "text/markdown"
+  defp builtin_content_type(".pdf"), do: "application/pdf"
+  defp builtin_content_type(_), do: "application/octet-stream"
 
   # Resolves an extension to :native, a {module, opts} parser, or an error.
   defp resolve(extension) do
@@ -196,7 +191,7 @@ defmodule Arcana.Parser do
         end
 
       {:ok, parser} ->
-        validate_and_parse(path, extension, parser, opts)
+        validate_and_parse(path, :path, extension, parser, opts)
 
       {:error, reason} ->
         {:error, reason}
@@ -205,9 +200,12 @@ defmodule Arcana.Parser do
 
   # PDFs are magic-byte checked before reaching a parser, so a mislabeled
   # file fails with :invalid_pdf instead of whatever the tool reports.
-  defp validate_and_parse(input, extension, parser, opts) do
+  # `kind` says whether `input` is a path to read or the bytes themselves:
+  # binary content that happens to look like a path must never be read
+  # off disk.
+  defp validate_and_parse(input, kind, extension, parser, opts) do
     if Config.normalize_extension(extension) in @pdf_extensions do
-      case pdf_content(input) do
+      case pdf_content(input, kind) do
         {:ok, content} ->
           if String.starts_with?(content, "%PDF") do
             FileParser.parse(parser, input, opts)
@@ -223,14 +221,12 @@ defmodule Arcana.Parser do
     end
   end
 
-  defp pdf_content(input) do
-    if File.exists?(input) do
-      case File.read(input) do
-        {:ok, content} -> {:ok, content}
-        {:error, _} -> {:error, :read_error}
-      end
-    else
-      {:ok, input}
+  defp pdf_content(binary, :binary), do: {:ok, binary}
+
+  defp pdf_content(path, :path) do
+    case File.read(path) do
+      {:ok, content} -> {:ok, content}
+      {:error, _} -> {:error, :read_error}
     end
   end
 end

--- a/lib/arcana/parser.ex
+++ b/lib/arcana/parser.ex
@@ -2,15 +2,32 @@ defmodule Arcana.Parser do
   @moduledoc """
   Parses files into text content for ingestion.
 
-  Supports multiple file formats including plain text, markdown, and PDF.
+  Plain text and markdown are read natively, PDFs go through a
+  configurable parser (Poppler's `pdftotext` by default), and any other
+  format is handled by a parser you register.
+
+  ## Resolution order
+
+  For a file's extension (lowercased, with a leading dot):
+
+  1. an exact match in `config :arcana, :file_parsers`
+  2. the built-ins: `.txt`/`.md`/`.markdown` read natively, `.pdf` via
+     `config :arcana, :pdf_parser`
+  3. `config :arcana, :fallback_parser`, if set
+  4. otherwise `{:error, :unsupported_format}`
+
+  ## Registering parsers
+
+      config :arcana,
+        # per-format
+        file_parsers: %{".docx" => {MyApp.DocxParser, []}},
+        # everything else (e.g. an extraction service covering many formats)
+        fallback_parser: {MyApp.ExtractionService, []}
+
+  Registering `".pdf"` in `:file_parsers` overrides the built-in PDF
+  route. See `Arcana.FileParser` for the behaviour.
 
   ## PDF Support
-
-  PDF parsing is handled by a configurable parser. The default uses
-  `pdftotext` from the Poppler library. See `Arcana.FileParser.PDF` for
-  implementing custom PDF parsers.
-
-  ### Default Parser (Poppler)
 
   The default PDF parser requires `pdftotext` to be installed:
 
@@ -23,25 +40,23 @@ defmodule Arcana.Parser do
       # Fedora
       dnf install poppler-utils
 
-  ### Custom PDF Parser
-
-  Configure a custom parser in `config.exs`:
-
-      config :arcana, pdf_parser: MyApp.PDFParser
-
-  See `Arcana.FileParser.PDF` for the behaviour specification.
   """
 
-  alias Arcana.FileParser
+  alias Arcana.{Config, FileParser}
 
   @text_extensions [".txt", ".md", ".markdown"]
   @pdf_extensions [".pdf"]
 
   @doc """
-  Returns list of supported file extensions.
+  Returns the list of supported file extensions.
+
+  Includes the natively handled formats plus any registered through
+  `:file_parsers`. When a `:fallback_parser` is configured every
+  extension is effectively supported, so this list is a lower bound.
   """
   def supported_formats do
-    @text_extensions ++ @pdf_extensions
+    (@text_extensions ++ @pdf_extensions ++ Map.keys(Config.file_parsers()))
+    |> Enum.uniq()
   end
 
   @doc """
@@ -56,13 +71,18 @@ defmodule Arcana.Parser do
       true  # or false if parser not available
 
   """
-  def pdf_support_available? do
-    {module, _opts} = Arcana.Config.pdf_parser()
+  def pdf_support_available?, do: available?(".pdf")
 
-    if function_exported?(module, :available?, 0) do
-      module.available?()
-    else
-      true
+  @doc """
+  Whether the parser handling `extension` can run right now.
+
+  Returns `false` when no parser handles the extension at all.
+  """
+  def available?(extension) do
+    case resolve(extension) do
+      {:ok, :native} -> true
+      {:ok, parser} -> FileParser.available?(parser)
+      {:error, _} -> false
     end
   end
 
@@ -70,57 +90,147 @@ defmodule Arcana.Parser do
   Parses a file and extracts text content.
 
   Returns `{:ok, text}` on success, or `{:error, reason}` on failure.
+  Use `parse_file/2` to also receive positional metadata.
   """
   def parse(path) do
-    cond do
-      not File.exists?(path) ->
-        {:error, :file_not_found}
-
-      text_file?(path) ->
-        parse_text_file(path)
-
-      pdf_file?(path) ->
-        parse_pdf(path)
-
-      true ->
-        {:error, :unsupported_format}
+    case parse_file(path) do
+      {:ok, text, _meta} -> {:ok, text}
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  defp text_file?(path) do
-    ext = Path.extname(path) |> String.downcase()
-    ext in @text_extensions
-  end
+  @doc """
+  Parses a file, returning text and any positional metadata the parser
+  reported.
 
-  defp pdf_file?(path) do
-    ext = Path.extname(path) |> String.downcase()
-    ext in @pdf_extensions
-  end
+  Returns `{:ok, text, meta}` where `meta` is `%{}` for parsers that
+  don't report positions. See `Arcana.FileParser` for the metadata shape.
+  """
+  def parse_file(path, opts \\ []) do
+    extension = Path.extname(path)
 
-  defp parse_text_file(path) do
-    case File.read(path) do
-      {:ok, content} -> {:ok, content}
-      {:error, _} -> {:error, :read_error}
+    if File.exists?(path) do
+      do_parse_file(path, extension, opts)
+    else
+      {:error, :file_not_found}
     end
   end
 
-  defp parse_pdf(path) do
-    # First verify it's a valid PDF by checking magic bytes
-    case File.read(path) do
-      {:ok, content} ->
-        if String.starts_with?(content, "%PDF") do
-          extract_pdf_text(path)
+  @doc """
+  Parses binary content, routing on `filename`'s extension.
+
+  The resolved parser must accept binary input (`supports_binary?/0`),
+  otherwise returns `{:error, {:binary_unsupported, module}}`. Natively
+  handled text formats always work.
+  """
+  def parse_binary(binary, filename, opts \\ []) when is_binary(binary) do
+    extension = Path.extname(filename)
+
+    case resolve(extension) do
+      {:ok, :native} ->
+        {:ok, binary, %{}}
+
+      {:ok, {module, _} = parser} ->
+        if FileParser.supports_binary?(parser) do
+          validate_and_parse(binary, extension, parser, opts)
         else
-          {:error, :invalid_pdf}
+          {:error, {:binary_unsupported, module}}
         end
 
-      {:error, _} ->
-        {:error, :read_error}
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp extract_pdf_text(path) do
-    pdf_parser = Arcana.Config.pdf_parser()
-    FileParser.PDF.parse(pdf_parser, path)
+  @doc """
+  Returns the content type for a path or filename, based on its
+  extension.
+
+  Registered parsers may declare a `:content_type` in their options;
+  otherwise unknown extensions report `application/octet-stream`.
+  """
+  def content_type_for(path) do
+    extension = Config.normalize_extension(Path.extname(path))
+
+    case extension do
+      ".txt" ->
+        "text/plain"
+
+      ext when ext in [".md", ".markdown"] ->
+        "text/markdown"
+
+      ".pdf" ->
+        "application/pdf"
+
+      _ ->
+        case resolve(extension) do
+          {:ok, {_module, opts}} ->
+            Keyword.get(opts, :content_type, "application/octet-stream")
+
+          _ ->
+            "application/octet-stream"
+        end
+    end
+  end
+
+  # Resolves an extension to :native, a {module, opts} parser, or an error.
+  defp resolve(extension) do
+    extension = Config.normalize_extension(extension)
+    registered = Config.file_parsers()
+
+    cond do
+      Map.has_key?(registered, extension) -> {:ok, Map.fetch!(registered, extension)}
+      extension in @text_extensions -> {:ok, :native}
+      extension in @pdf_extensions -> {:ok, Config.pdf_parser()}
+      fallback = Config.fallback_parser() -> {:ok, fallback}
+      true -> {:error, :unsupported_format}
+    end
+  end
+
+  defp do_parse_file(path, extension, opts) do
+    case resolve(extension) do
+      {:ok, :native} ->
+        case File.read(path) do
+          {:ok, content} -> {:ok, content, %{}}
+          {:error, _} -> {:error, :read_error}
+        end
+
+      {:ok, parser} ->
+        validate_and_parse(path, extension, parser, opts)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # PDFs are magic-byte checked before reaching a parser, so a mislabeled
+  # file fails with :invalid_pdf instead of whatever the tool reports.
+  defp validate_and_parse(input, extension, parser, opts) do
+    if Config.normalize_extension(extension) in @pdf_extensions do
+      case pdf_content(input) do
+        {:ok, content} ->
+          if String.starts_with?(content, "%PDF") do
+            FileParser.parse(parser, input, opts)
+          else
+            {:error, :invalid_pdf}
+          end
+
+        error ->
+          error
+      end
+    else
+      FileParser.parse(parser, input, opts)
+    end
+  end
+
+  defp pdf_content(input) do
+    if File.exists?(input) do
+      case File.read(input) do
+        {:ok, content} -> {:ok, content}
+        {:error, _} -> {:error, :read_error}
+      end
+    else
+      {:ok, input}
+    end
   end
 end

--- a/lib/arcana/parser.ex
+++ b/lib/arcana/parser.ex
@@ -129,6 +129,10 @@ defmodule Arcana.Parser do
   The resolved parser must accept binary input (`supports_binary?/0`),
   otherwise returns `{:error, {:binary_unsupported, module}}`. Natively
   handled text formats always work.
+
+  When a parser is both unavailable (`available?/0`) and path-only,
+  unavailability wins: this returns `{:error, {:parser_unavailable,
+  module}}`, the same reason the path-based flow gives.
   """
   def parse_binary(binary, filename, opts \\ []) when is_binary(binary) do
     extension = Path.extname(filename)
@@ -138,10 +142,19 @@ defmodule Arcana.Parser do
         {:ok, binary, %{}}
 
       {:ok, {module, _} = parser} ->
-        if FileParser.supports_binary?(parser) do
-          validate_and_parse(binary, :binary, extension, parser, opts)
-        else
-          {:error, {:binary_unsupported, module}}
+        cond do
+          FileParser.supports_binary?(parser) ->
+            validate_and_parse(binary, :binary, extension, parser, opts)
+
+          # A parser that can't run won't handle a file path either, so
+          # reporting :binary_unsupported would send the caller off to a
+          # retry that fails just the same. Unavailability wins, keeping
+          # this flow's reason identical to the path-based one.
+          not FileParser.available?(parser) ->
+            {:error, FileParser.unavailable_reason(parser)}
+
+          true ->
+            {:error, {:binary_unsupported, module}}
         end
 
       {:error, reason} ->
@@ -225,7 +238,7 @@ defmodule Arcana.Parser do
       case pdf_content(input, kind) do
         {:ok, content} ->
           if String.starts_with?(content, "%PDF") do
-            invoke(parser, input, opts)
+            FileParser.parse(parser, input, opts)
           else
             {:error, :invalid_pdf}
           end
@@ -234,27 +247,9 @@ defmodule Arcana.Parser do
           error
       end
     else
-      invoke(parser, input, opts)
-    end
-  end
-
-  # A parser that reports itself unavailable (`available?/0`) doesn't get
-  # called. Poppler self-guards, so this used to be harmless for the
-  # built-in route, but a third-party parser written to the documented
-  # contract was invoked anyway.
-  defp invoke(parser, input, opts) do
-    if FileParser.available?(parser) do
       FileParser.parse(parser, input, opts)
-    else
-      {:error, unavailable_reason(parser)}
     end
   end
-
-  # Poppler has reported :poppler_not_available since before this gate
-  # existed and callers match on it; keep that exact shape for the
-  # built-in and give everyone else the generic error.
-  defp unavailable_reason({Arcana.FileParser.PDF.Poppler, _opts}), do: :poppler_not_available
-  defp unavailable_reason({module, _opts}), do: {:parser_unavailable, module}
 
   defp pdf_content(binary, :binary), do: {:ok, binary}
 

--- a/test/arcana/chunker_test.exs
+++ b/test/arcana/chunker_test.exs
@@ -114,4 +114,45 @@ defmodule Arcana.ChunkerTest do
       assert length(token_chunks) < length(char_chunks)
     end
   end
+
+  describe "source offsets" do
+    test "every chunk carries byte offsets that slice back to its text" do
+      text =
+        Enum.map_join(1..40, "\n\n", fn i ->
+          "Paragraph #{i} with enough words to make the chunker split things up."
+        end)
+
+      chunks = Chunker.chunk(text, chunk_size: 60, chunk_overlap: 10)
+
+      assert length(chunks) > 1
+
+      for chunk <- chunks do
+        start_byte = chunk.metadata["start_byte"]
+        end_byte = chunk.metadata["end_byte"]
+
+        assert is_integer(start_byte) and is_integer(end_byte)
+        assert binary_part(text, start_byte, end_byte - start_byte) == chunk.text
+      end
+    end
+
+    test "offsets stay correct when the same text repeats" do
+      # A naive scan for chunk text would mislocate these; the offsets
+      # come from the splitter itself
+      paragraph = "The very same paragraph repeated verbatim several times over."
+      text = Enum.map_join(1..12, "\n\n", fn _ -> paragraph end)
+
+      chunks = Chunker.chunk(text, chunk_size: 40, chunk_overlap: 5)
+
+      offsets = Enum.map(chunks, & &1.metadata["start_byte"])
+
+      assert offsets == Enum.sort(offsets)
+      assert length(Enum.uniq(offsets)) == length(offsets)
+
+      for chunk <- chunks do
+        start_byte = chunk.metadata["start_byte"]
+        end_byte = chunk.metadata["end_byte"]
+        assert binary_part(text, start_byte, end_byte - start_byte) == chunk.text
+      end
+    end
+  end
 end

--- a/test/arcana/file_parser/pdf/poppler_test.exs
+++ b/test/arcana/file_parser/pdf/poppler_test.exs
@@ -70,10 +70,10 @@ defmodule Arcana.FileParser.PDF.PopplerTest do
                %{number: 1, start: 0, end: 8},
                %{number: 2, start: 9, end: 17},
                %{number: 3, start: 18, end: 28}
-             ] = Poppler.page_ranges(text)
+             ] = Poppler.page_ranges(text, String.trim(text))
 
       # each range slices back to its page's text
-      for %{start: s, end: e} <- Poppler.page_ranges(text) do
+      for %{start: s, end: e} <- Poppler.page_ranges(text, String.trim(text)) do
         assert binary_part(text, s, e - s) in ["page one", "page two", "page three"]
       end
     end
@@ -81,7 +81,22 @@ defmodule Arcana.FileParser.PDF.PopplerTest do
     test "single-page text is one range covering everything" do
       text = "just one page"
 
-      assert [%{number: 1, start: 0, end: 13}] = Poppler.page_ranges(text)
+      assert [%{number: 1, start: 0, end: 13}] = Poppler.page_ranges(text, String.trim(text))
+    end
+
+    test "blank leading pages keep their numbers and report empty ranges" do
+      # pdftotext emits a form feed per page boundary; two blank pages up
+      # front would otherwise be trimmed away, renumbering everything
+      raw = "\f\fpage three text"
+      trimmed = String.trim(raw)
+
+      assert [
+               %{number: 1, start: 0, end: 0},
+               %{number: 2, start: 0, end: 0},
+               %{number: 3, start: 0, end: 15}
+             ] = Poppler.page_ranges(raw, trimmed)
+
+      assert binary_part(trimmed, 0, 15) == "page three text"
     end
   end
 end

--- a/test/arcana/file_parser/pdf/poppler_test.exs
+++ b/test/arcana/file_parser/pdf/poppler_test.exs
@@ -61,4 +61,27 @@ defmodule Arcana.FileParser.PDF.PopplerTest do
   defp fixture_path(filename) do
     Path.join([__DIR__, "..", "..", "..", "fixtures", filename])
   end
+
+  describe "page_ranges/1" do
+    test "derives page byte ranges from form feeds" do
+      text = "page one\fpage two\fpage three"
+
+      assert [
+               %{number: 1, start: 0, end: 8},
+               %{number: 2, start: 9, end: 17},
+               %{number: 3, start: 18, end: 28}
+             ] = Poppler.page_ranges(text)
+
+      # each range slices back to its page's text
+      for %{start: s, end: e} <- Poppler.page_ranges(text) do
+        assert binary_part(text, s, e - s) in ["page one", "page two", "page three"]
+      end
+    end
+
+    test "single-page text is one range covering everything" do
+      text = "just one page"
+
+      assert [%{number: 1, start: 0, end: 13}] = Poppler.page_ranges(text)
+    end
+  end
 end

--- a/test/arcana/file_parser/pdf/poppler_test.exs
+++ b/test/arcana/file_parser/pdf/poppler_test.exs
@@ -1,6 +1,7 @@
 defmodule Arcana.FileParser.PDF.PopplerTest do
   use ExUnit.Case, async: true
 
+  alias Arcana.FileParser.PDF
   alias Arcana.FileParser.PDF.Poppler
 
   describe "available?/0" do
@@ -23,7 +24,7 @@ defmodule Arcana.FileParser.PDF.PopplerTest do
       if Poppler.available?() do
         path = fixture_path("sample.pdf")
 
-        assert {:ok, text} = Poppler.parse(path, [])
+        assert {:ok, text, _meta} = Poppler.parse(path, [])
         assert String.contains?(text, "Hello PDF")
       end
     end
@@ -40,7 +41,7 @@ defmodule Arcana.FileParser.PDF.PopplerTest do
       path = fixture_path("sample.pdf")
 
       case Poppler.parse(path, []) do
-        {:ok, _text} -> assert Poppler.available?()
+        {:ok, _text, _meta} -> assert Poppler.available?()
         {:error, :poppler_not_available} -> refute Poppler.available?()
         {:error, {:pdftotext_failed, _}} -> :ok
         {:error, other} -> flunk("Unexpected error: #{inspect(other)}")
@@ -52,8 +53,31 @@ defmodule Arcana.FileParser.PDF.PopplerTest do
         path = fixture_path("sample.pdf")
 
         # Both should succeed, layout just affects formatting
-        assert {:ok, _text1} = Poppler.parse(path, layout: true)
-        assert {:ok, _text2} = Poppler.parse(path, layout: false)
+        assert {:ok, _text1, _meta1} = Poppler.parse(path, layout: true)
+        assert {:ok, _text2, _meta2} = Poppler.parse(path, layout: false)
+      end
+    end
+
+    test "a one-page PDF reports exactly one page" do
+      # pdftotext terminates every page with a form feed, so a naive
+      # split reported a phantom empty page N+1. The hand-written
+      # page_ranges/2 fixtures below can't catch that: they have no
+      # trailing form feed. Only the real tool's output does.
+      if Poppler.available?() do
+        assert {:ok, text, %{pages: pages}} = Poppler.parse(fixture_path("sample.pdf"), [])
+
+        assert [%{number: 1, start: 0, end: page_end}] = pages
+        assert page_end == byte_size(text)
+        assert binary_part(text, 0, page_end) == text
+      end
+    end
+
+    test "PDF.parse/3 still hands legacy callers a two-tuple" do
+      if Poppler.available?() do
+        parser = {Poppler, []}
+
+        assert {:ok, text} = PDF.parse(parser, fixture_path("sample.pdf"))
+        assert String.contains?(text, "Hello PDF")
       end
     end
   end
@@ -62,7 +86,7 @@ defmodule Arcana.FileParser.PDF.PopplerTest do
     Path.join([__DIR__, "..", "..", "..", "fixtures", filename])
   end
 
-  describe "page_ranges/1" do
+  describe "page_ranges/2" do
     test "derives page byte ranges from form feeds" do
       text = "page one\fpage two\fpage three"
 
@@ -82,6 +106,26 @@ defmodule Arcana.FileParser.PDF.PopplerTest do
       text = "just one page"
 
       assert [%{number: 1, start: 0, end: 13}] = Poppler.page_ranges(text, String.trim(text))
+    end
+
+    test "the trailing form feed pdftotext emits is not a page" do
+      # Real pdftotext output terminates each page with \f, so two pages
+      # arrive as "one\ftwo\f" — splitting that naively yields a third,
+      # empty page.
+      raw = "page one\fpage two\f"
+
+      assert [%{number: 1}, %{number: 2}] = Poppler.page_ranges(raw, String.trim(raw))
+    end
+
+    test "a genuinely blank final page still gets its own range" do
+      # A blank page 3 arrives as its own (empty) segment before the
+      # terminating form feed, so it must survive the trailing-\f trim.
+      raw = "page one\fpage two\f\f"
+
+      assert [%{number: 1}, %{number: 2}, %{number: 3, start: s, end: e}] =
+               Poppler.page_ranges(raw, String.trim(raw))
+
+      assert s == e
     end
 
     test "blank leading pages keep their numbers and report empty ranges" do

--- a/test/arcana/file_parser/pdf_test.exs
+++ b/test/arcana/file_parser/pdf_test.exs
@@ -31,6 +31,20 @@ defmodule Arcana.FileParser.PDFTest do
       parser = {Poppler, []}
       refute PDF.supports_binary?(parser)
     end
+
+    test "loads the module before asking, so an unloaded parser isn't misreported" do
+      # A module exports nothing until it is loaded, and nothing guarantees
+      # a configured parser has been touched before this is called.
+      module = Arcana.Test.UnloadedBinaryParser
+
+      :code.purge(module)
+      :code.delete(module)
+      :code.purge(module)
+
+      refute :erlang.module_loaded(module)
+
+      assert PDF.supports_binary?({module, []})
+    end
   end
 
   defp fixture_path(filename) do

--- a/test/arcana/file_parser_registry_test.exs
+++ b/test/arcana/file_parser_registry_test.exs
@@ -81,6 +81,8 @@ end
 defmodule Arcana.FileParserRegistryTest do
   use Arcana.DataCase, async: true
 
+  alias Arcana.FileParser
+  alias Arcana.FileParser.PDF
   alias Arcana.Parser
 
   defp temp_file(content, extension) do
@@ -327,6 +329,41 @@ defmodule Arcana.FileParserRegistryTest do
 
       assert {:error, {:parser_unavailable, MustNotRunParser}} =
                Arcana.ingest_binary("x", filename: "report.docx", repo: Repo)
+    end
+
+    test "the public parser wrapper gates too, not just Arcana.Parser" do
+      # FileParser.parse/3 is public API; callers reaching for it directly
+      # got the parser invoked anyway, so the documented guarantee held
+      # only for the Arcana.Parser route.
+      assert {:error, {:parser_unavailable, MustNotRunParser}} =
+               FileParser.parse({MustNotRunParser, []}, "raw bytes")
+    end
+
+    test "the PDF wrapper routes through the same gate" do
+      assert {:error, {:parser_unavailable, MustNotRunParser}} =
+               PDF.parse({MustNotRunParser, []}, "/tmp/whatever.pdf")
+    end
+
+    test "the built-in Poppler parser keeps reporting :poppler_not_available" do
+      # Callers have matched on this bare atom since before the gate
+      # existed. Every other parser gets the generic tuple.
+      assert FileParser.unavailable_reason({PDF.Poppler, []}) == :poppler_not_available
+
+      assert FileParser.unavailable_reason({MustNotRunParser, []}) ==
+               {:parser_unavailable, MustNotRunParser}
+    end
+
+    test "an unavailable path-only parser reports unavailability, not binary_unsupported" do
+      # Both conditions hold here: the supports_binary? short-circuit used
+      # to answer first, so a caller matching {:parser_unavailable, _}
+      # missed it on the binary path while catching it on the path one.
+      put_arcana_env(:file_parsers, %{".docx" => UnavailableParser})
+
+      assert {:error, {:parser_unavailable, UnavailableParser}} =
+               Parser.parse_binary("raw", "report.docx")
+
+      path = temp_file("x", ".docx")
+      assert {:error, {:parser_unavailable, UnavailableParser}} = Parser.parse(path)
     end
   end
 

--- a/test/arcana/file_parser_registry_test.exs
+++ b/test/arcana/file_parser_registry_test.exs
@@ -49,6 +49,35 @@ defmodule UnavailableParser do
   def available?, do: false
 end
 
+defmodule MustNotRunParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts), do: raise("MustNotRunParser.parse/2 must not be invoked")
+
+  @impl true
+  def supports_binary?, do: true
+
+  @impl true
+  def available?, do: false
+end
+
+defmodule KeywordMetaParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts), do: {:ok, "text", pages: []}
+
+  @impl true
+  def supports_binary?, do: true
+end
+
+defmodule NotAParserAtAll do
+  @moduledoc false
+end
+
 defmodule Arcana.FileParserRegistryTest do
   use Arcana.DataCase, async: true
 
@@ -149,6 +178,32 @@ defmodule Arcana.FileParserRegistryTest do
         Arcana.Config.fallback_parser()
       end
     end
+
+    test "a boolean or nil tuple head is a config error too" do
+      # bare `false` was already rejected, but `{false, opts}` still looked
+      # like a valid {module, opts} pair and reached `false.parse/2`
+      put_arcana_env(:fallback_parser, {false, []})
+
+      assert_raise ArgumentError, ~r/invalid file parser config: \{false, \[\]\}/, fn ->
+        Arcana.Config.fallback_parser()
+      end
+
+      put_arcana_env(:fallback_parser, {nil, label: "x"})
+
+      assert_raise ArgumentError, ~r/invalid file parser config: \{nil, /, fn ->
+        Arcana.Config.fallback_parser()
+      end
+    end
+
+    test "a boolean tuple head in :file_parsers is a config error, not a runtime crash" do
+      put_arcana_env(:file_parsers, %{".docx" => {false, []}})
+
+      path = temp_file("x", ".docx")
+
+      assert_raise ArgumentError, ~r/invalid file parser config: \{false, \[\]\}/, fn ->
+        Parser.parse(path)
+      end
+    end
   end
 
   describe "disabling an extension" do
@@ -240,6 +295,47 @@ defmodule Arcana.FileParserRegistryTest do
 
     test "is false for extensions nothing handles" do
       refute Parser.available?(".rtf")
+    end
+
+    test "a module that doesn't exist reports unavailable instead of defaulting to true" do
+      put_arcana_env(:file_parsers, %{".docx" => MyApp.NoSuchParserWhatsoever})
+
+      refute Parser.available?(".docx")
+    end
+
+    test "a module without parse/2 reports unavailable" do
+      put_arcana_env(:file_parsers, %{".docx" => NotAParserAtAll})
+
+      refute Parser.available?(".docx")
+    end
+  end
+
+  describe "unavailable parsers" do
+    test "an unavailable parser is never invoked" do
+      put_arcana_env(:file_parsers, %{".docx" => MustNotRunParser})
+
+      path = temp_file("x", ".docx")
+
+      assert {:error, {:parser_unavailable, MustNotRunParser}} = Parser.parse(path)
+
+      assert {:error, {:parser_unavailable, MustNotRunParser}} =
+               Parser.parse_binary("x", "report.docx")
+    end
+
+    test "ingestion surfaces the unavailable parser instead of crashing" do
+      put_arcana_env(:file_parsers, %{".docx" => MustNotRunParser})
+
+      assert {:error, {:parser_unavailable, MustNotRunParser}} =
+               Arcana.ingest_binary("x", filename: "report.docx", repo: Repo)
+    end
+  end
+
+  describe "malformed parser returns" do
+    test "a non-map third element is an error tuple, not a CaseClauseError" do
+      put_arcana_env(:file_parsers, %{".docx" => KeywordMetaParser})
+
+      assert {:error, {:invalid_parser_metadata, KeywordMetaParser, [pages: []]}} =
+               Parser.parse_binary("raw", "doc.docx")
     end
   end
 

--- a/test/arcana/file_parser_registry_test.exs
+++ b/test/arcana/file_parser_registry_test.exs
@@ -121,6 +121,66 @@ defmodule Arcana.FileParserRegistryTest do
 
       assert {:error, :unsupported_format} = Parser.parse(path)
     end
+
+    test "false disables the fallback instead of being treated as a module" do
+      # `false` is an atom, so it used to sail through as a module name
+      # and blow up with `function false.parse/2` at parse time
+      put_arcana_env(:fallback_parser, false)
+
+      assert Arcana.Config.fallback_parser() == nil
+
+      path = temp_file("x", ".rtf")
+
+      assert {:error, :unsupported_format} = Parser.parse(path)
+    end
+
+    test "a disabled fallback still leaves native formats alone" do
+      put_arcana_env(:fallback_parser, false)
+
+      path = temp_file("plain text", ".txt")
+
+      assert {:ok, "plain text"} = Parser.parse(path)
+    end
+
+    test "a non-module fallback is a config error, not a runtime one" do
+      put_arcana_env(:fallback_parser, true)
+
+      assert_raise ArgumentError, ~r/invalid file parser config: true/, fn ->
+        Arcana.Config.fallback_parser()
+      end
+    end
+  end
+
+  describe "disabling an extension" do
+    test "a file_parsers entry of false turns the extension off" do
+      put_arcana_env(:file_parsers, %{".docx" => false})
+
+      path = temp_file("x", ".docx")
+
+      assert {:error, :unsupported_format} = Parser.parse(path)
+      refute Parser.available?(".docx")
+      refute ".docx" in Parser.supported_formats()
+    end
+
+    test "false beats the fallback parser, which would otherwise claim it" do
+      put_arcana_env(:fallback_parser, {FakeDocxParser, label: "fallback"})
+      put_arcana_env(:file_parsers, %{".docx" => false})
+
+      path = temp_file("x", ".docx")
+
+      assert {:error, :unsupported_format} = Parser.parse(path)
+      assert {:error, :unsupported_format} = Parser.parse_binary("x", "a.docx")
+    end
+
+    test "false beats a built-in format too" do
+      put_arcana_env(:file_parsers, %{".txt" => false})
+
+      path = temp_file("plain text", ".txt")
+
+      assert {:error, :unsupported_format} = Parser.parse(path)
+      refute ".txt" in Parser.supported_formats()
+      assert ".md" in Parser.supported_formats()
+    end
   end
 
   describe "parse_binary/3" do

--- a/test/arcana/file_parser_registry_test.exs
+++ b/test/arcana/file_parser_registry_test.exs
@@ -98,6 +98,30 @@ defmodule BarePageNumbersParser do
   def supports_binary?, do: true
 end
 
+defmodule ReversedPagesParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts),
+    do: {:ok, "some text", %{pages: [%{number: 1, start: 40, end: 10}]}}
+
+  @impl true
+  def supports_binary?, do: true
+end
+
+defmodule NegativePagesParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts),
+    do: {:ok, "some text", %{pages: [%{number: 1, start: -5, end: 20}]}}
+
+  @impl true
+  def supports_binary?, do: true
+end
+
 defmodule NotAParserAtAll do
   @moduledoc false
 end
@@ -410,6 +434,23 @@ defmodule Arcana.FileParserRegistryTest do
       put_arcana_env(:file_parsers, %{".docx" => BarePageNumbersParser})
 
       assert {:error, {:invalid_parser_metadata, BarePageNumbersParser, _meta}} =
+               Parser.parse_binary("raw", "doc.docx")
+    end
+
+    test "a page ending before it starts is rejected, not silently cited" do
+      # page_at/2 falls back rather than raising on a reversed range, so
+      # without the guard the chunk gets a citation pointing at text that
+      # isn't there - worse than an error, because it looks right.
+      put_arcana_env(:file_parsers, %{".docx" => ReversedPagesParser})
+
+      assert {:error, {:invalid_parser_metadata, ReversedPagesParser, _meta}} =
+               Parser.parse_binary("raw", "doc.docx")
+    end
+
+    test "a negative page start is rejected" do
+      put_arcana_env(:file_parsers, %{".docx" => NegativePagesParser})
+
+      assert {:error, {:invalid_parser_metadata, NegativePagesParser, _meta}} =
                Parser.parse_binary("raw", "doc.docx")
     end
 

--- a/test/arcana/file_parser_registry_test.exs
+++ b/test/arcana/file_parser_registry_test.exs
@@ -1,0 +1,204 @@
+defmodule FakeDocxParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(input, opts) do
+    label = Keyword.get(opts, :label, "docx")
+
+    if String.starts_with?(input, "/") do
+      {:ok, "#{label} from path"}
+    else
+      {:ok, "#{label} from binary"}
+    end
+  end
+
+  @impl true
+  def supports_binary?, do: true
+end
+
+defmodule PathOnlyParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts), do: {:ok, "path only"}
+end
+
+defmodule PagedParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts) do
+    {:ok, "page one\npage two", %{pages: [%{number: 1, start: 0, end: 8}]}}
+  end
+
+  @impl true
+  def supports_binary?, do: true
+end
+
+defmodule UnavailableParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts), do: {:ok, ""}
+
+  @impl true
+  def available?, do: false
+end
+
+defmodule Arcana.FileParserRegistryTest do
+  use Arcana.DataCase, async: true
+
+  alias Arcana.Parser
+
+  defp temp_file(content, extension) do
+    path =
+      Path.join(System.tmp_dir!(), "arcana_reg_#{System.unique_integer([:positive])}#{extension}")
+
+    File.write!(path, content)
+    on_exit(fn -> File.rm(path) end)
+    path
+  end
+
+  describe "registered parsers" do
+    test "an extension registered in :file_parsers is routed to its parser" do
+      put_arcana_env(:file_parsers, %{".docx" => {FakeDocxParser, label: "custom"}})
+
+      path = temp_file("binary-ish", ".docx")
+
+      assert {:ok, "custom from path"} = Parser.parse(path)
+    end
+
+    test "extensions are normalized (case and missing dot)" do
+      put_arcana_env(:file_parsers, %{"DOCX" => FakeDocxParser})
+
+      path = temp_file("x", ".docx")
+
+      assert {:ok, "docx from path"} = Parser.parse(path)
+    end
+
+    test "a registered parser overrides a built-in format" do
+      put_arcana_env(:file_parsers, %{".txt" => {FakeDocxParser, label: "override"}})
+
+      path = temp_file("plain text", ".txt")
+
+      assert {:ok, "override from path"} = Parser.parse(path)
+    end
+
+    test "supported_formats includes registered extensions" do
+      put_arcana_env(:file_parsers, %{".docx" => FakeDocxParser})
+
+      formats = Parser.supported_formats()
+
+      assert ".docx" in formats
+      assert ".txt" in formats
+      assert ".pdf" in formats
+    end
+  end
+
+  describe "fallback parser" do
+    test "handles extensions nothing else claims" do
+      put_arcana_env(:fallback_parser, {FakeDocxParser, label: "fallback"})
+
+      path = temp_file("x", ".rtf")
+
+      assert {:ok, "fallback from path"} = Parser.parse(path)
+    end
+
+    test "does not shadow native or registered formats" do
+      put_arcana_env(:fallback_parser, {FakeDocxParser, label: "fallback"})
+
+      path = temp_file("plain text", ".txt")
+
+      assert {:ok, "plain text"} = Parser.parse(path)
+    end
+
+    test "without a fallback, unknown extensions are unsupported" do
+      path = temp_file("x", ".rtf")
+
+      assert {:error, :unsupported_format} = Parser.parse(path)
+    end
+  end
+
+  describe "parse_binary/3" do
+    test "routes binaries through a binary-capable parser" do
+      put_arcana_env(:file_parsers, %{".docx" => FakeDocxParser})
+
+      assert {:ok, "docx from binary", %{}} = Parser.parse_binary("raw bytes", "report.docx")
+    end
+
+    test "native text formats accept binaries directly" do
+      assert {:ok, "hello", %{}} = Parser.parse_binary("hello", "notes.md")
+    end
+
+    test "a path-only parser refuses binary content" do
+      put_arcana_env(:file_parsers, %{".docx" => PathOnlyParser})
+
+      assert {:error, {:binary_unsupported, PathOnlyParser}} =
+               Parser.parse_binary("raw", "report.docx")
+    end
+
+    test "unknown extensions are unsupported" do
+      assert {:error, :unsupported_format} = Parser.parse_binary("raw", "report.rtf")
+    end
+  end
+
+  describe "positional metadata" do
+    test "parsers may return page metadata" do
+      put_arcana_env(:file_parsers, %{".paged" => PagedParser})
+
+      assert {:ok, "page one\npage two", %{pages: [%{number: 1}]}} =
+               Parser.parse_binary("raw", "doc.paged")
+    end
+
+    test "parsers returning plain text get empty metadata" do
+      put_arcana_env(:file_parsers, %{".docx" => FakeDocxParser})
+
+      assert {:ok, _text, %{}} = Parser.parse_binary("raw", "doc.docx")
+    end
+
+    test "parse/1 keeps the two-tuple shape for existing callers" do
+      put_arcana_env(:file_parsers, %{".paged" => PagedParser})
+
+      path = temp_file("x", ".paged")
+
+      assert {:ok, "page one\npage two"} = Parser.parse(path)
+    end
+  end
+
+  describe "available?/1" do
+    test "reports a parser's availability and true for native formats" do
+      put_arcana_env(:file_parsers, %{".broken" => UnavailableParser, ".docx" => FakeDocxParser})
+
+      refute Parser.available?(".broken")
+      assert Parser.available?(".docx")
+      assert Parser.available?(".txt")
+    end
+
+    test "is false for extensions nothing handles" do
+      refute Parser.available?(".rtf")
+    end
+  end
+
+  describe "content_type_for/1" do
+    test "covers native formats and registered declarations" do
+      put_arcana_env(:file_parsers, %{
+        ".docx" =>
+          {FakeDocxParser,
+           content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"}
+      })
+
+      assert Parser.content_type_for("a.txt") == "text/plain"
+      assert Parser.content_type_for("a.md") == "text/markdown"
+      assert Parser.content_type_for("a.pdf") == "application/pdf"
+
+      assert Parser.content_type_for("a.docx") ==
+               "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+      assert Parser.content_type_for("a.rtf") == "application/octet-stream"
+    end
+  end
+end

--- a/test/arcana/file_parser_registry_test.exs
+++ b/test/arcana/file_parser_registry_test.exs
@@ -74,6 +74,30 @@ defmodule KeywordMetaParser do
   def supports_binary?, do: true
 end
 
+defmodule StringKeyedPagesParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts) do
+    {:ok, "some text", %{pages: [%{"number" => 1, "start" => 0, "end" => 9}]}}
+  end
+
+  @impl true
+  def supports_binary?, do: true
+end
+
+defmodule BarePageNumbersParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts), do: {:ok, "some text", %{pages: [1, 2]}}
+
+  @impl true
+  def supports_binary?, do: true
+end
+
 defmodule NotAParserAtAll do
   @moduledoc false
 end
@@ -373,6 +397,33 @@ defmodule Arcana.FileParserRegistryTest do
 
       assert {:error, {:invalid_parser_metadata, KeywordMetaParser, [pages: []]}} =
                Parser.parse_binary("raw", "doc.docx")
+    end
+
+    test "string-keyed pages are rejected at the parser, not deep inside chunking" do
+      put_arcana_env(:file_parsers, %{".docx" => StringKeyedPagesParser})
+
+      assert {:error, {:invalid_parser_metadata, StringKeyedPagesParser, _meta}} =
+               Parser.parse_binary("raw", "doc.docx")
+    end
+
+    test "pages that aren't maps at all are rejected too" do
+      put_arcana_env(:file_parsers, %{".docx" => BarePageNumbersParser})
+
+      assert {:error, {:invalid_parser_metadata, BarePageNumbersParser, _meta}} =
+               Parser.parse_binary("raw", "doc.docx")
+    end
+
+    test "malformed pages leave no orphaned :processing document behind" do
+      # attach_pages/2 runs after the document row is inserted, so a raise
+      # from page_at/2 used to strand a half-ingested document.
+      put_arcana_env(:file_parsers, %{".docx" => StringKeyedPagesParser})
+
+      before = Repo.aggregate(Arcana.Document, :count)
+
+      assert {:error, {:invalid_parser_metadata, StringKeyedPagesParser, _meta}} =
+               Arcana.ingest_binary("raw", filename: "doc.docx", repo: Repo)
+
+      assert Repo.aggregate(Arcana.Document, :count) == before
     end
   end
 

--- a/test/arcana/ingest_binary_test.exs
+++ b/test/arcana/ingest_binary_test.exs
@@ -344,6 +344,33 @@ defmodule Arcana.IngestBinaryTest do
       assert chunk.metadata["page_end"] == 3
     end
 
+    test "a falsy :metadata is absent, not a crash" do
+      # Chunker.metadata_for/1 reaches for `||`, so `false` is simply no
+      # declared metadata there. attach_pages/2 used to have no clause for
+      # it and took the whole ingest down its failure path instead.
+      [_page_one, _page_two, page_three] = PagedFixtureParser.pages()
+
+      put_arcana_env(:chunker, fn text, _opts ->
+        [
+          %{
+            text: binary_part(text, page_three.start, page_three.end - page_three.start),
+            chunk_index: 0,
+            token_count: 5,
+            start_byte: page_three.start,
+            end_byte: page_three.end,
+            metadata: false
+          }
+        ]
+      end)
+
+      assert {:ok, document} =
+               Arcana.ingest_binary("ignored", filename: "doc.paged", repo: Repo)
+
+      assert [chunk] = chunks_of(document)
+      assert chunk.metadata["page_start"] == 3
+      assert chunk.metadata["page_end"] == 3
+    end
+
     test "a declared nil offset wins over a top-level extra, matching what gets stored" do
       [_page_one, _page_two, page_three] = PagedFixtureParser.pages()
 

--- a/test/arcana/ingest_binary_test.exs
+++ b/test/arcana/ingest_binary_test.exs
@@ -268,6 +268,52 @@ defmodule Arcana.IngestBinaryTest do
       assert chunks |> Enum.map(& &1.metadata["page_start"]) |> Enum.uniq() |> length() > 1
     end
 
+    test "a custom chunker's atom-keyed offsets still get pages" do
+      [_page_one, page_two, _page_three] = PagedFixtureParser.pages()
+
+      put_arcana_env(:chunker, fn text, _opts ->
+        [
+          %{
+            text: binary_part(text, page_two.start, page_two.end - page_two.start),
+            chunk_index: 0,
+            token_count: 5,
+            metadata: %{start_byte: page_two.start, end_byte: page_two.end}
+          }
+        ]
+      end)
+
+      assert {:ok, document} =
+               Arcana.ingest_binary("ignored", filename: "doc.paged", repo: Repo)
+
+      assert [chunk] = chunks_of(document)
+      assert chunk.metadata["start_byte"] == page_two.start
+      assert chunk.metadata["page_start"] == 2
+      assert chunk.metadata["page_end"] == 2
+    end
+
+    test "offsets handed back as top-level extras still get pages" do
+      [_page_one, _page_two, page_three] = PagedFixtureParser.pages()
+
+      put_arcana_env(:chunker, fn text, _opts ->
+        [
+          %{
+            text: binary_part(text, page_three.start, page_three.end - page_three.start),
+            chunk_index: 0,
+            token_count: 5,
+            start_byte: page_three.start,
+            end_byte: page_three.end
+          }
+        ]
+      end)
+
+      assert {:ok, document} =
+               Arcana.ingest_binary("ignored", filename: "doc.paged", repo: Repo)
+
+      assert [chunk] = chunks_of(document)
+      assert chunk.metadata["page_start"] == 3
+      assert chunk.metadata["page_end"] == 3
+    end
+
     test "parsers without page metadata leave chunks page-free" do
       assert {:ok, document} =
                Arcana.ingest_binary("plain text with no pages at all",

--- a/test/arcana/ingest_binary_test.exs
+++ b/test/arcana/ingest_binary_test.exs
@@ -327,6 +327,34 @@ defmodule Arcana.IngestBinaryTest do
       assert chunk.metadata["page_end"] == 3
     end
 
+    test "a declared nil offset wins over a top-level extra, matching what gets stored" do
+      [_page_one, _page_two, page_three] = PagedFixtureParser.pages()
+
+      put_arcana_env(:chunker, fn text, _opts ->
+        [
+          %{
+            text: text,
+            chunk_index: 0,
+            token_count: 5,
+            start_byte: page_three.start,
+            end_byte: page_three.end,
+            metadata: %{start_byte: nil, end_byte: nil}
+          }
+        ]
+      end)
+
+      assert {:ok, document} =
+               Arcana.ingest_binary("ignored", filename: "doc.paged", repo: Repo)
+
+      assert [chunk] = chunks_of(document)
+
+      # the declared entry is what reaches storage, so deriving pages from
+      # the shadowed top-level extra would cite an offset nobody can see
+      assert chunk.metadata["start_byte"] == nil
+      refute Map.has_key?(chunk.metadata, "page_start")
+      refute Map.has_key?(chunk.metadata, "page_end")
+    end
+
     test "parsers without page metadata leave chunks page-free" do
       assert {:ok, document} =
                Arcana.ingest_binary("plain text with no pages at all",

--- a/test/arcana/ingest_binary_test.exs
+++ b/test/arcana/ingest_binary_test.exs
@@ -91,9 +91,21 @@ defmodule Arcana.IngestBinaryTest do
                Arcana.ingest_binary("raw-bytes", filename: "report.docx", repo: Repo)
     end
 
-    test "PDF bytes report binary_unsupported: poppler shells out to a real file" do
-      assert {:error, {:binary_unsupported, Arcana.FileParser.PDF.Poppler}} =
-               Arcana.ingest_binary("%PDF-1.4 whatever", filename: "manual.pdf", repo: Repo)
+    test "PDF bytes are refused: poppler shells out to a real file" do
+      # Poppler is path-only, so binary_unsupported is the answer wherever
+      # pdftotext is installed. Without it the parser is unavailable too,
+      # and unavailability wins in parse_binary/3 — so the suite has to
+      # accept both rather than requiring poppler to run at all.
+      case Arcana.ingest_binary("%PDF-1.4 whatever", filename: "manual.pdf", repo: Repo) do
+        {:error, {:binary_unsupported, Arcana.FileParser.PDF.Poppler}} ->
+          assert Parser.pdf_support_available?()
+
+        {:error, :poppler_not_available} ->
+          refute Parser.pdf_support_available?()
+
+        other ->
+          flunk("Unexpected result: #{inspect(other)}")
+      end
     end
 
     test "unknown extensions are unsupported" do

--- a/test/arcana/ingest_binary_test.exs
+++ b/test/arcana/ingest_binary_test.exs
@@ -1,0 +1,322 @@
+defmodule PagedFixtureParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  # Three pages of roughly 40 bytes each, joined by newlines the way
+  # pdftotext-style extraction would hand them over.
+  @pages [
+    "Alpha alpha alpha the first page text.",
+    "Bravo bravo bravo the second page text.",
+    "Delta delta delta the third page text."
+  ]
+
+  def text, do: Enum.join(@pages, "\n")
+
+  def pages do
+    {ranges, _offset} =
+      Enum.reduce(@pages, {[], 0}, fn page, {acc, offset} ->
+        range = %{number: length(acc) + 1, start: offset, end: offset + byte_size(page)}
+        # +1 for the newline joining this page to the next
+        {[range | acc], offset + byte_size(page) + 1}
+      end)
+
+    Enum.reverse(ranges)
+  end
+
+  @impl true
+  def parse(_input, _opts), do: {:ok, text(), %{pages: pages()}}
+
+  @impl true
+  def supports_binary?, do: true
+end
+
+defmodule BinaryDocxParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(input, _opts), do: {:ok, "extracted<#{input}>"}
+
+  @impl true
+  def supports_binary?, do: true
+end
+
+defmodule PathBoundParser do
+  @moduledoc false
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts), do: {:ok, "never reached"}
+end
+
+defmodule Arcana.IngestBinaryTest do
+  use Arcana.DataCase, async: true
+
+  alias Arcana.{Chunk, Parser}
+
+  defp chunks_of(document) do
+    Repo.all(from(c in Chunk, where: c.document_id == ^document.id, order_by: c.chunk_index))
+  end
+
+  describe "ingest_binary/2" do
+    test "ingests bytes, recording the filename as provenance" do
+      content = "Some notes typed straight into memory, never written to disk."
+
+      assert {:ok, document} =
+               Arcana.ingest_binary(content, filename: "notes.txt", repo: Repo)
+
+      assert document.content == content
+      assert document.status == :completed
+      assert document.file_path == "notes.txt"
+      assert document.content_type == "text/plain"
+      assert document.chunk_count == length(chunks_of(document))
+    end
+
+    test "routes on the filename's extension and its parser's content type" do
+      put_arcana_env(:file_parsers, %{
+        ".docx" => {BinaryDocxParser, content_type: "application/vnd.docx"}
+      })
+
+      assert {:ok, document} =
+               Arcana.ingest_binary("raw-bytes", filename: "report.docx", repo: Repo)
+
+      assert document.content == "extracted<raw-bytes>"
+      assert document.content_type == "application/vnd.docx"
+    end
+
+    test "a path-only parser reports binary_unsupported instead of crashing" do
+      put_arcana_env(:file_parsers, %{".docx" => PathBoundParser})
+
+      assert {:error, {:binary_unsupported, PathBoundParser}} =
+               Arcana.ingest_binary("raw-bytes", filename: "report.docx", repo: Repo)
+    end
+
+    test "PDF bytes report binary_unsupported: poppler shells out to a real file" do
+      assert {:error, {:binary_unsupported, Arcana.FileParser.PDF.Poppler}} =
+               Arcana.ingest_binary("%PDF-1.4 whatever", filename: "manual.pdf", repo: Repo)
+    end
+
+    test "unknown extensions are unsupported" do
+      assert {:error, :unsupported_format} =
+               Arcana.ingest_binary("raw", filename: "thing.rtf", repo: Repo)
+    end
+
+    test "requires a filename to route on" do
+      assert_raise ArgumentError, ~r/requires a :filename/, fn ->
+        Arcana.ingest_binary("raw", repo: Repo)
+      end
+    end
+
+    test "no document is created when parsing fails" do
+      before = Repo.aggregate(Arcana.Document, :count)
+
+      assert {:error, :unsupported_format} =
+               Arcana.ingest_binary("raw", filename: "thing.rtf", repo: Repo)
+
+      assert Repo.aggregate(Arcana.Document, :count) == before
+    end
+  end
+
+  describe "parity with ingest_file/2" do
+    test "collection, source_id and metadata land the same way" do
+      content = "Identical content ingested two different ways for comparison."
+
+      path =
+        Path.join(System.tmp_dir!(), "arcana_parity_#{System.unique_integer([:positive])}.txt")
+
+      File.write!(path, content)
+      on_exit(fn -> File.rm(path) end)
+
+      opts = [
+        repo: Repo,
+        collection: "parity-check",
+        source_id: "doc-42",
+        metadata: %{"origin" => "test"}
+      ]
+
+      assert {:ok, from_file} = Arcana.ingest_file(path, opts)
+      assert {:ok, from_binary} = Arcana.ingest_binary(content, [filename: "parity.txt"] ++ opts)
+
+      assert from_binary.content == from_file.content
+      assert from_binary.source_id == from_file.source_id
+      assert from_binary.collection_id == from_file.collection_id
+      assert from_binary.content_type == from_file.content_type
+      assert from_binary.metadata == from_file.metadata
+      assert from_binary.chunk_count == from_file.chunk_count
+
+      # only provenance differs: one points at a path, one at the name
+      assert from_file.file_path == path
+      assert from_binary.file_path == "parity.txt"
+    end
+
+    test "strict_collections rejects an unknown collection for binaries too" do
+      put_arcana_env(:strict_collections, true)
+
+      assert {:error, {:unknown_collection, "nope"}} =
+               Arcana.ingest_binary("text", filename: "a.txt", repo: Repo, collection: "nope")
+    end
+  end
+
+  describe "stored chunk metadata" do
+    test "offsets survive the database and slice back to each chunk's text" do
+      text =
+        Enum.map_join(1..40, "\n\n", fn i ->
+          "Paragraph #{i} with enough words in it to make the chunker split things up."
+        end)
+
+      assert {:ok, document} =
+               Arcana.ingest_binary(text,
+                 filename: "long.txt",
+                 repo: Repo,
+                 chunk_size: 60,
+                 chunk_overlap: 10
+               )
+
+      chunks = chunks_of(document)
+      assert length(chunks) > 1
+
+      for chunk <- chunks do
+        start_byte = chunk.metadata["start_byte"]
+        end_byte = chunk.metadata["end_byte"]
+
+        assert is_integer(start_byte), "offsets missing from stored metadata"
+        assert is_integer(end_byte)
+        assert binary_part(text, start_byte, end_byte - start_byte) == chunk.text
+      end
+    end
+
+    test "plain-text ingest stores offsets too" do
+      text = Enum.map_join(1..30, "\n\n", fn i -> "Line #{i} of some reasonably wordy text." end)
+
+      assert {:ok, document} = Arcana.ingest(text, repo: Repo, chunk_size: 50)
+
+      for chunk <- chunks_of(document) do
+        assert binary_part(
+                 text,
+                 chunk.metadata["start_byte"],
+                 chunk.metadata["end_byte"] - chunk.metadata["start_byte"]
+               ) == chunk.text
+      end
+    end
+
+    test "a chunker's extra keys reach storage, as the behaviour promises" do
+      put_arcana_env(:chunker, fn _text, _opts ->
+        [%{text: "only chunk", chunk_index: 0, token_count: 2, page: 7, section: "intro"}]
+      end)
+
+      assert {:ok, document} = Arcana.ingest("whatever", repo: Repo)
+
+      assert [chunk] = chunks_of(document)
+      assert chunk.metadata["page"] == 7
+      assert chunk.metadata["section"] == "intro"
+    end
+  end
+
+  describe "page derivation" do
+    setup do
+      put_arcana_env(:file_parsers, %{".paged" => PagedFixtureParser})
+      :ok
+    end
+
+    test "a chunk spanning page breaks reports different start and end pages" do
+      # One chunk big enough to swallow all three pages
+      assert {:ok, document} =
+               Arcana.ingest_binary("ignored",
+                 filename: "doc.paged",
+                 repo: Repo,
+                 chunk_size: 10_000
+               )
+
+      assert [chunk] = chunks_of(document)
+      assert chunk.metadata["page_start"] == 1
+      assert chunk.metadata["page_end"] == 3
+    end
+
+    test "each chunk's pages match the page its byte range falls in" do
+      assert {:ok, document} =
+               Arcana.ingest_binary("ignored",
+                 filename: "doc.paged",
+                 repo: Repo,
+                 chunk_size: 12,
+                 chunk_overlap: 0,
+                 size_unit: :characters
+               )
+
+      chunks = chunks_of(document)
+      assert length(chunks) > 1
+
+      pages = PagedFixtureParser.pages()
+
+      for chunk <- chunks do
+        page_start = chunk.metadata["page_start"]
+        page_end = chunk.metadata["page_end"]
+
+        assert page_start in 1..3
+        assert page_end in 1..3
+        assert page_start <= page_end
+
+        # independently recompute the page holding the chunk's first byte
+        expected =
+          Enum.find(pages, fn page ->
+            chunk.metadata["start_byte"] >= page.start and chunk.metadata["start_byte"] < page.end
+          end)
+
+        if expected, do: assert(page_start == expected.number)
+      end
+
+      # the document really does span more than one page
+      assert chunks |> Enum.map(& &1.metadata["page_start"]) |> Enum.uniq() |> length() > 1
+    end
+
+    test "parsers without page metadata leave chunks page-free" do
+      assert {:ok, document} =
+               Arcana.ingest_binary("plain text with no pages at all",
+                 filename: "notes.txt",
+                 repo: Repo
+               )
+
+      for chunk <- chunks_of(document) do
+        refute Map.has_key?(chunk.metadata, "page_start")
+        assert is_integer(chunk.metadata["start_byte"])
+      end
+    end
+
+    test "search results expose the page a hit came from" do
+      assert {:ok, _document} =
+               Arcana.ingest_binary("ignored",
+                 filename: "doc.paged",
+                 repo: Repo,
+                 chunk_size: 12,
+                 chunk_overlap: 0,
+                 size_unit: :characters
+               )
+
+      assert {:ok, results} = Arcana.search("Delta delta delta", repo: Repo, limit: 10)
+
+      assert [%Arcana.SearchResult{} | _] = results
+      assert Enum.all?(results, &is_integer(&1.metadata["page_start"]))
+
+      # "delta" only appears on the third page, so any hit carrying it
+      # must reach page 3 — the whole point of deriving pages at ingest.
+      # A chunk straddling the page 2/3 break legitimately starts on 2.
+      hits = Enum.filter(results, &String.contains?(String.downcase(&1.text), "delta"))
+
+      assert hits != []
+      assert Enum.all?(hits, &(&1.metadata["page_end"] == 3))
+      assert Enum.all?(hits, &(&1.metadata["page_start"] in 2..3))
+    end
+  end
+
+  describe "content_type_for/1 drives ingestion" do
+    test "a registered parser's declared content type is what gets stored" do
+      put_arcana_env(:file_parsers, %{
+        ".docx" => {BinaryDocxParser, content_type: "application/vnd.docx"}
+      })
+
+      assert Parser.content_type_for("a.docx") == "application/vnd.docx"
+
+      assert {:ok, document} = Arcana.ingest_binary("x", filename: "a.docx", repo: Repo)
+      assert document.content_type == "application/vnd.docx"
+    end
+  end
+end

--- a/test/arcana/ingest_binary_test.exs
+++ b/test/arcana/ingest_binary_test.exs
@@ -58,6 +58,11 @@ defmodule Arcana.IngestBinaryTest do
     Repo.all(from(c in Chunk, where: c.document_id == ^document.id, order_by: c.chunk_index))
   end
 
+  defp page_for_offset(byte) do
+    page = Enum.find(PagedFixtureParser.pages(), &(byte >= &1.start and byte < &1.end))
+    page.number
+  end
+
   describe "ingest_binary/2" do
     test "ingests bytes, recording the filename as provenance" do
       content = "Some notes typed straight into memory, never written to disk."
@@ -365,6 +370,62 @@ defmodule Arcana.IngestBinaryTest do
       assert chunk.metadata["start_byte"] == nil
       refute Map.has_key?(chunk.metadata, "page_start")
       refute Map.has_key?(chunk.metadata, "page_end")
+    end
+
+    test "colliding atom and string offsets derive pages from the one that is stored" do
+      [page_one, _page_two, page_three] = PagedFixtureParser.pages()
+
+      put_arcana_env(:chunker, fn text, _opts ->
+        [
+          %{
+            text: text,
+            chunk_index: 0,
+            token_count: 5,
+            metadata: %{
+              :start_byte => page_one.start,
+              :end_byte => page_one.end,
+              "start_byte" => page_three.start,
+              "end_byte" => page_three.end
+            }
+          }
+        ]
+      end)
+
+      assert {:ok, document} =
+               Arcana.ingest_binary("ignored", filename: "doc.paged", repo: Repo)
+
+      assert [chunk] = chunks_of(document)
+
+      # The two keys sit on different pages, so reading the wrong one shows
+      assert page_for_offset(page_one.start) != page_for_offset(page_three.start)
+
+      # Chunker.metadata_for/1 stringifies both keys into one slot, so only
+      # one of the two survives. Pages have to follow whichever that is,
+      # not whichever a second implementation happens to reach first.
+      assert chunk.metadata["page_start"] == page_for_offset(chunk.metadata["start_byte"])
+    end
+
+    test "offsets in a keyword-list :metadata get pages instead of crashing" do
+      [_page_one, page_two, _page_three] = PagedFixtureParser.pages()
+
+      put_arcana_env(:chunker, fn text, _opts ->
+        [
+          %{
+            text: binary_part(text, page_two.start, page_two.end - page_two.start),
+            chunk_index: 0,
+            token_count: 5,
+            metadata: [start_byte: page_two.start, end_byte: page_two.end]
+          }
+        ]
+      end)
+
+      assert {:ok, document} =
+               Arcana.ingest_binary("ignored", filename: "doc.paged", repo: Repo)
+
+      assert [chunk] = chunks_of(document)
+      assert chunk.metadata["start_byte"] == page_two.start
+      assert chunk.metadata["page_start"] == 2
+      assert chunk.metadata["page_end"] == 2
     end
 
     test "parsers without page metadata leave chunks page-free" do

--- a/test/arcana/ingest_binary_test.exs
+++ b/test/arcana/ingest_binary_test.exs
@@ -245,24 +245,37 @@ defmodule Arcana.IngestBinaryTest do
       chunks = chunks_of(document)
       assert length(chunks) > 1
 
-      pages = PagedFixtureParser.pages()
+      # Independent recomputation, derived from the fixture text rather
+      # than the parser's ranges: the pages are joined by single newlines
+      # and hold none of their own, so a byte's page is one more than the
+      # number of newlines preceding it. This is total — a chunk starting
+      # exactly on a separator byte (bytes 38 and 78 here, which the
+      # ranges themselves cover in neither page) still gets checked,
+      # landing on the page the newline closes.
+      text = PagedFixtureParser.text()
+
+      page_for = fn byte ->
+        prefix = binary_part(text, 0, min(byte, byte_size(text)))
+        1 + (prefix |> :binary.matches("\n") |> length())
+      end
 
       for chunk <- chunks do
-        page_start = chunk.metadata["page_start"]
-        page_end = chunk.metadata["page_end"]
+        start_byte = chunk.metadata["start_byte"]
+        end_byte = chunk.metadata["end_byte"]
 
-        assert page_start in 1..3
-        assert page_end in 1..3
-        assert page_start <= page_end
+        # end_byte is exclusive, so the chunk's last byte is end_byte - 1
+        assert end_byte > start_byte
 
-        # independently recompute the page holding the chunk's first byte
-        expected =
-          Enum.find(pages, fn page ->
-            chunk.metadata["start_byte"] >= page.start and chunk.metadata["start_byte"] < page.end
-          end)
-
-        if expected, do: assert(page_start == expected.number)
+        assert chunk.metadata["page_start"] == page_for.(start_byte)
+        assert chunk.metadata["page_end"] == page_for.(end_byte - 1)
       end
+
+      # the separator-byte chunks really are in play: without them the
+      # unconditional assertions above would be no stronger than the old
+      # "only when a page contains the byte" version
+      assert Enum.any?(chunks, fn chunk ->
+               chunk.metadata["start_byte"] in [38, 78]
+             end)
 
       # the document really does span more than one page
       assert chunks |> Enum.map(& &1.metadata["page_start"]) |> Enum.uniq() |> length() > 1

--- a/test/arcana/maintenance_test.exs
+++ b/test/arcana/maintenance_test.exs
@@ -1,7 +1,67 @@
 defmodule Arcana.MaintenanceTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Maintenance
+  alias Arcana.{Chunk, Collection, Document, Maintenance}
+
+  describe "rechunking crashed ingests" do
+    test "recovered chunks carry the same metadata a fresh ingest would" do
+      {:ok, collection} = Collection.get_or_create("default", Repo)
+
+      {:ok, document} =
+        %Document{}
+        |> Document.changeset(%{
+          content: "Alpha alpha alpha the first part. Bravo bravo bravo the second part.",
+          status: :pending,
+          chunk_count: 0,
+          collection_id: collection.id
+        })
+        |> Repo.insert()
+
+      assert {:ok, %{rechunked_documents: 1}} = Maintenance.reembed(Repo)
+
+      chunks = Repo.all(from(c in Chunk, where: c.document_id == ^document.id))
+
+      assert chunks != []
+
+      for chunk <- chunks do
+        assert is_integer(chunk.metadata["start_byte"])
+        assert is_integer(chunk.metadata["end_byte"])
+        assert chunk.metadata["end_byte"] > chunk.metadata["start_byte"]
+      end
+    end
+
+    test "a custom chunker's extra keys survive rechunking too" do
+      {:ok, collection} = Collection.get_or_create("default", Repo)
+
+      {:ok, document} =
+        %Document{}
+        |> Document.changeset(%{
+          content: "whatever",
+          status: :pending,
+          chunk_count: 0,
+          collection_id: collection.id
+        })
+        |> Repo.insert()
+
+      put_arcana_env(:chunker, fn text, _opts ->
+        [
+          %{
+            text: text,
+            chunk_index: 0,
+            token_count: 2,
+            page: 7,
+            metadata: %{"section" => "intro"}
+          }
+        ]
+      end)
+
+      assert {:ok, %{rechunked_documents: 1}} = Maintenance.reembed(Repo)
+
+      assert [chunk] = Repo.all(from(c in Chunk, where: c.document_id == ^document.id))
+      assert chunk.metadata["page"] == 7
+      assert chunk.metadata["section"] == "intro"
+    end
+  end
 
   describe "strict collections" do
     test "reembed/2 errors on an unknown collection" do

--- a/test/support/unloaded_binary_parser.ex
+++ b/test/support/unloaded_binary_parser.ex
@@ -1,0 +1,18 @@
+defmodule Arcana.Test.UnloadedBinaryParser do
+  @moduledoc """
+  A binary-capable parser that exists only to be unloaded.
+
+  `Arcana.FileParser.PDF.supports_binary?/1` has to load a module before
+  asking what it exports, and proving that needs a module no other test
+  touches: the check purges this one from the code server first, which
+  would break anything referencing it concurrently.
+  """
+
+  @behaviour Arcana.FileParser
+
+  @impl true
+  def parse(_input, _opts), do: {:ok, "unloaded parser output"}
+
+  @impl true
+  def supports_binary?, do: true
+end


### PR DESCRIPTION
#94 items 5 and 6. This PR lands the parser/chunker half; `Arcana.ingest_binary/2` and page-number derivation follow as commits on this branch once #124 merges (it's rewriting the ingest finalize path that they build on).

**Parser registry.** New `Arcana.FileParser` behaviour, and two config shapes as agreed:

```elixir
config :arcana,
  file_parsers: %{".docx" => {MyApp.DocxParser, []}},   # per-format
  fallback_parser: {MyApp.ExtractionService, []}          # everything else
```

Resolution is registry → built-ins (`.txt`/`.md` native, `.pdf` via the existing `:pdf_parser` config, untouched) → fallback → `:unsupported_format`. The fallback covers the xberg case (one service, ~100 formats); registering `.pdf` explicitly overrides the built-in route.

**Positional metadata.** Parsers may return `{:ok, text, meta}` with page byte ranges. `FileParser.parse/3` normalizes the old two-tuple so every existing parser keeps working untouched, and `FileParser.PDF.parse/3` still returns two-tuples for its own callers. Poppler derives page ranges from `pdftotext`'s form feeds — PDFs get citations with no new dependency.

**Chunk offsets.** `Chunker.Default` was throwing away the byte offsets text_chunker already computes (`Enum.map(& &1.text)`); they now ride in chunk metadata. Tests assert every chunk's offsets slice back to its exact text, including with overlap and with deliberately repeated paragraphs — a naive text search would mislocate those, which is why the offsets have to come from the splitter.

**Extension knowledge in one place.** `Parser` gains `parse_file/2`, `parse_binary/3` (refuses parsers that only accept paths, with `{:error, {:binary_unsupported, module}}`), `available?/1`, and `content_type_for/1`; `supported_formats/0` now includes registered extensions. `parse/1` and `pdf_support_available?/0` keep their exact contracts.

17 new registry tests plus chunker offset and Poppler page-range tests; full suite 892 green, `mix credo --strict` clean.

Refs #94

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a general file parser registry with binary ingest and chunk source offsets so search can cite pages and byte ranges. Previously only PDFs were pluggable and offsets were dropped; now any extension can be routed, positions are preserved, and parser availability is gated consistently.

- Resolution: registry → built-ins (`.txt`/`.md` native, `.pdf` via configured PDF parser) → `fallback_parser` → unsupported. Map entries of `false` disable an extension; registering `".pdf"` overrides the built-in route.
- Central gate in `Arcana.FileParser.parse/3`: unavailable parsers are not invoked and return `{:error, {:parser_unavailable, module}}` (Poppler keeps `:poppler_not_available`). `Arcana.Parser.available?/1` reports per-extension readiness.
- New parse APIs: `Arcana.Parser.parse_file/2` and `parse_binary/3` return `{:ok, text, meta}`; `parse/1` stays two‑tuple. Path‑only parsers yield `{:error, {:binary_unsupported, module}}` unless also unavailable (unavailability wins). PDFs are magic‑byte validated for files and binaries.
- Metadata validation: `Arcana.FileParser.parse/3` normalizes two‑tuples and rejects invalid metadata (non‑map, bad `:pages` shape, negative or reversed ranges) with `{:invalid_parser_metadata, module, meta}`.
- Poppler now implements `Arcana.FileParser` and returns `{:ok, text, %{pages: [...]}}`; page ranges derive from `pdftotext` form feeds without phantom trailing pages and preserve blank leading pages. `Arcana.FileParser.PDF.parse/3` still returns two‑tuples; `PDF.supports_binary?/1` loads the module before checking.
- `Arcana.ingest_binary/2` ingests in‑memory bytes (requires `:filename` for routing/provenance). Parsers must opt in via `supports_binary?/0`.
- `Arcana.Chunker.Default` attaches `"start_byte"`/`"end_byte"`. Ingestion persists chunk metadata via `Arcana.Chunker.metadata_for/1` (declared `:metadata` wins over top‑level extras; atom or string keys; keyword lists and falsy values tolerated) and intersects parser page ranges to add `"page_start"`/`"page_end"`. `Arcana.Maintenance.reembed/2` stores the same chunk metadata as a fresh ingest (pages cannot be reconstructed).
- `supported_formats/0` includes registered minus disabled; `content_type_for/1` prefers a registered parser’s declared `:content_type`.
- Config hardening: file‑parser extensions are normalized; boolean tuple heads like `{false, opts}` are rejected; `fallback_parser: false` disables the fallback.

**Rollout/Migration**
- Configure `file_parsers` and optional `fallback_parser`; e.g. `file_parsers: %{".docx" => {MyApp.DocxParser, []}}`. Set an extension to `false` to disable it.
- Implement `supports_binary?/0` and `available?/0` as applicable.
- Direct callers of `Arcana.FileParser.PDF.Poppler.parse/2` must handle `{:ok, text, meta}`; callers using `Arcana.FileParser.PDF.parse/3` or `Arcana.Parser.parse/1` remain two‑tuple.
- Pass `filename:` when using `Arcana.ingest_binary/2`.

<sup>Written for commit 934009e555b1be0d67b686ce5d23cc54c6d2a62e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

BREAKING CHANGE: Poppler.parse/2 returns {:ok, text, meta} instead of {:ok, text}. Parsers that delegate directly to it and match {:ok, text} now raise a MatchError. Callers going through Arcana.FileParser.PDF.parse/3 or Arcana.Parser.parse/1 are unaffected: both still normalize to a two-tuple.
