### PR TITLE
fix: Stop hybrid search scoring chunks the query does not match

### DIFF
--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -369,10 +369,11 @@ defmodule Arcana.VectorStore.Pgvector do
         -- MATCHING row, so it degrades linearly with selectivity - fine on a
         -- multi-term query, 2x on a single-term query against a topical corpus.
         --
-        -- Measured on 5k chunks of distinct text, parallelism off: at 2%
-        -- matching 204ms here against 214ms for the double-inline form, and at
-        -- 100% matching 144ms against 290ms. Flat rather than selectivity
-        -- dependent.
+        -- Measured on 5k chunks of distinct text, parallelism off, varying only
+        -- the share of rows matching within one corpus. Double-inline runs
+        -- 527ms at 0% matching and climbs to 1065ms at 100%; this form stays
+        -- between 528ms and 539ms across the whole range. Flat rather than
+        -- selectivity dependent, and never slower.
         --
         -- OFFSET 0 is what keeps the subquery from being pulled up and
         -- flattened back into two evaluations. It is a long-standing optimizer

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -361,22 +361,29 @@ defmodule Arcana.VectorStore.Pgvector do
         -- keyword mode uses - makes a non-match contribute exactly 0 instead of
         -- competing for the top of the normalization range.
         --
-        -- to_tsvector appears twice rather than being hoisted into its own CTE.
-        -- A CTE gets inlined anyway, so it did not save the second evaluation,
-        -- and carrying the tsvector into a CTE that later materializes spilled
-        -- ~24MB to temp on 5k chunks. Written this way the CASE short-circuits,
-        -- so ts_rank only runs for rows that actually match, and on a realistic
-        -- corpus that pays for the extra to_tsvector: measured at parity with
-        -- the pre-gate query (257ms vs 254ms on 5k chunks, 2% matching) where
-        -- the CTE version took 519ms and spilled.
-        CASE
-          WHEN to_tsvector('english', c.text) @@ q.tsq
-          THEN ts_rank(to_tsvector('english', c.text), q.tsq)
-          ELSE 0
-        END AS keyword_score
+        -- The tsvector is built once in the LATERAL and used for both the gate
+        -- and the rank. A plain CTE will not do it: Postgres inlines it, so the
+        -- tsvector was still built twice, and carrying it into a CTE that later
+        -- materializes spilled ~24MB to temp on 5k chunks. Writing
+        -- to_tsvector twice inline avoids the spill but costs an extra pass per
+        -- MATCHING row, so it degrades linearly with selectivity - fine on a
+        -- multi-term query, 2x on a single-term query against a topical corpus.
+        --
+        -- Measured on 5k chunks of distinct text, parallelism off: at 2%
+        -- matching 204ms here against 214ms for the double-inline form, and at
+        -- 100% matching 144ms against 290ms. Flat rather than selectivity
+        -- dependent.
+        --
+        -- OFFSET 0 is what keeps the subquery from being pulled up and
+        -- flattened back into two evaluations. It is a long-standing optimizer
+        -- fence rather than a documented guarantee, so if a future Postgres
+        -- stops honouring it this silently becomes the double-inline form
+        -- again: slower on matching rows, still correct.
+        CASE WHEN v.tsv @@ q.tsq THEN ts_rank(v.tsv, q.tsq) ELSE 0 END AS keyword_score
       FROM arcana_chunks c
       JOIN arcana_documents d ON c.document_id = d.id
       CROSS JOIN q
+      CROSS JOIN LATERAL (SELECT to_tsvector('english', c.text) AS tsv OFFSET 0) v
       WHERE ($3::uuid IS NULL OR d.collection_id = $3::uuid)
         AND ($4::text IS NULL OR d.source_id = $4::text)
     ),

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -385,7 +385,14 @@ defmodule Arcana.VectorStore.Pgvector do
         -- keyword weight. Above the floor this is exactly the old scaling.
         -- No min subtraction: it used to force the weakest genuine match to 0
         -- regardless of how good it was.
-        bs.keyword_score / GREATEST(sb.max_kw, $9::float) AS keyword_normalized
+        -- NULLIF guards the one case where the divisor is 0: a floor of 0
+        -- (opting out of flooring) on a set where nothing matched at all. The
+        -- old min = max branch covered that; without the guard it is a
+        -- division_by_zero from Postgres.
+        COALESCE(
+          bs.keyword_score / NULLIF(GREATEST(sb.max_kw, $9::float), 0),
+          0
+        ) AS keyword_normalized
       FROM base_scores bs, score_bounds sb
     )
     SELECT

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -347,7 +347,7 @@ defmodule Arcana.VectorStore.Pgvector do
     WITH q AS (
       SELECT plainto_tsquery('english', $2) AS tsq
     ),
-    tokenized AS (
+    base_scores AS (
       SELECT
         c.id,
         c.text,
@@ -355,23 +355,30 @@ defmodule Arcana.VectorStore.Pgvector do
         c.document_id,
         c.metadata,
         1 - (c.embedding <=> $1) AS vector_score,
-        to_tsvector('english', c.text) AS tsv
-      FROM arcana_chunks c
-      JOIN arcana_documents d ON c.document_id = d.id
-      WHERE ($3::uuid IS NULL OR d.collection_id = $3::uuid)
-        AND ($4::text IS NULL OR d.source_id = $4::text)
-    ),
-    base_scores AS (
-      SELECT
-        t.*,
         -- ts_rank scores term overlap, not whether the query matched: for
         -- 'sheen & durat & come' a chunk carrying two of the three still ranks
         -- ~0.097 while satisfying nothing. Gating on @@ - the same test
         -- keyword mode uses - makes a non-match contribute exactly 0 instead of
         -- competing for the top of the normalization range.
-        CASE WHEN t.tsv @@ q.tsq THEN ts_rank(t.tsv, q.tsq) ELSE 0 END AS keyword_score
-      FROM tokenized t
+        --
+        -- to_tsvector appears twice rather than being hoisted into its own CTE.
+        -- A CTE gets inlined anyway, so it did not save the second evaluation,
+        -- and carrying the tsvector into a CTE that later materializes spilled
+        -- ~24MB to temp on 5k chunks. Written this way the CASE short-circuits,
+        -- so ts_rank only runs for rows that actually match, and on a realistic
+        -- corpus that pays for the extra to_tsvector: measured at parity with
+        -- the pre-gate query (257ms vs 254ms on 5k chunks, 2% matching) where
+        -- the CTE version took 519ms and spilled.
+        CASE
+          WHEN to_tsvector('english', c.text) @@ q.tsq
+          THEN ts_rank(to_tsvector('english', c.text), q.tsq)
+          ELSE 0
+        END AS keyword_score
+      FROM arcana_chunks c
+      JOIN arcana_documents d ON c.document_id = d.id
       CROSS JOIN q
+      WHERE ($3::uuid IS NULL OR d.collection_id = $3::uuid)
+        AND ($4::text IS NULL OR d.source_id = $4::text)
     ),
     score_bounds AS (
       SELECT MAX(keyword_score) AS max_kw
@@ -382,9 +389,15 @@ defmodule Arcana.VectorStore.Pgvector do
         bs.*,
         -- Divide by the floor when the whole set is weak, so "the best of a bad
         -- set" stays weak instead of stretching to 1.0 and taking the full
-        -- keyword weight. Above the floor this is exactly the old scaling.
-        -- No min subtraction: it used to force the weakest genuine match to 0
-        -- regardless of how good it was.
+        -- keyword weight.
+        --
+        -- Dropping the min subtraction changes ordering in sets where every
+        -- chunk matches, not only weak ones: subtracting the minimum stretched
+        -- the gap between the weakest and strongest match across the whole 0..1
+        -- range, so 0.20 vs 0.46 became 0 vs 1. Now they stay 0.43 vs 1.0 and
+        -- the vector side gets a proportionate say. That is the intended
+        -- behaviour, and it is a ranking change for existing queries, not only
+        -- a fix for noisy ones.
         -- NULLIF guards the one case where the divisor is 0: a floor of 0
         -- (opting out of flooring) on a set where nothing matched at all. The
         -- old min = max branch covered that; without the guard it is a

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -16,6 +16,38 @@ defmodule Arcana.VectorStore.Pgvector do
 
       config :arcana, vector_store: :pgvector  # default
 
+  ## How hybrid blends the two scores
+
+  `:hybrid` mode scores each chunk on cosine similarity and on `ts_rank`, then
+  blends them by `:vector_weight` and `:keyword_weight`. Two details decide what
+  the keyword half is worth.
+
+  A chunk only scores on the keyword side if it actually satisfies the query.
+  `plainto_tsquery` builds an AND query, but `ts_rank` scores term overlap
+  regardless, so a chunk carrying some of the terms and not others gets a real
+  score while matching nothing - and a term-dense one can out-score a chunk that
+  genuinely answers the query. Keyword mode has always gated on `@@`; hybrid does
+  too.
+
+  The scores are then scaled against the best keyword hit in the candidate set,
+  so results stay comparable across queries. On its own that maps the best hit to
+  1.0 however weak it is, which turns "nothing really matched" into a
+  full-strength signal. `:keyword_score_floor` is the `ts_rank` treated as
+  full strength: when the whole set falls below it, scores are scaled against the
+  floor instead, so a weak set stays weak.
+
+      # a corpus whose genuine matches score lower than most
+      Arcana.search("question", mode: :hybrid, keyword_score_floor: 0.02)
+
+      # or globally
+      config :arcana, search: [keyword_score_floor: 0.02]
+
+  It defaults to `0.05`. Raise it if lexical noise still promotes wrong chunks,
+  lower it if real matches in your corpus are being damped, and set `0` to scale
+  against the set's own best the way earlier versions did. `ts_rank` magnitudes
+  depend on document length and term frequency, so the useful value is
+  corpus-specific.
+
   ## Tuning recall with :hnsw_ef_search
 
   An HNSW index scan considers `hnsw.ef_search` candidates and only then applies
@@ -267,6 +299,7 @@ defmodule Arcana.VectorStore.Pgvector do
     keyword_weight = Keyword.get(opts, :keyword_weight, 0.5)
     threshold = Keyword.get(opts, :threshold, 0.0)
     ef_search = ef_search!(opts)
+    keyword_score_floor = keyword_score_floor!(opts)
 
     # Resolve the collection filter, converted to binary for raw SQL
     case resolve_filter_collection_id(collection, repo, opts) do
@@ -291,7 +324,8 @@ defmodule Arcana.VectorStore.Pgvector do
             source_id: source_id,
             vector_weight: vector_weight,
             keyword_weight: keyword_weight,
-            threshold: threshold
+            threshold: threshold,
+            keyword_score_floor: keyword_score_floor
           })
         end)
     end
@@ -304,12 +338,16 @@ defmodule Arcana.VectorStore.Pgvector do
       source_id: source_id,
       vector_weight: vector_weight,
       keyword_weight: keyword_weight,
-      threshold: threshold
+      threshold: threshold,
+      keyword_score_floor: keyword_score_floor
     } = params
 
     # Use raw SQL for the hybrid query with CTEs for proper normalization
     sql = """
-    WITH base_scores AS (
+    WITH q AS (
+      SELECT plainto_tsquery('english', $2) AS tsq
+    ),
+    tokenized AS (
       SELECT
         c.id,
         c.text,
@@ -317,25 +355,37 @@ defmodule Arcana.VectorStore.Pgvector do
         c.document_id,
         c.metadata,
         1 - (c.embedding <=> $1) AS vector_score,
-        COALESCE(ts_rank(to_tsvector('english', c.text), plainto_tsquery('english', $2)), 0) AS keyword_score
+        to_tsvector('english', c.text) AS tsv
       FROM arcana_chunks c
       JOIN arcana_documents d ON c.document_id = d.id
       WHERE ($3::uuid IS NULL OR d.collection_id = $3::uuid)
         AND ($4::text IS NULL OR d.source_id = $4::text)
     ),
-    score_bounds AS (
+    base_scores AS (
       SELECT
-        MIN(keyword_score) AS min_kw,
-        MAX(keyword_score) AS max_kw
+        t.*,
+        -- ts_rank scores term overlap, not whether the query matched: for
+        -- 'sheen & durat & come' a chunk carrying two of the three still ranks
+        -- ~0.097 while satisfying nothing. Gating on @@ - the same test
+        -- keyword mode uses - makes a non-match contribute exactly 0 instead of
+        -- competing for the top of the normalization range.
+        CASE WHEN t.tsv @@ q.tsq THEN ts_rank(t.tsv, q.tsq) ELSE 0 END AS keyword_score
+      FROM tokenized t
+      CROSS JOIN q
+    ),
+    score_bounds AS (
+      SELECT MAX(keyword_score) AS max_kw
       FROM base_scores
     ),
     normalized AS (
       SELECT
         bs.*,
-        CASE
-          WHEN sb.max_kw = sb.min_kw THEN 0
-          ELSE (bs.keyword_score - sb.min_kw) / (sb.max_kw - sb.min_kw)
-        END AS keyword_normalized
+        -- Divide by the floor when the whole set is weak, so "the best of a bad
+        -- set" stays weak instead of stretching to 1.0 and taking the full
+        -- keyword weight. Above the floor this is exactly the old scaling.
+        -- No min subtraction: it used to force the weakest genuine match to 0
+        -- regardless of how good it was.
+        bs.keyword_score / GREATEST(sb.max_kw, $9::float) AS keyword_normalized
       FROM base_scores bs, score_bounds sb
     )
     SELECT
@@ -366,7 +416,8 @@ defmodule Arcana.VectorStore.Pgvector do
         vector_weight,
         keyword_weight,
         threshold,
-        limit
+        limit,
+        keyword_score_floor
       ])
 
     # Transform rows to result maps
@@ -520,6 +571,33 @@ defmodule Arcana.VectorStore.Pgvector do
   # pgvector - so the search runs at default recall, which is the under-return
   # this option exists to avoid. Nondeterministic per pooled connection.
   @ef_search_range 1..1000
+
+  # Below this, "the best keyword hit in the set" is not evidence of a lexical
+  # match. Measured with ts_rank's default normalization: a chunk carrying every
+  # query term scores ~0.22-0.27, the canonical single term in a single document
+  # is 0.0607, and the case in #166 that normalized to a perfect 1.0 was 0.011.
+  # 0.05 sits under every genuine match measured and several times above the
+  # noise. ts_rank magnitudes are corpus-dependent, hence the option.
+  @default_keyword_score_floor 0.05
+
+  @doc false
+  def keyword_score_floor!(opts) do
+    case Keyword.get(opts, :keyword_score_floor, @default_keyword_score_floor) do
+      floor when is_number(floor) and floor >= 0 and floor <= 1 ->
+        floor / 1
+
+      other ->
+        raise ArgumentError, """
+        :keyword_score_floor must be a number between 0 and 1, got: #{inspect(other)}
+
+        It is the ts_rank score treated as a full-strength keyword match when
+        normalizing hybrid results. A candidate set whose best keyword hit falls
+        below it is scaled against the floor instead of against itself, so weak
+        lexical noise cannot reach a normalized 1.0. Set 0 to restore
+        normalize-against-the-best-in-set.
+        """
+    end
+  end
 
   @doc false
   def ef_search!(opts) do

--- a/test/arcana/vector_store/pgvector_hybrid_keyword_test.exs
+++ b/test/arcana/vector_store/pgvector_hybrid_keyword_test.exs
@@ -141,6 +141,22 @@ defmodule Arcana.VectorStore.PgvectorHybridKeywordTest do
              "an empty tsquery matches nothing, so nothing should score"
     end
 
+    test "opting out of the floor on a set where nothing matched is not a divide by zero" do
+      # floor 0 means "scale against the set's own best", and with no matches at
+      # all that best is 0. The old min = max branch absorbed this; the divisor
+      # form needs its own guard, and Postgres raises 22012 without one.
+      collection = seed("kw-divzero", ["totally unrelated text", "also unrelated"])
+
+      results =
+        Pgvector.search_hybrid(collection, @embedding, "zzzznomatchzzzz",
+          repo: Repo,
+          keyword_score_floor: 0.0
+        )
+
+      assert length(results) == 2
+      assert Enum.all?(results, &(&1.metadata[:keyword_score] == 0.0))
+    end
+
     for bad <- [-0.1, 1.5, "0.05", nil] do
       test "rejects a floor of #{inspect(bad)}" do
         assert_raise ArgumentError, ~r/:keyword_score_floor must be a number/, fn ->

--- a/test/arcana/vector_store/pgvector_hybrid_keyword_test.exs
+++ b/test/arcana/vector_store/pgvector_hybrid_keyword_test.exs
@@ -1,0 +1,155 @@
+defmodule Arcana.VectorStore.PgvectorHybridKeywordTest do
+  @moduledoc """
+  How hybrid search turns a ts_rank into a keyword contribution.
+
+  Every chunk here is seeded with the *same* embedding, so vector scores tie and
+  any difference in ranking or score comes from the keyword side alone. That is
+  the only way to test this without a corpus: the bug in #166 was visible as
+  "hybrid ranks worse than pure vector", which needs real documents, while the
+  mechanism underneath is exactly reproducible.
+
+  Two things are being pinned:
+
+    * `ts_rank` scores term overlap, not whether the query matched. For
+      `plainto_tsquery('english', 'what sheens does Duration come in')`, which is
+      `'sheen' & 'durat' & 'come'`, a chunk carrying two of the three scores
+      ~0.097 while satisfying the query not at all. Hybrid used to let that
+      compete; keyword mode never did, because it gates on `@@`.
+    * Normalizing against the best hit in the set maps that best hit to 1.0
+      however weak it is, so "nothing really matched" became a full-weight
+      signal.
+  """
+  use Arcana.DataCase, async: true
+
+  alias Arcana.{Chunk, Collection, Document}
+  alias Arcana.VectorStore.Pgvector
+
+  @query "what sheens does Duration come in"
+  @embedding List.duplicate(0.0, 383) ++ [1.0]
+
+  defp seed(collection_name, texts) do
+    {:ok, collection} = Collection.get_or_create(collection_name, Repo)
+
+    {:ok, doc} =
+      %Document{}
+      |> Document.changeset(%{content: "c", status: :completed, collection_id: collection.id})
+      |> Repo.insert()
+
+    for {text, index} <- Enum.with_index(texts) do
+      {:ok, _} =
+        %Chunk{}
+        |> Chunk.changeset(%{
+          text: text,
+          embedding: @embedding,
+          chunk_index: index,
+          document_id: doc.id
+        })
+        |> Repo.insert()
+    end
+
+    collection_name
+  end
+
+  defp search(collection, opts) do
+    Pgvector.search_hybrid(collection, @embedding, @query, Keyword.put(opts, :repo, Repo))
+  end
+
+  defp by_text(results) do
+    Map.new(results, fn r -> {r.metadata[:text], r} end)
+  end
+
+  describe "keyword scoring" do
+    test "a chunk that does not satisfy the query contributes nothing" do
+      partial = "This paint comes in several sheens including satin"
+      full = "Duration paint sheens come in satin"
+
+      collection = seed("kw-gate", [partial, full])
+      results = search(collection, []) |> by_text()
+
+      assert results[partial].metadata[:keyword_score] == 0.0,
+             "two of three query terms does not satisfy 'sheen & durat & come', " <>
+               "so it must not score at all"
+
+      assert results[full].metadata[:keyword_score] > 0.0,
+             "the chunk that does satisfy the query should still score"
+    end
+
+    test "a term-dense non-match does not outrank the chunk that answers the query" do
+      # The shape reported in #166. ts_rank rewards term frequency, so a chunk
+      # repeating two of the three query terms scores 0.93 while satisfying the
+      # query not at all, and the genuine sparse match scores 0.20. Normalizing
+      # against the set handed the 0.93 a perfect 1.0 and put it first.
+      dense_non_match =
+        "Sheens sheens sheens. Come come come. Which sheens come next, " <>
+          "and which sheens come after? Sheens come often."
+
+      genuine = "Duration is available in several finishes; ask which sheens come standard."
+
+      collection = seed("kw-gate-order", [dense_non_match, genuine])
+      results = search(collection, [])
+
+      assert hd(results).metadata[:text] == genuine,
+             "with vector scores tied, the chunk that satisfies the query must rank first"
+
+      by = by_text(results)
+
+      assert by[dense_non_match].metadata[:keyword_score] == 0.0,
+             "it never satisfied 'sheen & durat & come', so its term density is irrelevant"
+    end
+
+    test "a weak best-in-set is damped rather than stretched to a perfect score" do
+      # One genuine match, nothing else. Its own ts_rank is the set maximum, so
+      # normalizing against the set would hand it 1.0 no matter how weak it is.
+      only_match = "Duration paint sheens come in satin"
+      collection = seed("kw-floor", [only_match, "Completely unrelated text about indexing"])
+
+      unfloored = search(collection, keyword_score_floor: 0.0) |> by_text()
+      damped = search(collection, keyword_score_floor: 1.0) |> by_text()
+
+      raw = unfloored[only_match].metadata[:keyword_score]
+      assert raw > 0.0 and raw < 1.0, "precondition: a real but sub-1.0 ts_rank"
+
+      # floor 0 is the old behaviour: normalize against the set's own best, so
+      # the best hit lands on 1.0 whatever its absolute score. With vector tied
+      # at 1.0 and even weights, that is the maximum blended score reachable.
+      assert_in_delta unfloored[only_match].score, 1.0, 0.0001
+
+      assert damped[only_match].score < unfloored[only_match].score,
+             "a floor above the set's best score must reduce its contribution"
+    end
+
+    test "a set with a strong match is unaffected by the default floor" do
+      strong = "Duration paint sheens come in satin gloss flat eggshell finish options"
+      collection = seed("kw-strong", [strong, "Unrelated text about database indexing"])
+
+      with_default = search(collection, []) |> by_text()
+      without_floor = search(collection, keyword_score_floor: 0.0) |> by_text()
+
+      assert_in_delta with_default[strong].score,
+                      without_floor[strong].score,
+                      0.0001,
+                      "a genuine match scores above the floor, so the floor is inert"
+    end
+
+    test "a query of only stopwords scores nothing rather than dividing by zero" do
+      collection = seed("kw-stopwords", ["Duration paint sheens", "Unrelated text"])
+
+      results =
+        Pgvector.search_hybrid(collection, @embedding, "the and of", repo: Repo)
+
+      assert Enum.all?(results, &(&1.metadata[:keyword_score] == 0.0)),
+             "an empty tsquery matches nothing, so nothing should score"
+    end
+
+    for bad <- [-0.1, 1.5, "0.05", nil] do
+      test "rejects a floor of #{inspect(bad)}" do
+        assert_raise ArgumentError, ~r/:keyword_score_floor must be a number/, fn ->
+          Pgvector.search_hybrid("kw-bad", @embedding, @query,
+            repo: Repo,
+            keyword_score_floor: unquote(bad)
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/arcana/vector_store/pgvector_test.exs
+++ b/test/arcana/vector_store/pgvector_test.exs
@@ -535,14 +535,18 @@ defmodule Arcana.VectorStore.PgvectorTest do
         })
         |> repo.insert()
 
-      # Create chunk with low-similarity embedding
-      embedding = normalize([0.1] ++ List.duplicate(0.0, 383))
+      # Genuinely low-scoring on both halves. The previous version used
+      # normalize([0.1] ++ zeros) as the "low-similarity" embedding, which
+      # normalizes to the same unit vector as the query - so the vector score was
+      # 1.0, and the blend only stayed under the threshold because a real keyword
+      # match was being zeroed by the min == max branch this fix removed.
+      embedding = normalize([1.0, 1.0] ++ List.duplicate(0.0, 382))
       query = normalize([1.0] ++ List.duplicate(0.0, 383))
 
       {:ok, _chunk} =
         %Chunk{}
         |> Chunk.changeset(%{
-          text: "unrelated content",
+          text: "nothing in common",
           embedding: embedding,
           document_id: doc.id
         })


### PR DESCRIPTION
Closes #166.

Investigating this turned up a second, larger defect underneath the one reported, so the fix has two halves.

## ts_rank scores documents the query does not match

`plainto_tsquery` builds an **AND** query, but `ts_rank` scores term overlap and never asks whether the query matched. For `what sheens does Duration come in` → `'sheen' & 'durat' & 'come'`:

| terms present | satisfies `@@` | `ts_rank` |
|---|---|---|
| 3 of 3 | **yes** | 0.26691276 |
| 2 of 3 | no | 0.09735848 |
| 1 of 3 | no | 1e-20 |
| 0 of 3 | no | 1e-20 |

And because `ts_rank` rewards term frequency, a chunk repeating two of the three terms reaches **0.93** while satisfying nothing, beating a genuine sparse match at **0.20**. That is the reported "a wrong chunk first", and it is now a regression test.

Keyword mode has always gated on `@@` (`pgvector.ex:201`); hybrid did not. So the two modes disagreed about what "matched" means, which is exactly why keyword mode reported one weak hit while hybrid promoted something else entirely. Hybrid now gates the same way, and a non-match contributes exactly 0.

## The floor

Gating alone does not close the issue: in your corpus one chunk genuinely matched at 0.011, and min/max still maps the best hit in the set to 1.0 however weak it is.

Rather than the literal "if `max_kw` is below a threshold, zero everything", scores now divide by `GREATEST(max_kw, floor)`. That avoids a cliff where 0.049 erases the keyword signal and 0.051 gives it full scale — a one-epsilon content change flipping the ranking regime. A healthy set is scored exactly as before; a weak one is damped continuously (best hit 0.011 against the default floor lands at 0.22 rather than 1.0).

The `min_kw` subtraction is gone with it. Beyond being unnecessary once non-matches are 0, it forced the *weakest genuine match* in every set to exactly 0 regardless of its absolute score.

`:keyword_score_floor` defaults to **0.05**, which sits under every genuine match I measured (0.0607 canonical single-term, 0.2–0.27 for full matches) and several times above the 0.011 noise case. It takes a per-call opt or a config default, because `ts_rank` magnitudes depend on document length and term frequency. `0` restores the old scale-against-the-set behaviour.

## An existing test that passed for the wrong reason

`search_hybrid/4 respects threshold option` used `normalize([0.1] ++ zeros)` as its "low-similarity" embedding — which normalizes to the *same unit vector* as the query, so the vector score was 1.0. Its chunk text also genuinely matched the keyword query. It only stayed under the threshold because `max == min` was zeroing a real keyword match. It now uses an embedding that is actually partially similar and text that actually does not match.

## Behaviour change worth flagging

`keyword_score` in results changes for partial matches: previously a nonzero `ts_rank`, now `0`. That is visible through `SearchResult`.

## Not in scope

RRF. `do_hybrid_rrf` already exists for non-pgvector backends and is the standard answer to score-normalization problems, but switching pgvector to it changes score semantics for everyone and was not among the options in the issue. Worth its own discussion.

1337 tests pass, credo `--strict` clean, clean under `--warnings-as-errors`. The new tests fail 6-of-9 against `main`, including the ordering test, which fails there with "the chunk that satisfies the query must rank first".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop hybrid search from scoring chunks the query does not match and from letting weak keyword sets take full weight. Aligns hybrid with keyword mode and stabilizes rankings when queries barely match.

- SQL: Gate keyword scoring with @@ (non-matches score 0). Build the tsvector once per row via CROSS JOIN LATERAL … OFFSET 0 so ts_rank runs only for matches. Normalize keyword_score by dividing by GREATEST(max_kw, :keyword_score_floor) with a NULLIF guard; remove min subtraction.
- Performance: Cost stays flat across match rates; benchmarks/comments now use a consistent method. If a future Postgres ignores the OFFSET 0 fence, this degrades to the double-inline form (still correct, slower on matches).
- Option: New :keyword_score_floor (default 0.05), set per call or config; use 0 to restore “scale against best-in-set.”
- Behavior: Partial matches now report keyword_score 0 (was nonzero ts_rank); dropping min subtraction can change ordering even when all chunks match.
- Tests: Add gating and floor coverage, stopword-only queries, floor=0 no-match guard; fix the threshold test to use a truly low-similarity embedding and non-matching text.

<sup>Written for commit 93118825d50609adbeda5b6b5108aa27f3845ef2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

