### PR TITLE
fix: Explain the missing GraphRAG schema instead of 500ing the Graph page

### DIFF
--- a/lib/arcana/graph.ex
+++ b/lib/arcana/graph.ex
@@ -261,18 +261,27 @@ defmodule Arcana.Graph do
 
   ## Options
 
-    * `:prefix` - the Postgres schema to look in (defaults to the connection's
-      current schema)
+    * `:prefix` - the Postgres schema to look in. Without it the question is
+      whether an unqualified query would find the table, which is what the
+      callers actually do
   """
   def installed?(repo, opts \\ []) do
     prefix = Keyword.get(opts, :prefix)
 
+    # pg_table_is_visible rather than current_schema() for the unprefixed case.
+    # current_schema() is only the first entry on the search_path, but the
+    # queries this guards are unqualified and resolve against the whole path -
+    # so on the common `search_path = tenant, public` layout with arcana in
+    # public, comparing against current_schema() reports "not installed" for a
+    # database whose graph queries work perfectly well, and the page then
+    # refuses to render.
     %{rows: [[count]]} =
       repo.query!(
         "SELECT count(*) FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = $1 AND c.relkind IN ('r', 'p') " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
+          "AND CASE WHEN $2::text IS NULL " <>
+          "THEN pg_table_is_visible(c.oid) ELSE n.nspname = $2::text END",
         ["arcana_graph_entities", prefix]
       )
 

--- a/lib/arcana/graph.ex
+++ b/lib/arcana/graph.ex
@@ -242,6 +242,44 @@ defmodule Arcana.Graph do
   end
 
   @doc """
+  Returns whether the GraphRAG schema is installed in the database.
+
+  Separate from `enabled?/0`, which only reads config. The graph tables ship on
+  their own migration version, so an app can legitimately run
+  `Arcana.Migration.up/1` and skip `Arcana.Graph.Migration.up/1` - and then a
+  graph query fails with `relation "arcana_graph_entities" does not exist`
+  rather than returning nothing. Config being on says the operator wants graph
+  features; this says the database can actually answer.
+
+      if Arcana.Graph.installed?(MyApp.Repo) do
+        # safe to query entities, relationships, communities
+      end
+
+  Checks the table rather than the `arcana_graph:<n>` version marker on purpose:
+  the marker can be missing on an install that predates versioning, or that had
+  its table comment clobbered, and those databases can still be queried.
+
+  ## Options
+
+    * `:prefix` - the Postgres schema to look in (defaults to the connection's
+      current schema)
+  """
+  def installed?(repo, opts \\ []) do
+    prefix = Keyword.get(opts, :prefix)
+
+    %{rows: [[count]]} =
+      repo.query!(
+        "SELECT count(*) FROM pg_class c " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "WHERE c.relname = $1 AND c.relkind IN ('r', 'p') " <>
+          "AND n.nspname = COALESCE($2, current_schema())",
+        ["arcana_graph_entities", prefix]
+      )
+
+    count > 0
+  end
+
+  @doc """
   Resolves the query-time graph traversal depth from per-call opts and
   global config.
 

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -113,9 +113,20 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_collections_with_graph_status(repo, allowed) do
       collections = load_collections(repo, allowed)
+      counts = entity_counts(repo)
 
-      # Get entity counts per collection
-      entity_counts =
+      Enum.map(collections, fn c ->
+        Map.put(c, :graph_enabled, Map.get(counts, c.id, 0) > 0)
+      end)
+    end
+
+    # The graph tables are on their own migration version, so an install can
+    # skip them - and this page is reachable from the nav on a database that
+    # did. Without the check the entity count raises undefined_table and takes
+    # the whole page with it. No graph schema means no entities, which is what
+    # an empty map says.
+    defp entity_counts(repo) do
+      if Arcana.Graph.installed?(repo) do
         repo.all(
           from(e in Entity,
             group_by: e.collection_id,
@@ -123,11 +134,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           )
         )
         |> Map.new()
-
-      Enum.map(collections, fn c ->
-        entity_count = Map.get(entity_counts, c.id, 0)
-        Map.put(c, :graph_enabled, entity_count > 0)
-      end)
+      else
+        %{}
+      end
     end
 
     defp selected_graph_enabled?(collections, selected) do

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -703,8 +703,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
                 this page.
               </p>
               <p>
-                Nothing else on the dashboard needs them, so the rest keeps working
-                without it.
+                The other pages work without it: they show no entity counts and
+                nothing else changes.
               </p>
             </div>
           <% else %>

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -419,6 +419,14 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     @impl true
+    # Hiding the controls only stops the honest client. Every handler below
+    # reaches a loader that queries arcana_graph_entities, so a forged event
+    # over the socket would still crash the LiveView on a database without the
+    # graph schema. This clause is first so it catches all of them.
+    def handle_event(_event, _params, %{assigns: %{graph_installed: false}} = socket) do
+      {:noreply, socket}
+    end
+
     def handle_event("switch_subtab", %{"tab" => tab}, socket) do
       {:noreply, push_patch(socket, to: build_path(socket, tab: tab))}
     end

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -28,6 +28,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       {:ok,
        socket
        |> assign(repo: repo)
+       # The graph tables carry their own migration version, so an install can
+       # legitimately skip them. Everything below queries arcana_graph_entities,
+       # which is an undefined_table error rather than an empty page when they
+       # are absent.
+       |> assign(graph_installed: Arcana.Graph.installed?(repo))
        |> assign(
          current_subtab: :entities,
          selected_collection: nil,
@@ -72,10 +77,18 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       selected_collection =
         normalize_selected_collection(params["collection"], socket.assigns.allowed_collections)
 
-      {:noreply,
-       socket
-       |> assign(current_subtab: subtab, selected_collection: selected_collection)
-       |> load_data()}
+      socket = assign(socket, current_subtab: subtab, selected_collection: selected_collection)
+
+      if socket.assigns.graph_installed do
+        {:noreply, load_data(socket)}
+      else
+        # load_stats/2 tolerates the missing tables, so the stats bar and nav
+        # still render around the explanation.
+        {:noreply,
+         assign(socket,
+           stats: load_stats(socket.assigns.repo, socket.assigns.allowed_collections)
+         )}
+      end
     end
 
     # Unrestricted dashboards keep the param as-is (nil means "all
@@ -672,6 +685,22 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
             Explore entities, relationships, and communities extracted from your documents.
           </p>
 
+          <%= if !@graph_installed do %>
+            <div class="arcana-empty-state">
+              <p><strong>GraphRAG is not installed in this database.</strong></p>
+              <p>
+                The graph tables carry their own migration version, so they are not
+                created by <code>Arcana.Migration.up/1</code>. Add a migration that
+                calls <code>Arcana.Graph.Migration.up(dimensions: n)</code> to use
+                this page.
+              </p>
+              <p>
+                Nothing else on the dashboard needs them, so the rest keeps working
+                without it.
+              </p>
+            </div>
+          <% else %>
+
           <div class="arcana-collection-selector">
             <label>Collection:</label>
             <select phx-change="select_collection" name="collection">
@@ -758,6 +787,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
                   total_pages={total_pages(@communities_total)}
                 />
             <% end %>
+          <% end %>
           <% end %>
         </div>
       </.dashboard_layout>

--- a/test/arcana/graph/installed_test.exs
+++ b/test/arcana/graph/installed_test.exs
@@ -29,6 +29,27 @@ defmodule Arcana.Graph.InstalledTest do
       refute Arcana.Graph.installed?(Repo, prefix: "no_such_schema_here")
     end
 
+    test "finds the table through the search_path, not just the first schema on it" do
+      # The multi-tenant layout: a tenant schema first, arcana's tables in
+      # public. An unqualified query resolves through the whole search_path and
+      # finds the graph, so comparing against current_schema() alone reported
+      # "not installed" for a database whose graph pages work.
+      SQL.query!(Repo, ~s(CREATE SCHEMA IF NOT EXISTS "tenant_first"), [])
+      original = SQL.query!(Repo, "SHOW search_path", []).rows |> List.flatten() |> hd()
+
+      try do
+        SQL.query!(Repo, ~s(SET search_path TO "tenant_first", public), [])
+
+        assert SQL.query!(Repo, "SELECT count(*) FROM arcana_graph_entities", []),
+               "precondition: an unqualified query still resolves the table"
+
+        assert Arcana.Graph.installed?(Repo),
+               "installed?/2 must agree with how the page's own queries resolve"
+      after
+        SQL.query!(Repo, "SET search_path TO #{original}", [])
+      end
+    end
+
     test "does not confuse another table in the same schema for the graph" do
       SQL.query!(Repo, ~s(CREATE SCHEMA IF NOT EXISTS "graph_decoy"), [])
 

--- a/test/arcana/graph/installed_test.exs
+++ b/test/arcana/graph/installed_test.exs
@@ -1,0 +1,45 @@
+defmodule Arcana.Graph.InstalledTest do
+  @moduledoc """
+  Covers the check the dashboard uses to decide whether the Graph page can run.
+
+  The graph tables ship on their own migration version, so skipping
+  `Arcana.Graph.Migration.up/1` is a supported install - and before this the
+  dashboard mounted the Graph page anyway and raised
+  `relation "arcana_graph_entities" does not exist`.
+  """
+  use Arcana.DataCase, async: true
+
+  alias Ecto.Adapters.SQL
+
+  describe "installed?/2" do
+    test "is true where the graph tables were migrated" do
+      assert Arcana.Graph.installed?(Repo)
+    end
+
+    test "is false in a schema that has no graph tables" do
+      # A schema rather than a dropped table: this suite's own graph tests need
+      # arcana_graph_entities to exist, and dropping it here would take them
+      # with it. An empty schema is the same question asked somewhere harmless.
+      SQL.query!(Repo, ~s(CREATE SCHEMA IF NOT EXISTS "graph_absent"), [])
+
+      refute Arcana.Graph.installed?(Repo, prefix: "graph_absent")
+    end
+
+    test "is false for a schema that does not exist at all" do
+      refute Arcana.Graph.installed?(Repo, prefix: "no_such_schema_here")
+    end
+
+    test "does not confuse another table in the same schema for the graph" do
+      SQL.query!(Repo, ~s(CREATE SCHEMA IF NOT EXISTS "graph_decoy"), [])
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE IF NOT EXISTS \"graph_decoy\".arcana_documents (id int)",
+        []
+      )
+
+      refute Arcana.Graph.installed?(Repo, prefix: "graph_decoy"),
+             "presence of some arcana table is not presence of the graph schema"
+    end
+  end
+end

--- a/test/arcana_web/live/graph_live_uninstalled_test.exs
+++ b/test/arcana_web/live/graph_live_uninstalled_test.exs
@@ -44,6 +44,25 @@ defmodule ArcanaWeb.GraphLiveUninstalledTest do
            "the collection selector queries entities, so it must not render"
   end
 
+  test "a forged event does not crash the page the controls are hidden from", %{conn: conn} do
+    # Hiding the controls only stops the honest client. Every graph handler
+    # reaches a loader that queries arcana_graph_entities, so an event pushed
+    # straight over the socket would still crash the LiveView.
+    {:ok, view, _html} = live(conn, "/arcana/graph")
+
+    for {event, params} <- [
+          {"switch_subtab", %{"tab" => "relationships"}},
+          {"filter_entities", %{"name" => "anything"}},
+          {"select_entity", %{"id" => Ecto.UUID.generate()}},
+          {"filter_communities", %{"name" => "x"}}
+        ] do
+      assert render_hook(view, event, params) =~ "GraphRAG is not installed",
+             "#{event} should be ignored, not crash the view"
+    end
+
+    assert Process.alive?(view.pid), "the LiveView should have survived every forged event"
+  end
+
   test "the rest of the dashboard still works without the graph schema", %{conn: conn} do
     # The point of the split migration: skipping graph costs you the graph page
     # and nothing else.

--- a/test/arcana_web/live/graph_live_uninstalled_test.exs
+++ b/test/arcana_web/live/graph_live_uninstalled_test.exs
@@ -66,7 +66,19 @@ defmodule ArcanaWeb.GraphLiveUninstalledTest do
   test "the rest of the dashboard still works without the graph schema", %{conn: conn} do
     # The point of the split migration: skipping graph costs you the graph page
     # and nothing else.
-    for path <- ["/arcana", "/arcana/documents", "/arcana/collections", "/arcana/search"] do
+    # Every page reachable from the nav, not a subset. The first version of this
+    # list omitted /arcana/ask, which was the one that still raised 42P01 - so
+    # the test asserted the claim it was meant to check and passed anyway.
+    for path <- [
+          "/arcana",
+          "/arcana/documents",
+          "/arcana/collections",
+          "/arcana/search",
+          "/arcana/ask",
+          "/arcana/evaluation",
+          "/arcana/maintenance",
+          "/arcana/info"
+        ] do
       assert {:ok, _view, _html} = live(conn, path), "#{path} should mount without graph tables"
     end
   end

--- a/test/arcana_web/live/graph_live_uninstalled_test.exs
+++ b/test/arcana_web/live/graph_live_uninstalled_test.exs
@@ -1,0 +1,54 @@
+defmodule ArcanaWeb.GraphLiveUninstalledTest do
+  @moduledoc """
+  The Graph page on a database that never ran the graph migration.
+
+  The graph tables carry their own migration version, so installing arcana
+  without them is supported - and the dashboard used to mount the page anyway
+  and raise `relation "arcana_graph_entities" does not exist`, from a nav link
+  reachable on every page.
+
+  `async: false` so the sandbox runs in shared mode and the LiveView uses this
+  test's connection. That is what makes the setup safe: renaming the table is
+  DDL inside the test's transaction, so the rollback at the end puts it back.
+  Nothing here leaks to another test or survives the run.
+  """
+  use ArcanaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Ecto.Adapters.SQL
+
+  setup do
+    SQL.query!(
+      Repo,
+      "ALTER TABLE arcana_graph_entities RENAME TO arcana_graph_entities_hidden",
+      []
+    )
+
+    :ok
+  end
+
+  test "says so instead of raising", %{conn: conn} do
+    refute Arcana.Graph.installed?(Repo), "precondition: the graph table must look absent"
+
+    {:ok, _view, html} = live(conn, "/arcana/graph")
+
+    assert html =~ "GraphRAG is not installed in this database"
+    assert html =~ "Arcana.Graph.Migration.up"
+  end
+
+  test "does not render the entity browser it cannot fill", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/arcana/graph")
+
+    refute has_element?(view, "select[name='collection']"),
+           "the collection selector queries entities, so it must not render"
+  end
+
+  test "the rest of the dashboard still works without the graph schema", %{conn: conn} do
+    # The point of the split migration: skipping graph costs you the graph page
+    # and nothing else.
+    for path <- ["/arcana", "/arcana/documents", "/arcana/collections", "/arcana/search"] do
+      assert {:ok, _view, _html} = live(conn, path), "#{path} should mount without graph tables"
+    end
+  end
+end


### PR DESCRIPTION
Closes #163.

Took option 1 from the issue — detect it — with one deliberate deviation on the nav link, explained at the bottom.

## The fix

`Arcana.Graph.installed?/2` asks whether `arcana_graph_entities` exists. That is deliberately separate from `enabled?/0`, which only reads config and answers a different question: an app can have graph **enabled with no schema** (the reported 500) or a **schema with graph disabled**. Config says what the operator wants; this says what the database can answer.

It checks the table rather than the `arcana_graph:<n>` marker the issue suggested. The marker is missing on an install that predates versioning, or one whose table comment got clobbered — both of which can still be queried perfectly well, and both would have been told GraphRAG was not installed.

`GraphLive` then skips the graph queries and renders an explanation pointing at `Arcana.Graph.Migration.up/1`. The stats bar and nav still render around it, because `load_stats/2` already tolerates the missing tables.

## Testing

The interesting part is that the absent-schema case is testable safely. The test renames `arcana_graph_entities` **inside the sandbox transaction**, so the rollback puts it back — no destructive DDL survives the test, and I verified the table is present afterwards. `async: false` so the sandbox is shared and the LiveView uses the test's connection, which is what makes the rename visible to it.

With the guard disabled, those tests reproduce the reported error exactly:

```
** (Postgrex.Error) ERROR 42P01 (undefined_table) relation "arcana_graph_entities" does not exist
```

Coverage: `installed?/2` true in the migrated schema, false in an empty schema, false for a schema that does not exist, and false for a schema holding some *other* arcana table (presence of arcana is not presence of the graph). Then the page explains rather than raising, does not render the entity browser it cannot fill, and the rest of the dashboard still mounts.

1335 tests pass, credo `--strict` clean, clean under `--warnings-as-errors`.

## Why the nav link is still there

The issue also suggested omitting it, and I did not, because the only way to do it without touching all nine LiveViews is to key off `@stats[:entities]` in the shared layout — and that is absent both when the schema is missing **and** when graph is merely disabled in config. That would hide the page from someone who has graph data and has simply turned new extraction off, which is a behaviour regression I do not think you want bundled into a crash fix.

Clicking Graph now gives a clear explanation rather than a 500, so the harm is gone. If you do want the link controlled, the issue's option 2 (`except:` / `pages:` on `arcana_dashboard/2`) is the honest way to do it and helps hosts hiding Evaluation or Maintenance too. Happy to do that as a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explains a missing GraphRAG schema instead of 500ing the Graph page, and hardens related pages. Previously `/arcana/graph` and parts of `/arcana/ask` raised `undefined_table`; now the UI detects absence, renders guidance, skips graph queries, and drops socket events so the dashboard stays up.

- Add `Arcana.Graph.installed?/2`, which checks for `arcana_graph_entities` (not the `arcana_graph:<n>` marker), uses `pg_table_is_visible` to match search_path resolution, and supports `:prefix`; separate from `enabled?/0`.
- Update `GraphLive` to assign `graph_installed`, skip graph queries and load only stats when false, render install instructions, keep the Graph nav link, and add a catch‑all `handle_event/3` that drops events while uninstalled.
- Gate `/arcana/ask` entity counts behind `installed?/2`, so the page mounts on databases without the graph schema.
- Tests cover `installed?/2` across schemas and search_path, LiveView behavior with the table temporarily renamed inside the sandbox, forged socket events, and mounting every nav page without graph tables.
- No migration required for this fix; to use the Graph page, add a migration calling `Arcana.Graph.Migration.up(dimensions: n)`.

<sup>Written for commit 1bc5735fc9285ec259b8d8f89c66dbd5777ee361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

