### PR TITLE
ci: Stop the apt step hanging a job for half an hour

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,16 +56,32 @@ jobs:
             exit 0
           fi
 
-          for attempt in 1 2 3; do
-            if timeout 90 sudo apt-get update &&
-               timeout 120 sudo apt-get install -y --no-install-recommends cmake poppler-utils; then
+          # Two attempts at 60s + 90s plus one 10s sleep is 310s worst case,
+          # inside the 6 minute step timeout above - so the error below always
+          # gets to print. Three attempts would not fit, and the runner killing
+          # the step swallows the diagnostic.
+          for attempt in 1 2; do
+            status=0
+            timeout 60 sudo apt-get update &&
+              timeout 90 sudo apt-get install -y --no-install-recommends cmake poppler-utils ||
+              status=$?
+
+            if [ "$status" -eq 0 ]; then
               exit 0
             fi
-            echo "::warning::apt attempt $attempt did not finish, retrying"
+
+            # 124 is timeout(1) killing a stalled call; anything else is apt
+            # itself refusing, which needs reading rather than retrying.
+            if [ "$status" -eq 124 ]; then
+              echo "::warning::apt attempt $attempt stalled and was killed, retrying"
+            else
+              echo "::warning::apt attempt $attempt failed with status $status, retrying"
+            fi
+
             sleep 10
           done
 
-          echo "::error::apt-get never completed after 3 attempts"
+          echo "::error::could not install cmake and poppler-utils. A stall is usually the Ubuntu mirror; the apt output above says which."
           exit 1
       - name: Set up Elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,11 +56,17 @@ jobs:
             exit 0
           fi
 
-          # Two attempts at 60s + 90s plus one 10s sleep is 310s worst case,
+          # One 10s sleep plus two attempts at 60s + 90s is 310s worst case,
           # inside the 6 minute step timeout above - so the error below always
           # gets to print. Three attempts would not fit, and the runner killing
-          # the step swallows the diagnostic.
+          # the step swallows the diagnostic. The sleep is before the retry
+          # rather than after each attempt, so a run that is going to fail does
+          # not sit there for another 10s first.
           for attempt in 1 2; do
+            if [ "$attempt" -gt 1 ]; then
+              sleep 10
+            fi
+
             status=0
             timeout 60 sudo apt-get update &&
               timeout 90 sudo apt-get install -y --no-install-recommends cmake poppler-utils ||
@@ -73,12 +79,10 @@ jobs:
             # 124 is timeout(1) killing a stalled call; anything else is apt
             # itself refusing, which needs reading rather than retrying.
             if [ "$status" -eq 124 ]; then
-              echo "::warning::apt attempt $attempt stalled and was killed, retrying"
+              echo "::warning::apt attempt $attempt stalled and was killed"
             else
-              echo "::warning::apt attempt $attempt failed with status $status, retrying"
+              echo "::warning::apt attempt $attempt failed with status $status"
             fi
-
-            sleep 10
           done
 
           echo "::error::could not install cmake and poppler-utils. A stall is usually the Ubuntu mirror; the apt output above says which."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      # apt-get blocks rather than fails when it loses the dpkg lock race
+      # against the runner's unattended-upgrades, and it does not time out on
+      # its own. On the 3.0.0 release commit two of three jobs sat on this step
+      # for 30 minutes while the third passed, so a wedged runner looks exactly
+      # like a slow build. Bound each call, retry, and skip apt entirely when
+      # the image already has both tools.
       - name: Install cmake (for hnswlib) and poppler (for PDF tests)
-        run: sudo apt-get update && sudo apt-get install -y cmake poppler-utils
+        timeout-minutes: 6
+        run: |
+          if command -v cmake >/dev/null && command -v pdftotext >/dev/null; then
+            echo "cmake and poppler-utils already present, nothing to install"
+            exit 0
+          fi
+
+          for attempt in 1 2 3; do
+            if timeout 90 sudo apt-get update &&
+               timeout 120 sudo apt-get install -y --no-install-recommends cmake poppler-utils; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt did not finish, retrying"
+            sleep 10
+          done
+
+          echo "::error::apt-get never completed after 3 attempts"
+          exit 1
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:


### PR DESCRIPTION
The apt step can block forever, and it just cost us a release-day CI signal.

## What happened

`apt-get` blocks rather than fails when it loses the dpkg lock race against the runner's `unattended-upgrades`, and nothing bounds it. On the 3.0.0 release commit, **two of three jobs sat on this one step for 30 minutes** while the third passed normally. A rerun I triggered on #118 hung identically. The step never reaches `mix test`, so a wedged runner looks exactly like a slow build — and I merged 3.0.0 with two jobs still stuck there, reasoning from the fact that the release branch had no `lib/` or `test/` diff against a green main. I would rather not have to reason that way again.

## The change

Three things, in order of how often they will matter:

1. **Skip apt when the image already has both tools.** `cmake` and `pdftotext` are checked with `command -v`; if both are present nothing runs. GitHub's images already carry cmake, so this likely removes the apt call from most runs rather than merely bounding it.
2. **Bound each apt call with `timeout(1)`** so a hang becomes a failure instead of a stall.
3. **Retry three times**, so transient lock contention self-heals rather than failing the build.

`timeout-minutes: 6` on the step is the backstop for anything that wedges outside those two calls.

Also `--no-install-recommends`, since we want two binaries and not their suggested extras.

## Verification, and its limits

Being straight about this: a workflow change cannot be fully tested off a runner, so **this PR's own CI run is the real test** — that is why it is a PR rather than a push.

What I could check locally: `bash -n` parses the script, the skip branch prints and exits 0 with both tools present, and the guard correctly falls through when either one is missing (tested both directions). The retry and timeout paths only exist on a runner.

What to look for in the checks below: the step should complete in seconds with "cmake and poppler-utils already present, nothing to install" if the image carries both. If it does hit apt, a hang now surfaces as a `::warning::` and a retry instead of a 30-minute stall.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents CI from stalling on the apt install step; previously it could hang ~30 minutes on the dpkg lock. Now it skips when tools already exist or fails fast with bounded retries and clear diagnostics.

- Skip apt if `cmake` and `pdftotext` are present (common on GitHub images).
- Bound `apt-get update` (60s) and `apt-get install` (90s) with timeouts; retry once after a 10s sleep placed before the retry to keep worst case within the step’s `timeout-minutes: 6`; install with `--no-install-recommends`.
- Distinguish stalls from real apt errors: treat exit 124 as a killed stall, anything else as an apt failure, and ensure a final ::error prints before the step timeout.

<sup>Written for commit a06e5a760a859417c1b0891da18030b51add022c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

