### PR TITLE
fix: Anchor the migration version marker and document where it lives

### DIFF
--- a/lib/arcana/graph/migration.ex
+++ b/lib/arcana/graph/migration.ex
@@ -30,6 +30,24 @@ defmodule Arcana.Graph.Migration do
   Version 1 converges them: it creates only what is absent and adds only the
   columns and indexes a later release introduced. It never drops anything.
 
+  ## Where the version is recorded
+
+  The applied version is stored as the Postgres comment on `arcana_graph_entities`, as
+  exactly `arcana_graph:<n>`:
+
+      SELECT obj_description('arcana_graph_entities'::regclass);
+
+  Arcana owns that comment. Two consequences worth knowing before you point
+  schema-documentation or data-catalog tooling at this table:
+
+    * recording a version replaces whatever comment is there, so a
+      description you wrote on `arcana_graph_entities` is lost on the next migration
+    * a comment Arcana doesn't recognise reads as version 0, the same as a
+      fresh install, so `up/1` re-runs the converge path (idempotent, and
+      harmless) while `down/1` declines to drop anything
+
+  Comment on any other table freely. Only `arcana_graph_entities` is reserved.
+
   ## Version history
 
     * 1 - entities, relationships, mentions and communities, including the
@@ -129,8 +147,13 @@ defmodule Arcana.Graph.Migration do
 
   defp parse_version(nil), do: 0
 
+  # Anchored, so only a comment that is exactly the marker counts. An
+  # unanchored match read a version out of any prose that happened to
+  # contain "arcana_graph:2", and a bare integer (what Oban stores) would read a
+  # host's own "1" as version 1. Anything we don't recognise reads as 0,
+  # which is the same answer as "never installed" - see the moduledoc.
   defp parse_version(comment) do
-    case Regex.run(~r/arcana_graph:(\d+)/, comment) do
+    case Regex.run(~r/\Aarcana_graph:(\d+)\z/, String.trim(comment)) do
       [_, version] -> String.to_integer(version)
       _ -> 0
     end

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -34,6 +34,24 @@ defmodule Arcana.Migration do
   when missing. Running it against an existing database changes nothing it
   already has, and never drops anything.
 
+  ## Where the version is recorded
+
+  The applied version is stored as the Postgres comment on `arcana_documents`, as
+  exactly `arcana:<n>`:
+
+      SELECT obj_description('arcana_documents'::regclass);
+
+  Arcana owns that comment. Two consequences worth knowing before you point
+  schema-documentation or data-catalog tooling at this table:
+
+    * recording a version replaces whatever comment is there, so a
+      description you wrote on `arcana_documents` is lost on the next migration
+    * a comment Arcana doesn't recognise reads as version 0, the same as a
+      fresh install, so `up/1` re-runs the converge path (idempotent, and
+      harmless) while `down/1` declines to drop anything
+
+  Comment on any other table freely. Only `arcana_documents` is reserved.
+
   ## Version history
 
     * 1 - collections, documents, chunks and the evaluation tables
@@ -45,8 +63,6 @@ defmodule Arcana.Migration do
   @current_version 1
   @default_dimensions 384
 
-  # The version lives in a comment on arcana_documents. It needs no table of
-  # its own and survives anything that keeps the schema.
   @version_table "arcana_documents"
 
   @doc """
@@ -135,8 +151,13 @@ defmodule Arcana.Migration do
 
   defp parse_version(nil), do: 0
 
+  # Anchored, so only a comment that is exactly the marker counts. An
+  # unanchored match read a version out of any prose that happened to
+  # contain "arcana:2", and a bare integer (what Oban stores) would read a
+  # host's own "1" as version 1. Anything we don't recognise reads as 0,
+  # which is the same answer as "never installed" - see the moduledoc.
   defp parse_version(comment) do
-    case Regex.run(~r/arcana:(\d+)/, comment) do
+    case Regex.run(~r/\Aarcana:(\d+)\z/, String.trim(comment)) do
       [_, version] -> String.to_integer(version)
       _ -> 0
     end

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -94,6 +94,13 @@ defmodule Arcana.MigrationTest do
     rule
   end
 
+  # COMMENT ON TABLE takes no bind parameters, so the literal is escaped the
+  # way Postgres wants: a single quote doubled.
+  defp set_table_comment(comment) do
+    escaped = String.replace(comment, "'", "''")
+    SQL.query!(Repo, "COMMENT ON TABLE arcana_documents IS '#{escaped}'", [])
+  end
+
   defp columns(table) do
     %{rows: rows} =
       SQL.query!(
@@ -252,6 +259,33 @@ defmodule Arcana.MigrationTest do
 
       %{rows: [[content]]} = SQL.query!(Repo, "SELECT content FROM arcana_documents", [])
       assert content == "kept", "converging the constraint must not touch rows"
+    end
+
+    # A comment arcana doesn't own must never be read as a version. The
+    # marker is anchored, so only an exact match counts.
+    for {label, comment} <- [
+          {"a host's own description", "Documents ingested by our pipeline"},
+          {"prose that happens to contain the marker", "see arcana:2 for details"},
+          {"a bare integer, which is what Oban stores", "1"},
+          {"the marker with trailing junk", "arcana:1 (do not edit)"},
+          {"an empty comment", ""}
+        ] do
+      test "#{label} does not read as a version" do
+        migrate(Arcana.Migration)
+        assert Arcana.Migration.recorded_version(Repo) == 1
+
+        set_table_comment(unquote(comment))
+
+        assert Arcana.Migration.recorded_version(Repo) == 0,
+               "#{unquote(label)} was mistaken for a recorded version"
+      end
+    end
+
+    test "the marker parses with surrounding whitespace" do
+      migrate(Arcana.Migration)
+      set_table_comment("  arcana:1\n")
+
+      assert Arcana.Migration.recorded_version(Repo) == 1
     end
 
     test "refuses to run against a database a newer release migrated" do


### PR DESCRIPTION
Addresses the third point of #145 and its documentation suggestion. Keeps the comment as the storage, per the discussion about how Oban does this.

## What changed

The marker was matched **anywhere** in the comment:

```elixir
Regex.run(~r/arcana:(\d+)/, comment)
```

so `"see arcana:2 for details"` read as version 2, and `"arcana:1 (do not edit)"` read as 1. It is now anchored against the trimmed comment, in both streams:

```elixir
Regex.run(~r/\Aarcana:(\d+)\z/, String.trim(comment))
```

Only an exact marker counts. Anything else reads as 0, which is the same answer as "never installed".

Worth noting we are deliberately **not** matching Oban here. Oban stores a bare integer and parses with `String.to_integer/1`, which means a host comment of `1` reads as version 1. An anchored prefixed marker cannot be produced by accident, so it is strictly safer on that axis. There is a test asserting exactly that.

## What is documented, not fixed

Both modules now carry a `## Where the version is recorded` section naming the object, the exact format, and the query to read it, plus the two consequences that come with comment storage:

- recording a version replaces whatever comment is on that table, so a host description there is lost
- a comment arcana does not recognise reads as version 0, so `up/1` re-runs the converge path (idempotent) while `down/1` declines to drop anything

Those are the first two bullets of #145 and they are **not** fixed. Keeping the comment means keeping them; they are now stated in the docs rather than being discoverable only from the source. If the data loss matters more than the no-extra-table property, the dedicated-table option in #145 is the fix, and doing it before 3.0.0 ships would need no migration path since nothing released uses the marker yet.

## Verification

Six new tests covering a host description, prose containing the marker, a bare integer, marker-with-trailing-junk, an empty comment, and the marker with surrounding whitespace. Two of them fail against the unanchored version, which are the two cases anchoring actually fixes.

1273 tests pass, credo clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the migration version marker so only an exact, trimmed table comment counts. Previously, any occurrence of the marker in a comment (e.g., “see arcana:2” or “arcana:1 (do not edit)”) was parsed as a version; now only `arcana:<n>`/`arcana_graph:<n>` is accepted. This prevents accidental version detection from host comments.

**Reviewer notes**
- `parse_version/1` in both `Arcana.Migration` and `Arcana.Graph.Migration` now uses an anchored regex on `String.trim(comment)`. Non-exact comments read as 0.
- Added “Where the version is recorded” docs to both modules:
  - The version lives in the table comment on `arcana_documents`/`arcana_graph_entities` as exactly `arcana:<n>`/`arcana_graph:<n>`.
  - Arcana owns that comment. Recording a version overwrites any host description.
  - Unrecognized comments read as 0: `up/1` re-runs converge (idempotent); `down/1` declines to drop.
- Tests cover host descriptions, prose containing the marker, bare integers, trailing junk, empty comments, and surrounding whitespace. Existing installs that relied on non-exact comments will read 0 until an exact marker is set; no data migration needed.

<sup>Written for commit 259310118aa73b43e38182500638c07d5646e805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

