### PR TITLE
ci: Run the test suite on PRs that don't target main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,11 @@ name: Run Tests
 on:
   push:
     branches: ["main"]
+  # Every PR, whatever it targets. Filtering on ["main"] meant a PR stacked
+  # on another PR's branch never ran the suite at all - it still reported
+  # all checks green, because the only ones that ran were the title
+  # validator and the review bot.
   pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Noticed while babysitting the 135→136→137→138 stack: #137 and #138 have never run the test suite. Not a flake, not a skip. `tests.yml` had

```yaml
pull_request:
  branches: ["main"]
```

so a PR based on another PR's branch doesn't match the trigger and the workflow never starts. The PR still shows all-green, because the title validator and cubic both do run, and a workflow that never starts leaves no failing check behind. That's the worst shape for this to take, since the checks list looks complete.

Dropping the filter so every PR runs it regardless of base. Push-to-main is unchanged.

Worth knowing this applies to every stacked PR the repo has ever had, not just this stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the test suite on every PR, not just those targeting `main`. Previously, stacked PRs did not run tests and appeared green because only non-test checks ran.

- Removed the `pull_request.branches: ["main"]` filter in `.github/workflows/tests.yml` so the test workflow triggers for all PRs.
- Push-to-`main` behavior is unchanged.
- Expect test checks to appear on stacked PRs; CI minutes may increase slightly. No migration required.

<sup>Written for commit 4365682e8f7160952fc1ea7987f688969984c52f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

