### PR TITLE
ci: Install poppler and run the pdf_support tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - name: Install cmake (for hnswlib)
-        run: sudo apt-get update && sudo apt-get install -y cmake
+      - name: Install cmake (for hnswlib) and poppler (for PDF tests)
+        run: sudo apt-get update && sudo apt-get install -y cmake poppler-utils
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
@@ -90,4 +90,7 @@ jobs:
         env:
           MIX_ENV: test
           POSTGRES_PORT: "5432"
-        run: mix test
+        # :pdf_support is excluded by default in test_helper.exs because it
+        # needs pdftotext; poppler-utils is installed above, so run it here.
+        # The remaining excluded tags need model downloads or network.
+        run: mix test --include pdf_support


### PR DESCRIPTION
`test/test_helper.exs` excludes `:pdf_support` (those tests shell out to `pdftotext`), and the workflow runs bare `mix test` — so the PDF tests have never run in CI, on any branch.

That isn't theoretical: a return-shape change on #129 broke three Poppler tests that pass on main, and CI stayed green through it. The adversarial review caught it; CI couldn't.

This installs `poppler-utils` next to the existing cmake step and runs `mix test --include pdf_support`. Verified locally: 912 pass with the tag included.

The other excluded tags stay out — `:serving`/`:colbert`/`:end_to_end` need model downloads or network, and `:memory` needs the optional hnswlib dep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs PDF tests in CI by installing `poppler-utils` and including the `:pdf_support` tag. Previously CI ran `mix test` while `test_helper.exs` excluded `:pdf_support`, so Poppler-based failures could merge unnoticed.

- Adds `poppler-utils` alongside `cmake` in the workflow to provide `pdftotext`.
- Changes the test step to run `mix test --include pdf_support`.
- Keeps other excluded tags out (`:serving`, `:colbert`, `:end_to_end`, `:memory`) to avoid model downloads, network, or optional `hnswlib`.

<sup>Written for commit 4b8a5cbe3c10b848839c2e3d765b5a5fabd54356. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

