### PR TITLE
fix: Reject the Maintenance page's graph actions when the schema is absent

### DIFF
--- a/lib/arcana_web/live/maintenance_live.ex
+++ b/lib/arcana_web/live/maintenance_live.ex
@@ -21,6 +21,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       {:ok,
        socket
        |> assign(repo: repo)
+       # The graph tables are on their own migration version, so this page is
+       # reachable on a database without them. The counts below already rescue,
+       # but the actions do not - see the guard on the graph events.
+       |> assign(graph_installed: Arcana.Graph.installed?(repo))
        |> assign(
          reembed_running: false,
          reembed_progress: nil,
@@ -169,6 +173,26 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     @impl true
+    # Every one of these reaches the graph tables. The buttons are hidden when
+    # there is nothing to act on, but hiding a control does not stop an event
+    # pushed straight over the socket, and on a database without the graph
+    # schema that took the whole LiveView down with an undefined_table. Named
+    # rather than a catch-all: the other events on this page have nothing to do
+    # with the graph and must keep working.
+    @graph_events ~w(rebuild_graph detect_communities summarize_communities
+                     assign_orphans delete_orphans)
+
+    def handle_event(event, _params, %{assigns: %{graph_installed: false}} = socket)
+        when event in @graph_events do
+      {:noreply,
+       put_flash(
+         socket,
+         :error,
+         "GraphRAG is not installed in this database. Run a migration calling " <>
+           "Arcana.Graph.Migration.up/1 to use the graph actions."
+       )}
+    end
+
     def handle_event("select_reembed_collection", %{"collection" => collection}, socket) do
       collection = if collection == "", do: nil, else: collection
 

--- a/test/arcana_web/live/maintenance_live_uninstalled_test.exs
+++ b/test/arcana_web/live/maintenance_live_uninstalled_test.exs
@@ -1,0 +1,62 @@
+defmodule ArcanaWeb.MaintenanceLiveUninstalledTest do
+  @moduledoc """
+  The Maintenance page's graph actions on a database without the graph schema.
+
+  The page itself mounts fine because its orphan counts rescue, and the buttons
+  are hidden at zero counts - but hiding a control does not stop an event pushed
+  over the socket, and each of these handlers reaches arcana_graph_entities. A
+  forged `delete_orphans` took the whole LiveView down with 42P01.
+
+  Same approach as the Graph page tests: rename the table inside the sandbox
+  transaction so the rollback restores it, `async: false` so the LiveView shares
+  this test's connection.
+  """
+  use ArcanaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Ecto.Adapters.SQL
+
+  setup do
+    SQL.query!(
+      Repo,
+      "ALTER TABLE arcana_graph_entities RENAME TO arcana_graph_entities_hidden",
+      []
+    )
+
+    :ok
+  end
+
+  test "the page still mounts", %{conn: conn} do
+    refute Arcana.Graph.installed?(Repo), "precondition: the graph table must look absent"
+
+    assert {:ok, _view, _html} = live(conn, "/arcana/maintenance")
+  end
+
+  test "a forged graph action says so instead of crashing", %{conn: conn} do
+    for event <- ~w(delete_orphans assign_orphans rebuild_graph detect_communities
+                    summarize_communities) do
+      {:ok, view, _html} = live(conn, "/arcana/maintenance")
+
+      html = render_hook(view, event, %{})
+
+      assert html =~ "GraphRAG is not installed",
+             "#{event} should report the missing schema"
+
+      assert Process.alive?(view.pid), "#{event} should not take the LiveView down"
+    end
+  end
+
+  test "events that have nothing to do with the graph still work", %{conn: conn} do
+    # The guard names its events rather than swallowing everything, so the rest
+    # of the page has to keep behaving normally.
+    {:ok, view, _html} = live(conn, "/arcana/maintenance")
+
+    html = render_hook(view, "select_reembed_collection", %{"collection" => "anything"})
+
+    refute html =~ "GraphRAG is not installed",
+           "a non-graph event must not hit the graph guard"
+
+    assert Process.alive?(view.pid)
+  end
+end


### PR DESCRIPTION
Follow-up to #168, same bug class one page over. Found by the adversarial review on that PR and deliberately kept out of it, since it is pre-existing and the fix shape differs.

## The bug

`/arcana/maintenance` mounts fine on a database without the GraphRAG schema — its orphan counts already rescue — and the orphan buttons hide at zero counts. But hiding a control does not stop an event pushed straight over the socket, and five handlers on this page reach `arcana_graph_entities`.

Demonstrated rather than reasoned: mount the page with the table absent, `render_hook(view, "delete_orphans", %{})`, and the LiveView dies with `Postgrex.Error 42P01` from `maintenance_live.ex:288` → `delete_orphaned_graph_data`.

#168 established that forged events count for this bug class — its commit was literally "Reject graph events too, not just hide the controls" — so leaving this one open would have been inconsistent with the standard that PR set.

## The fix

A guard clause naming the five graph events (`rebuild_graph`, `detect_communities`, `summarize_communities`, `assign_orphans`, `delete_orphans`) rather than a catch-all like GraphLive uses. That difference is deliberate: GraphLive is entirely about the graph, so swallowing everything there is right. This page also does re-embedding and collection selection, which must keep working — and there is a test asserting a non-graph event does **not** hit the guard.

It reports the missing schema through a flash instead of ignoring the event, since the operator clicked something and deserves to know why nothing happened.

## Verification

Removing the guard reproduces `42P01` on the forged-event test. Tests cover: the page still mounts, all five graph events report rather than crash and leave the view alive, and a non-graph event is unaffected.

Same sandbox approach as #168 — the table rename happens inside the test transaction, so the rollback restores it and nothing leaks.

1350 tests pass, credo `--strict` clean, clean under `--warnings-as-errors`.

## Related, not fixed here

The same review flagged `documents_live`'s "build_graph" button: it is gated on `Graph.enabled?()` config only, so with graph enabled but tables missing an honest click leaves the spinner running forever — the task crashes unlinked, so the page survives but never receives its completion message. Code-read only, config-gated, and a different fix (the task needs to report failure back). Worth its own issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects Maintenance page graph actions when the GraphRAG schema is absent to prevent LiveView crashes. Previously, hidden buttons could still be triggered and crashed with 42P01; now these events are blocked with a flash message while non-graph actions continue to work.

- Guards events: rebuild_graph, detect_communities, summarize_communities, assign_orphans, delete_orphans; returns a flash error instead of executing.
- Sets a graph_installed assign on mount using Arcana.Graph.installed?(repo); the page still mounts without the schema.
- Non-graph events (e.g., select_reembed_collection) are unaffected.
- Adds tests covering mount, guarded events, and a non-graph event on a database missing the graph table.
- Migration action: to enable graph actions, run a migration that calls `Arcana.Graph.Migration.up/1`.

<sup>Written for commit 293d8eebeea7fc0371db51a1b50b977621bd5081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

