### PR TITLE
fix: Resolve the reranker's LLM from config, and say what reranking actually does

### DIFF
--- a/lib/arcana/reranker.ex
+++ b/lib/arcana/reranker.ex
@@ -10,8 +10,12 @@ defmodule Arcana.Reranker do
   `Arcana.search/2` returns its results unreranked, even when an LLM is
   configured for `Arcana.ask/2`.
 
-      config :arcana, reranker: :llm                     # every search
-      Arcana.search(query, reranker: :llm)               # this search
+      config :arcana, reranker: Arcana.Reranker.LLM        # every search
+      Arcana.search(query, reranker: Arcana.Reranker.LLM)  # this search
+
+  A module, or a `{module, opts}` tuple, or a three-arity function. There is no
+  `:llm` shortcut - unlike `:embedder` and `:chunker`, the reranker spec defines
+  none, so name the module.
 
   ## Reranking filters as well as reorders
 
@@ -24,10 +28,9 @@ defmodule Arcana.Reranker do
 
   ## Built-in Implementations
 
-  - `Arcana.Reranker.LLM` - uses your LLM to score relevance. This is what
-    `:llm` resolves to, and it costs an LLM round trip per search, which is
-    seconds rather than milliseconds - see its moduledoc before using it on an
-    interactive path
+  - `Arcana.Reranker.LLM` - uses your LLM to score relevance. Costs an LLM round
+    trip per search, which is seconds rather than milliseconds - see its
+    moduledoc before using it on an interactive path
   - `Arcana.Reranker.CrossEncoder` and `Arcana.Reranker.ColBERT` - local models,
     no LLM call
 

--- a/lib/arcana/reranker.ex
+++ b/lib/arcana/reranker.ex
@@ -5,9 +5,31 @@ defmodule Arcana.Reranker do
   Re-rankers improve retrieval quality by scoring chunks based on their
   relevance to the question, then filtering and re-sorting by score.
 
+  **No reranker runs unless you configure one.** There is no implicit default:
+  with neither `config :arcana, reranker: ...` nor a `:reranker` option,
+  `Arcana.search/2` returns its results unreranked, even when an LLM is
+  configured for `Arcana.ask/2`.
+
+      config :arcana, reranker: :llm                     # every search
+      Arcana.search(query, reranker: :llm)               # this search
+
+  ## Reranking filters as well as reorders
+
+  Worth knowing before you enable one: the callback returns chunks *filtered* by
+  `:threshold` and sorted by score, so a chunk that was in the results can be
+  absent afterwards rather than merely lower down. `:threshold` is therefore a
+  recall-for-precision trade, not a display preference - if a relevant chunk
+  disappears when you turn reranking on, lower it (or set it to 0 to reorder
+  only).
+
   ## Built-in Implementations
 
-  - `Arcana.Reranker.LLM` - Uses your LLM to score relevance (default)
+  - `Arcana.Reranker.LLM` - uses your LLM to score relevance. This is what
+    `:llm` resolves to, and it costs an LLM round trip per search, which is
+    seconds rather than milliseconds - see its moduledoc before using it on an
+    interactive path
+  - `Arcana.Reranker.CrossEncoder` and `Arcana.Reranker.ColBERT` - local models,
+    no LLM call
 
   ## Custom Implementations
 

--- a/lib/arcana/reranker/llm.ex
+++ b/lib/arcana/reranker/llm.ex
@@ -5,6 +5,25 @@ defmodule Arcana.Reranker.LLM do
   Sends all chunks to the LLM in one prompt, gets back JSON scores (0-10),
   then filters by threshold and sorts by score descending.
 
+  ## Cost
+
+  One LLM call per search, on the critical path. Measured on a ~230 document
+  collection at `limit: 8` with `over_fetch: 3`: 16-35 seconds per search against
+  0.2-0.8 seconds unreranked. That is fine for a batch or background path and
+  usually too slow for an interactive one - `Arcana.Reranker.CrossEncoder` and
+  `Arcana.Reranker.ColBERT` score locally if you want reranking without the round
+  trip.
+
+  Also note the threshold filters: it defaults to 7, so chunks the LLM scores
+  below that are dropped from the results rather than moved down. See
+  `Arcana.Reranker` for what that trade means.
+
+  ## Which LLM it uses
+
+  In order: `:llm` in these opts (whether passed beside `:reranker` or inside its
+  option list), then `config :arcana, llm: ...`. `Arcana.Pipeline` supplies
+  `ctx.llm` through the first. It raises only when neither is set.
+
   ## Usage
 
       # With Arcana.Pipeline (uses ctx.llm automatically)
@@ -41,7 +60,7 @@ defmodule Arcana.Reranker.LLM do
   def rerank(_question, [], _opts), do: {:ok, []}
 
   def rerank(question, chunks, opts) do
-    llm = Keyword.fetch!(opts, :llm)
+    llm = resolve_llm!(opts)
     threshold = Keyword.get(opts, :threshold, @default_threshold)
     prompt_fn = Keyword.get(opts, :prompt)
 
@@ -54,6 +73,32 @@ defmodule Arcana.Reranker.LLM do
 
       {:error, _} ->
         {:ok, chunks}
+    end
+  end
+
+  # Falls back to the configured LLM the way Arcana.Ask does. Without this,
+  # `search(reranker: {Arcana.Reranker.LLM, []})` raised KeyError on an app that
+  # had an LLM configured all along, and the fix was to hand the library its own
+  # LLM back - `llm: Arcana.Config.get([], :llm)`. Pipeline still supplies
+  # ctx.llm through opts, and a per-call `llm:` still wins over config.
+  defp resolve_llm!(opts) do
+    case Arcana.Config.get(opts, :llm) do
+      nil ->
+        raise ArgumentError, """
+        Arcana.Reranker.LLM needs an LLM and none was found.
+
+        Configure one globally:
+
+            config :arcana, llm: {MyApp.LLM, :complete}
+
+        or pass it for this call, either beside :reranker or inside its opts:
+
+            Arcana.search(query, reranker: {Arcana.Reranker.LLM, []}, llm: my_llm)
+            Arcana.search(query, reranker: {Arcana.Reranker.LLM, llm: my_llm})
+        """
+
+      llm ->
+        llm
     end
   end
 

--- a/test/arcana/reranker_llm_resolution_test.exs
+++ b/test/arcana/reranker_llm_resolution_test.exs
@@ -1,0 +1,93 @@
+defmodule Arcana.RerankerLlmResolutionTest do
+  @moduledoc """
+  Where `Arcana.Reranker.LLM` gets its LLM from.
+
+  `rerank/3` used `Keyword.fetch!(opts, :llm)`, so enabling the reranker through
+  `Arcana.search/2` raised `KeyError` on an app that had an LLM configured all
+  along - the workaround being to hand the library its own LLM back with
+  `llm: Arcana.Config.get([], :llm)`. It now falls back to config the way
+  `Arcana.ask/2` does.
+  """
+  use Arcana.DataCase, async: true
+
+  alias Arcana.Reranker.LLM
+
+  @chunks [
+    %{id: "1", text: "Elixir runs on the BEAM"},
+    %{id: "2", text: "Unrelated weather text"}
+  ]
+
+  defp scorer, do: fn _prompt -> {:ok, ~s({"1": 9, "2": 1})} end
+
+  describe "llm resolution" do
+    test "uses the configured llm when the call does not carry one" do
+      put_arcana_env(:llm, scorer())
+
+      assert {:ok, [%{id: "1"}]} = LLM.rerank("what runs on the BEAM?", @chunks, [])
+    end
+
+    test "a per-call llm wins over the configured one" do
+      put_arcana_env(:llm, fn _ -> {:ok, ~s({"1": 1, "2": 9})} end)
+
+      assert {:ok, [%{id: "1"}]} = LLM.rerank("q", @chunks, llm: scorer())
+    end
+
+    test "explains itself when there is no llm anywhere" do
+      # Previously a bare KeyError on :llm, which said nothing about how to
+      # configure one.
+      err =
+        assert_raise ArgumentError, fn ->
+          LLM.rerank("q", @chunks, [])
+        end
+
+      assert err.message =~ "needs an LLM"
+      assert err.message =~ "config :arcana, llm:"
+    end
+
+    test "reaches the reranker through Arcana.search/2 with only config set" do
+      # The shape from the issue: reranker named in the search opts, LLM only in
+      # config. This raised before.
+      put_arcana_env(:llm, scorer())
+      {:ok, _} = Arcana.ingest("Elixir is a functional programming language.", repo: Repo)
+
+      assert {:ok, results} =
+               Arcana.search("functional programming",
+                 repo: Repo,
+                 reranker: {LLM, []}
+               )
+
+      assert is_list(results)
+    end
+
+    test "and with the llm inside the reranker tuple" do
+      # This form already worked - Keyword.merge keeps the tuple's :llm when the
+      # top-level opts have none - so it is pinned rather than fixed.
+      {:ok, _} = Arcana.ingest("Elixir is a functional programming language.", repo: Repo)
+
+      assert {:ok, results} =
+               Arcana.search("functional programming",
+                 repo: Repo,
+                 reranker: {LLM, llm: scorer()}
+               )
+
+      assert is_list(results)
+    end
+  end
+
+  describe "filtering" do
+    test "drops chunks below the threshold rather than reordering them" do
+      # The contract the docs now state plainly: a chunk that was in the results
+      # can be absent afterwards.
+      llm = fn _ -> {:ok, ~s({"1": 9, "2": 3})} end
+
+      assert {:ok, [%{id: "1"}]} = LLM.rerank("q", @chunks, llm: llm, threshold: 7)
+    end
+
+    test "threshold 0 reorders without dropping anything" do
+      llm = fn _ -> {:ok, ~s({"1": 3, "2": 9})} end
+
+      assert {:ok, [%{id: "2"}, %{id: "1"}]} =
+               LLM.rerank("q", @chunks, llm: llm, threshold: 0)
+    end
+  end
+end

--- a/test/arcana/reranker_llm_resolution_test.exs
+++ b/test/arcana/reranker_llm_resolution_test.exs
@@ -56,7 +56,11 @@ defmodule Arcana.RerankerLlmResolutionTest do
                  reranker: {LLM, []}
                )
 
-      assert is_list(results)
+      # Asserting on :rerank_score, not just {:ok, _}: a bare shape check would
+      # also pass if reranking were silently skipped, which is the thing this
+      # test exists to notice.
+      assert Enum.all?(results, &is_number(&1.rerank_score)),
+             "every returned chunk should carry the score the reranker gave it"
     end
 
     test "and with the llm inside the reranker tuple" do
@@ -70,7 +74,7 @@ defmodule Arcana.RerankerLlmResolutionTest do
                  reranker: {LLM, llm: scorer()}
                )
 
-      assert is_list(results)
+      assert Enum.all?(results, &is_number(&1.rerank_score))
     end
   end
 


### PR DESCRIPTION
Closes #167 and #169. Both are about enabling reranking through `Arcana.search/2`, so they land together.

## The bug: `:llm` had no config fallback

`Arcana.Reranker.LLM.rerank/3` read `Keyword.fetch!(opts, :llm)`, so this raised `KeyError` on an app that had an LLM configured all along:

```elixir
Arcana.search(q, repo: Repo, reranker: {Arcana.Reranker.LLM, over_fetch: 3})
```

The workaround was handing the library its own LLM back (`llm: Arcana.Config.get([], :llm)`), which is a strange thing to have to do. It now resolves the same way `Arcana.ask/2` does — per-call `:llm` first, then config — and when neither is set it raises an `ArgumentError` that shows how to configure one, rather than a bare `KeyError` on a keyword list.

**One claim in #169 does not hold.** The report says putting `:llm` inside the reranker tuple "doesn't help either". It already worked: `maybe_rerank/5` does `Keyword.merge(reranker_opts, Keyword.take(opts, [...]))`, and `Keyword.take` returns `[]` when the top-level opts carry no `:llm`, so the tuple's own value survives. I verified all three forms before changing anything — tuple works, top-level works, config-only raised. There is now a test pinning the tuple form so it stays working.

## #167: "(default)" read as "already on"

The moduledoc listed `Arcana.Reranker.LLM` as `(default)` next to the built-ins, which reads as active out of the box. It now leads with the fact that **nothing reranks unless `:reranker` is set**, and shows both ways to set it.

## #169 second finding: reranking filters, it does not just reorder

Stated plainly now, because the contract is genuinely surprising: the callback returns chunks *filtered* by `:threshold`, so a chunk that was in the results can be **absent** afterwards rather than lower down. `:threshold` is a recall-for-precision trade, and `0` reorders without dropping. Both behaviours have tests.

## Cost

`Arcana.Reranker.LLM` now carries the number from the issue: one LLM call on the critical path, 16–35s per search against 0.2–0.8s unreranked on a ~230 document collection. It points at `CrossEncoder` and `ColBERT` for reranking without the round trip.

## Not done here

#167 also floats making the LLM reranker on-by-default when an LLM is configured. I left that alone — it would put an LLM call on every search by default, and at the latency above that is a significant behaviour change rather than a doc fix. Worth its own discussion if you want it.

## Verification

Reverting to `Keyword.fetch!` fails 3 of the 7 new tests with exactly the reported `KeyError: key :llm not found`. 1357 tests pass, credo `--strict` clean, clean under `--warnings-as-errors`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the reranker’s LLM from per-call opts, then config, and clarifies that reranking is opt-in and filters results by threshold. Previously `Arcana.Reranker.LLM.rerank/3` required `:llm` in opts and raised `KeyError`; now it falls back to the configured LLM and raises a guided `ArgumentError` when none exists.

- LLM resolution order: `opts[:llm]` > `config :arcana, llm: ...`. Tuple-embedded `:llm` still works; new tests cover both and the no-LLM error.
- Docs: no implicit reranker. Removed the nonexistent `:llm` shortcut; examples now use `Arcana.Reranker.LLM` or `{Arcana.Reranker.LLM, opts}`.
- Behavior: reranking filters by `:threshold` then sorts; `threshold: 0` reorders without dropping. Tests pin both and assert `:rerank_score` is present to prove reranking ran.
- Cost: one LLM call per search; points to `Arcana.Reranker.CrossEncoder` and `Arcana.Reranker.ColBERT` for local reranking.
- Migration: remove any `llm: Arcana.Config.get([], :llm)` workarounds. Replace `reranker: :llm` with `reranker: Arcana.Reranker.LLM` (or `{Arcana.Reranker.LLM, ...}`). To enable reranking, set `:reranker` and tune `:threshold` if recall drops.

<sup>Written for commit 6cde690d712fda417136ad572b68ba36d875dbb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

