### PR TITLE
fix: Clear the compile warnings #154 left behind and guard against more

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,14 @@ jobs:
         run: mix deps.get
       - name: Check formatting
         run: mix format --check-formatted
+      # Catches unused variables, orphaned requires and the like in lib/. Not
+      # `mix test --warnings-as-errors`: the LiveView test helpers emit dozens
+      # of runtime warnings, which would drown this signal rather than add to
+      # it.
+      - name: Compile without warnings
+        env:
+          MIX_ENV: test
+        run: mix compile --force --warnings-as-errors
       - name: Run Credo
         run: mix credo --strict
       - name: Create database

--- a/lib/arcana/graph/migration.ex
+++ b/lib/arcana/graph/migration.ex
@@ -75,8 +75,6 @@ defmodule Arcana.Graph.Migration do
 
   use Ecto.Migration
 
-  require Logger
-
   alias Arcana.Migration.Dimensions
   alias Arcana.Migration.UniqueIndex
 

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -82,8 +82,6 @@ defmodule Arcana.Migration do
 
   use Ecto.Migration
 
-  require Logger
-
   alias Arcana.Migration.Dimensions
   alias Arcana.Migration.UniqueIndex
 

--- a/lib/arcana/migration/unique_index.ex
+++ b/lib/arcana/migration/unique_index.ex
@@ -38,7 +38,7 @@ defmodule Arcana.Migration.UniqueIndex do
   defp converge_existing!(repo, name, table, columns, prefix, qualify) do
     case describe(repo, name, table, prefix) do
       nil ->
-        create_absent!(repo, name, table, columns, prefix, qualify)
+        create_absent!(repo, name, table, columns, qualify)
 
       %{
         unique: true,
@@ -51,7 +51,7 @@ defmodule Arcana.Migration.UniqueIndex do
         :ok
 
       existing ->
-        rebuild!(repo, name, table, columns, existing, prefix, qualify)
+        rebuild!(repo, name, table, columns, existing, qualify)
     end
   end
 
@@ -114,10 +114,10 @@ defmodule Arcana.Migration.UniqueIndex do
   # Postgrex.Error unique violation rather than the explanation this module
   # promises - and a table whose index was manually dropped is exactly the
   # kind of drifted install adoption exists to handle.
-  defp create_absent!(repo, name, table, columns, prefix, qualify) do
+  defp create_absent!(repo, name, table, columns, qualify) do
     lock!(repo, table, qualify)
 
-    case duplicates(repo, table, columns, prefix, qualify) do
+    case duplicates(repo, table, columns, qualify) do
       [] ->
         create!(repo, name, table, columns, qualify)
 
@@ -126,10 +126,10 @@ defmodule Arcana.Migration.UniqueIndex do
     end
   end
 
-  defp rebuild!(repo, name, table, columns, existing, prefix, qualify) do
+  defp rebuild!(repo, name, table, columns, existing, qualify) do
     lock!(repo, table, qualify)
 
-    case duplicates(repo, table, columns, prefix, qualify) do
+    case duplicates(repo, table, columns, qualify) do
       [] ->
         repo.query!("DROP INDEX #{qualify.(name)}")
         create!(repo, name, table, columns, qualify)
@@ -200,7 +200,7 @@ defmodule Arcana.Migration.UniqueIndex do
   # any key column never collide and must not count as duplicates here - a
   # GROUP BY would otherwise group them together and block a migration that
   # would in fact succeed.
-  defp duplicates(repo, table, columns, prefix, qualify) do
+  defp duplicates(repo, table, columns, qualify) do
     cols = Enum.map_join(columns, ", ", &quoted/1)
     not_null = Enum.map_join(columns, " AND ", &(quoted(&1) <> " IS NOT NULL"))
 


### PR DESCRIPTION
Extracting `UniqueIndex` in #154 left three compile warnings on main, and CI had no step that would notice.

`duplicates/5` took a `prefix` it never read, because `qualify` already carries it. Dropping the parameter cascades: `create_absent!` and `rebuild!` only took `prefix` to hand it on, so they lose it too. Both migration modules were also still `require Logger` after the only calls moved into `UniqueIndex`, which requires it itself.

The guard is `mix compile --force --warnings-as-errors` in its own CI step. Deliberately not `mix test --warnings-as-errors`: the LiveView test helpers emit 57 runtime warnings (the "form with phx-change but missing id" ones already filling the CI logs), so that flag would bury this signal rather than add to it. Fixing those is a separate job.

Verified the guard actually catches the class rather than just passing: with the unused `require` back in place it exits 1 on `unused require Logger`, and 0 once removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unused `prefix` plumbing in `UniqueIndex` and stray `require Logger`, and adds a CI compile step that fails on warnings. Previously these produced compile warnings that CI ignored; now CI blocks them and behavior is unchanged.

- Drops the unused `prefix` param from `duplicates/5` (now `duplicates/4`), `create_absent!/6`, and `rebuild!/6`; updates internal call sites. `qualify` already carries the schema prefix.
- Removes `require Logger` from `Arcana.Migration` and `Arcana.Graph.Migration`; logging remains in `UniqueIndex`.
- CI now runs `mix compile --force --warnings-as-errors` (with `MIX_ENV=test`) to fail on compile-time warnings; intentionally not `mix test --warnings-as-errors` due to noisy LiveView runtime warnings.

<sup>Written for commit 5d4699fe115861bbf2adc508831aafa0faea1216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

