### PR TITLE
test: Wait for async LiveView work instead of sleeping past it

### DIFF
--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -86,21 +86,6 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
   # The ask flow answers asynchronously, so poll the render instead of
   # sleeping a magic number of milliseconds.
-  defp render_until(view, expected, attempts \\ 50) do
-    html = render(view)
-
-    cond do
-      html =~ expected ->
-        html
-
-      attempts <= 0 ->
-        html
-
-      true ->
-        Process.sleep(20)
-        render_until(view, expected, attempts - 1)
-    end
-  end
 
   describe "collections page" do
     test "lists only allowed collections", %{conn: conn} do

--- a/test/arcana_web/live/ask_live_test.exs
+++ b/test/arcana_web/live/ask_live_test.exs
@@ -445,8 +445,7 @@ defmodule ArcanaWeb.AskLiveTest do
       |> form("#ask-form", %{"question" => "q"})
       |> render_submit()
 
-      :timer.sleep(50)
-      assert render(view) =~ "should-be-cleared-on-switch"
+      render_until(view, "should-be-cleared-on-switch")
 
       view |> element(".arcana-ask-sub-tab", "Advanced") |> render_click()
 
@@ -506,12 +505,9 @@ defmodule ArcanaWeb.AskLiveTest do
       })
       |> render_submit()
 
-      # The ask_complete message should produce a loop-shaped result.
-      # Wait for the async task to complete.
-      :timer.sleep(50)
-      html = render(view)
-
-      assert html =~ "Agent trace"
+      # The ask_complete message should produce a loop-shaped result, which
+      # arrives from the async task rather than from render_submit.
+      html = render_until(view, "Agent trace")
       assert html =~ "stubbed answer from test"
     end
   end

--- a/test/arcana_web/live/maintenance_live_test.exs
+++ b/test/arcana_web/live/maintenance_live_test.exs
@@ -52,22 +52,6 @@ defmodule ArcanaWeb.MaintenanceLiveTest do
     # result lands in the LiveView asynchronously. Poll observable state
     # rather than the flash: a flash is one render away from being replaced,
     # and the state is what the assertion is actually about.
-    defp wait_until(fun, attempts \\ 100) do
-      cond do
-        fun.() ->
-          true
-
-        attempts == 0 ->
-          flunk("timed out waiting for the condition to hold")
-
-        true ->
-          # Process.sleep/1 returns :ok, so `sleep || recurse` would
-          # short-circuit and never retry. Keep these as statements.
-          Process.sleep(20)
-          wait_until(fun, attempts - 1)
-      end
-    end
-
     defp insert_community(collection, attrs) do
       %Community{}
       |> Community.changeset(Map.merge(%{level: 0, collection_id: collection.id}, attrs))

--- a/test/support/async_assertions.ex
+++ b/test/support/async_assertions.ex
@@ -18,27 +18,37 @@ defmodule ArcanaWeb.AsyncAssertions do
   @doc """
   Renders `view` until the markup contains `expected`, then returns it.
 
-  Fails with the last markup rendered if it never appears.
+  On a timeout the failure carries the markup that was actually rendered,
+  which is the thing you need to tell "never arrived" from "arrived in a
+  different shape".
   """
   def render_until(view, expected, attempts \\ @attempts) do
+    poll_render(view, expected, attempts, attempts)
+  end
+
+  defp poll_render(view, expected, remaining, total) do
     html = Phoenix.LiveViewTest.render(view)
 
     cond do
       html =~ expected ->
         html
 
-      attempts <= 0 ->
+      remaining <= 0 ->
         flunk("""
-        timed out after #{@attempts * @interval}ms waiting for the render to contain:
+        timed out after #{budget(total)} waiting for the render to contain:
 
             #{inspect(expected)}
+
+        last rendered markup:
+
+        #{html}
         """)
 
       true ->
         # Process.sleep/1 returns :ok, so `sleep || recurse` would
         # short-circuit and never retry. Keep these as statements.
         Process.sleep(@interval)
-        render_until(view, expected, attempts - 1)
+        poll_render(view, expected, remaining - 1, total)
     end
   end
 
@@ -49,16 +59,24 @@ defmodule ArcanaWeb.AsyncAssertions do
   work is expected to write.
   """
   def wait_until(fun, attempts \\ @attempts) do
+    poll_until(fun, attempts, attempts)
+  end
+
+  defp poll_until(fun, remaining, total) do
     cond do
       fun.() ->
         true
 
-      attempts <= 0 ->
-        flunk("timed out after #{@attempts * @interval}ms waiting for the condition to hold")
+      remaining <= 0 ->
+        flunk("timed out after #{budget(total)} waiting for the condition to hold")
 
       true ->
         Process.sleep(@interval)
-        wait_until(fun, attempts - 1)
+        poll_until(fun, remaining - 1, total)
     end
   end
+
+  # Reported from the attempts the caller actually asked for, not the
+  # default: by the time we flunk, the countdown is at zero.
+  defp budget(total), do: "#{total * @interval}ms"
 end

--- a/test/support/async_assertions.ex
+++ b/test/support/async_assertions.ex
@@ -1,0 +1,64 @@
+defmodule ArcanaWeb.AsyncAssertions do
+  @moduledoc """
+  Waiting on LiveView work that finishes in another process.
+
+  A submit that spawns a task returns before the task pushes its result, so
+  asserting straight afterwards races it. A fixed `Process.sleep/1` before
+  the assertion turns that race into "usually long enough", and a loaded CI
+  runner is exactly where it stops being long enough.
+
+  These poll for the condition instead, so they return as soon as it holds
+  and only fail once it genuinely hasn't happened.
+  """
+  import ExUnit.Assertions
+
+  @attempts 100
+  @interval 20
+
+  @doc """
+  Renders `view` until the markup contains `expected`, then returns it.
+
+  Fails with the last markup rendered if it never appears.
+  """
+  def render_until(view, expected, attempts \\ @attempts) do
+    html = Phoenix.LiveViewTest.render(view)
+
+    cond do
+      html =~ expected ->
+        html
+
+      attempts <= 0 ->
+        flunk("""
+        timed out after #{@attempts * @interval}ms waiting for the render to contain:
+
+            #{inspect(expected)}
+        """)
+
+      true ->
+        # Process.sleep/1 returns :ok, so `sleep || recurse` would
+        # short-circuit and never retry. Keep these as statements.
+        Process.sleep(@interval)
+        render_until(view, expected, attempts - 1)
+    end
+  end
+
+  @doc """
+  Polls `fun` until it returns a truthy value.
+
+  For conditions that aren't about rendered markup, such as a row the async
+  work is expected to write.
+  """
+  def wait_until(fun, attempts \\ @attempts) do
+    cond do
+      fun.() ->
+        true
+
+      attempts <= 0 ->
+        flunk("timed out after #{@attempts * @interval}ms waiting for the condition to hold")
+
+      true ->
+        Process.sleep(@interval)
+        wait_until(fun, attempts - 1)
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -10,6 +10,7 @@ defmodule ArcanaWeb.ConnCase do
       import Phoenix.ConnTest
       import Phoenix.LiveViewTest
       import Arcana.ConfigCase
+      import ArcanaWeb.AsyncAssertions
 
       alias Arcana.TestRepo, as: Repo
 


### PR DESCRIPTION
#141's CI failed on OTP 27 / Elixir 1.18 with a diff that only touched `lib/arcana/chunker/default.ex`. A rerun with no code change went green, so it was a flake, and the mechanism is worth fixing rather than rerunning past.

Two tests in `ask_live_test.exs` submit a form that spawns a task, then do `:timer.sleep(50)` and assert on the render. That's a race against a fixed guess, and a loaded runner is exactly where the guess stops holding.

Reproduced deliberately by stubbing a 400ms runner:

```
400ms runner + render_until  -> 40 passed
400ms runner + sleep(50)     -> 39/40, the same test CI failed on
```

Two other files had each independently grown a correct retry helper (`wait_until/2` in `maintenance_live_test`, `render_until/3` in `allowed_collections_test`), both carrying the same comment about `Process.sleep/1` returning `:ok` so `sleep || recurse` never retries. This promotes one into `test/support/async_assertions.ex`, imported from `ConnCase`, and deletes both copies.

Left alone deliberately: `Process.sleep` calls **inside stubs** that simulate a slow LLM so a spinner is observable. Those aren't races.

Worth flagging, not fixed here: `allowed_collections_test.exs:818` and `:836` sleep 300ms then assert a negative (`assert is_nil(...summary)`). Polling can't prove nothing happened, so a slow runner makes those pass for the wrong reason rather than fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits for async LiveView updates in tests instead of sleeping a fixed time, removing race-based flakes. Previously tests slept 50ms after form submit; now they poll with `render_until/2` (and `wait_until/1`) and assert as soon as the condition holds.

- Add `ArcanaWeb.AsyncAssertions` with `render_until/2` and `wait_until/1`; import it in `ConnCase`.
- Replace `:timer.sleep/1` with `render_until/2` in `ask_live_test`.
- Remove duplicate helpers from `allowed_collections_test` and `maintenance_live_test`; tests use the shared helper.
- Timeouts now report the real polling budget (based on passed attempts) and include the last rendered markup to diagnose “never arrived” vs “wrong shape.”
- Keep sleeps inside stubbed slow LLMs to show spinners.
- Known gap: `allowed_collections_test` still sleeps before negative assertions (lines ~818, ~836); not addressed here.

<sup>Written for commit 45ef13f6dea79720100b3a9075b2c4bea4ad38f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

