### PR TITLE
fix: Stop the optional hallmark dep warning in every app that lacks it

### DIFF
--- a/lib/arcana/grounding/hallmark_serving.ex
+++ b/lib/arcana/grounding/hallmark_serving.ex
@@ -26,6 +26,18 @@ defmodule Arcana.Grounding.HallmarkServing do
   The model is downloaded automatically on first use via Bumblebee.
   """
 
+  # hallmark is an optional dependency, so in an app that does not use NLI
+  # grounding the module genuinely is not there and every reference to it warns
+  # at compile time. Nothing here runs without it: this GenServer only starts
+  # when grounding is configured, and Arcana.Grounding checks first. A
+  # Code.ensure_loaded? guard at each call site would say the same thing while
+  # adding a branch that can never be taken.
+  #
+  # Arcana's own build has hallmark, so its compile is clean either way and CI
+  # cannot catch a regression here - reproduce by commenting the dep out of
+  # mix.exs and running `MIX_ENV=dev mix compile --force`.
+  @compile {:no_warn_undefined, Hallmark}
+
   use GenServer
 
   alias Arcana.Grounding.{Attribution, Result}


### PR DESCRIPTION
Closes #161.

`hallmark` is `optional: true`, so any app that brings its own embedder and never touches NLI grounding compiles arcana with two undefined-function warnings. Both call sites are unreachable without the dep — the GenServer only starts when grounding is configured — so `@compile {:no_warn_undefined, Hallmark}` states exactly that. A `Code.ensure_loaded?` guard at each call site would say the same thing while adding a branch that can never be taken.

## Swept the general case, and it is clean

The issue asked whether other optional deps share this shape. Rather than grep for it I undeclared **all 12** and compiled: a dev compile emits **exactly these 2 warnings**. Hallmark was the only unguarded one — `Phoenix.LiveView`, `Igniter`, `Leidenfold` and `MDEx` are already behind `Code.ensure_loaded?`.

## Why CI never caught this, and cannot

Worth stating plainly, because it undercuts an assumption from #157: **arcana's own build installs its optional dependencies.** `Code.ensure_loaded?(Hallmark)` is `true` here, so our compile is clean and the `--warnings-as-errors` step added in #157 is structurally blind to this entire class. It only shows up downstream.

So the verification had to reproduce the consumer condition:

```
# comment the dep out of mix.exs, then
MIX_ENV=dev mix compile --force
```

**Before:** 2 warnings, at `hallmark_serving.ex:95` and `:265`, matching the issue exactly.
**After:** 0.

(`MIX_ENV=test` is the wrong env for this check — it compiles `test/support`, which needs Phoenix, so undeclaring the optional deps fails the build for an unrelated reason.)

Also 1328 tests pass, credo `--strict` clean, and the normal `--warnings-as-errors` compile still passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops undefined-function warnings in consumer apps that don’t include the optional `hallmark` dep by marking `Hallmark` as no-warn-undefined in `Arcana.Grounding.HallmarkServing`. Previously those apps saw two compile warnings; now they see none, with no runtime behavior change.

- Adds `@compile {:no_warn_undefined, Hallmark}`; the GenServer only starts when grounding is configured, so calls are unreachable without the dep.
- Verified the general case: with all optional deps undeclared, only these 2 warnings appeared; `Phoenix.LiveView`, `Igniter`, `Leidenfold`, and `MDEx` were already guarded.
- CI won’t catch this class because our build installs optional deps; to reproduce: comment `hallmark` out of `mix.exs` and run `MIX_ENV=dev mix compile --force`.

<sup>Written for commit 4184fb28d842f4fbac908f1a01d44dd52ff901f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

