### PR TITLE
test: Assert the tenancy refusal instead of sleeping and checking nothing

### DIFF
--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -799,8 +799,15 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
       {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/maintenance")
 
-      render_click(view, "summarize_communities", %{})
-      Process.sleep(300)
+      # Assert the refusal, not the absence of a result. Sleeping and then
+      # checking nothing happened passes just as well when the summarize did
+      # start and is merely slower than the sleep, which on a loaded runner
+      # is the likely outcome. The refusal is synchronous and flashes, so
+      # there is a positive signal to assert instead.
+      html = render_click(view, "summarize_communities", %{})
+
+      assert html =~ "Select an allowed collection first",
+             "expected a refusal, so nothing was ever dispatched"
 
       assert is_nil(Repo.get!(Community, theirs.id).summary),
              "summarized a collection the host never allowed"
@@ -817,8 +824,14 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/maintenance")
 
       render_change(view, "select_summarize_communities_collection", %{"collection" => "other"})
-      render_click(view, "summarize_communities", %{})
-      Process.sleep(300)
+      html = render_click(view, "summarize_communities", %{})
+
+      # The forged name never sticks, so the selection is still empty and the
+      # click is refused synchronously. Asserting the flash proves that,
+      # where a sleep plus a nil check would also pass if the summarizer had
+      # accepted "other" and simply not finished yet.
+      assert html =~ "Select an allowed collection first",
+             "the forged collection was accepted instead of refused"
 
       assert is_nil(Repo.get!(Community, theirs.id).summary),
              "a forged collection name reached the summarizer"


### PR DESCRIPTION
Two maintenance tenancy tests did `render_click(view, "summarize_communities", ...)`, `Process.sleep(300)`, then asserted the community summary was still `nil`.

The refusal path is synchronous and puts a flash (`"Select an allowed collection first"`), so there is a positive signal to assert. These now assert that, and drop the sleep.

**Correcting my own earlier claim:** I described these as passing for the wrong reason. They were not. I checked by breaking `validate_maintenance_collection/2` to accept anything and running the *original* tests: all four maintenance tenancy tests fail, including these two. The stubbed LLM returns instantly, so 300ms was always enough for the forbidden summarize to land and be caught.

So the honest value here is narrower than I first said:

- no timing dependency, so no chance of the described false pass if the summarize ever becomes slower than the sleep
- 600ms off the suite
- the assertion names the mechanism (a refusal happened) instead of inferring it from an absence

Verified both directions. With the boundary broken, these two fail on the specific new assertions (`expected a refusal, so nothing was ever dispatched` and `the forged collection was accepted instead of refused`). With it intact, 1267 tests pass, credo clean.

That leaves two `Process.sleep` calls in the LiveView tests, both **inside stubs** simulating a slow LLM so a spinner is observable. Those are latency simulation, not races, and should stay.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace sleep-based checks in two maintenance tenancy tests with direct assertions of the synchronous refusal flash. Previously, tests slept 300ms and asserted the summary stayed nil; now they assert “Select an allowed collection first” and still verify the summary is nil. This removes timing dependency and saves ~600ms.

**Review notes**
- Updated `test/arcana_web/live/allowed_collections_test.exs` to assert the refusal on "summarize_communities" and removed `Process.sleep`.
- Makes tests deterministic regardless of summarization latency; keeps a nil summary check as a safety.
- No production behavior changes; remaining sleeps only simulate LLM latency in stubs.

<sup>Written for commit 62685112297c67986d2fb83078c11de8b4726f17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

