### PR TITLE
docs: Say what the loop's LLM options actually accept, and what they don't

### DIFF
--- a/deps
+++ b/deps
@@ -1,0 +1,1 @@
+/private/tmp/claude-502/-Users-george-code-arcana/75db2209-deac-4c48-8917-9dcf991cbf2c/scratchpad/rerank/deps

--- a/deps
+++ b/deps
@@ -1,1 +1,0 @@
-/private/tmp/claude-502/-Users-george-code-arcana/75db2209-deac-4c48-8917-9dcf991cbf2c/scratchpad/rerank/deps

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -67,6 +67,12 @@ defmodule Arcana.Loop do
   asked for prose, but both roles go through the same call path, so it takes a
   model spec or a three-arity function too.
 
+  Its return contract is looser, though. The `:type` routing above is the
+  controller's: the answerer (and the `max_iterations` fallback synthesizer) only
+  needs `{:ok, %{text: binary}}` with a non-empty string, and anything else -
+  including an error - silently keeps the controller's own draft rather than
+  failing the run.
+
   ## Two models
 
   You can configure separate models for the loop controller and the final

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -68,10 +68,16 @@ defmodule Arcana.Loop do
   model spec or a three-arity function too.
 
   Its return contract is looser, though. The `:type` routing above is the
-  controller's: the answerer (and the `max_iterations` fallback synthesizer) only
-  needs `{:ok, %{text: binary}}` with a non-empty string, and anything else -
-  including an error - silently keeps the controller's own draft rather than
-  failing the run.
+  controller's: the answerer only needs `{:ok, %{text: binary}}` with a non-empty
+  string, and anything else - including an error - silently keeps the
+  controller's own draft rather than failing the run.
+
+  The `max_iterations` fallback synthesizer wants that same non-empty text, but
+  failing it costs you more. It only runs when the controller never called
+  `answer`, so there is no draft underneath it: a failed synthesis leaves
+  `:answer` as `nil` and the run still comes back `{:ok, ctx}` with
+  `terminated_by: :max_iterations`. Check for a nil answer on that path rather
+  than assuming something was written.
 
   ## Two models
 

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -41,8 +41,12 @@ defmodule Arcana.Loop do
       Arcana.Loop.run(ctx,
         controller_llm: fn messages, tools, opts ->
           # messages are ReqLLM.Context entries, tools are ReqLLM.Tool structs.
-          # Return {:ok, %{text: ..., tool_calls: [...]}} in the shape
-          # ReqLLM.Response.classify/1 produces, or {:error, reason}.
+          # Return the shape ReqLLM.Response.classify/1 produces. The loop
+          # routes on :type and has no fallback clause, so it must be there:
+          #
+          #     {:ok, %{type: :tool_calls, tool_calls: [...]}}
+          #     {:ok, %{type: :final_answer, text: "..."}}
+          #     {:error, reason}
           MyApp.LLM.complete_with_tools(messages, tools, opts)
         end
       )

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -72,12 +72,15 @@ defmodule Arcana.Loop do
   string, and anything else - including an error - silently keeps the
   controller's own draft rather than failing the run.
 
-  The `max_iterations` fallback synthesizer wants that same non-empty text, but
-  failing it costs you more. It only runs when the controller never called
-  `answer`, so there is no draft underneath it: a failed synthesis leaves
-  `:answer` as `nil` and the run still comes back `{:ok, ctx}` with
-  `terminated_by: :max_iterations`. Check for a nil answer on that path rather
-  than assuming something was written.
+  The `max_iterations` fallback synthesizer has no draft underneath it at all,
+  since it only runs when the controller never called `answer`, so failing it
+  costs you more. A failed synthesis leaves `:answer` as `nil` and the run still
+  comes back `{:ok, ctx}` with `terminated_by: :max_iterations`.
+
+  The non-empty part of that contract belongs to the default synthesizer rather
+  than to the loop. A custom `:synthesizer` has its `{:ok, text}` stored
+  verbatim, so `{:ok, ""}` leaves you an empty answer instead of `nil`. If you
+  supply your own, check that the answer is present rather than just non-nil.
 
   ## Two models
 

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -24,6 +24,45 @@ defmodule Arcana.Loop do
       ctx.tool_history
       ctx.terminated_by
 
+  ## The loop's LLM options differ from the rest of arcana
+
+  `Arcana.ask/2`, `Arcana.Pipeline`, graph extraction and community
+  summarization all accept a `{module, function}` LLM. **The loop does not**, and
+  passing one raises `ArgumentError`. Two things to know before adopting it.
+
+  `req_llm` is required either way. `run/2` refuses to start without it, because
+  the messages and tools the loop builds are `ReqLLM.Context` and `ReqLLM.Tool`
+  structs. So the loop is the one part of arcana an app cannot use while leaving
+  `req_llm` out.
+
+  You can still route the model call through your own stack, using a
+  three-arity function rather than a `{module, function}` tuple:
+
+      Arcana.Loop.run(ctx,
+        controller_llm: fn messages, tools, opts ->
+          # messages are ReqLLM.Context entries, tools are ReqLLM.Tool structs.
+          # Return {:ok, %{text: ..., tool_calls: [...]}} in the shape
+          # ReqLLM.Response.classify/1 produces, or {:error, reason}.
+          MyApp.LLM.complete_with_tools(messages, tools, opts)
+        end
+      )
+
+  That is the hook for your own tracing and cost accounting. What it cannot do is
+  live in `config/runtime.exs` as data: a captured function does not serialize
+  into a release's `sys.config`, which is exactly what `{module, function}` was
+  added for elsewhere. So the loop's LLM has to be wired where code runs, not in
+  config.
+
+  Why the tuple is refused rather than supported: a `{module, function}` LLM is
+  called as a plain completion - prompt in, text out - with nowhere to pass tools
+  or read tool calls back. The loop needs both, so accepting the shape would mean
+  a provider-agnostic tool-calling contract for arcana. If you want that, say so
+  on [#164](https://github.com/georgeguimaraes/arcana/issues/164).
+
+  `:answer_llm` carries the same restriction. The answerer is passed no tools and
+  asked for prose, but both roles go through the same call path, so it takes a
+  model spec or a three-arity function too.
+
   ## Two models
 
   You can configure separate models for the loop controller and the final

--- a/test/arcana/loop_test.exs
+++ b/test/arcana/loop_test.exs
@@ -12,6 +12,55 @@ defmodule Arcana.LoopTest do
   alias Arcana.Loop.Context
   alias Arcana.Loop.Tools
 
+  describe "llm option shapes" do
+    test "a {module, function} controller is refused, and says what to pass instead" do
+      # The loop cannot use the serializable {module, function} LLM the rest of
+      # arcana accepts: that shape is called as prompt-in/text-out, with nowhere
+      # to pass tools or read tool calls back. See the moduledoc section on the
+      # loop's LLM options.
+      ctx = Loop.new("q", repo: Arcana.TestRepo)
+
+      err =
+        assert_raise ArgumentError, fn ->
+          Loop.run(ctx, controller_llm: {MyApp.LLM, :complete})
+        end
+
+      assert err.message =~ ":controller_llm"
+      assert err.message =~ "provider:model"
+    end
+
+    test "and the same for :answer_llm" do
+      ctx = Loop.new("q", repo: Arcana.TestRepo)
+
+      assert_raise ArgumentError, ~r/:answer_llm/, fn ->
+        Loop.run(ctx,
+          controller_llm: fn _m, _t, _o -> {:ok, %{type: :final_answer, text: "x"}} end,
+          answer_llm: {MyApp.LLM, :complete}
+        )
+      end
+    end
+
+    test "a three-arity function is the supported way to bring your own stack" do
+      # This is what the moduledoc points people at, so it is pinned here rather
+      # than left implicit in the stub helper every other test happens to use.
+      ctx = Loop.new("q", repo: Arcana.TestRepo)
+
+      called = :counters.new(1, [])
+
+      controller = fn messages, tools, _opts ->
+        :counters.add(called, 1, 1)
+        assert is_list(tools), "the loop must hand tools to a custom controller"
+        assert messages != [], "and the conversation so far"
+        {:ok, %{type: :final_answer, text: "done"}}
+      end
+
+      {:ok, result} = Loop.run(ctx, controller_llm: controller)
+
+      assert :counters.get(called, 1) == 1, "the custom function must actually be called"
+      assert result.answer == "done"
+    end
+  end
+
   # Builds a stub controller that returns scripted responses one per call.
   # Each scripted response is either a `ReqLLM.Response.classify_result()`-shaped
   # map or a function `(messages, tools, opts) -> {:ok, classified}` that lets a


### PR DESCRIPTION
Closes #164.

Documenting the restriction, per your call. But writing it up turned up something the issue and I both had wrong, and it changes the answer.

## The loop is not closed to your own LLM stack

`call_controller/4` has an `is_function(llm, 3)` clause:

```elixir
defp call_controller(llm, messages, tools, opts) when is_function(llm, 3) do
  llm.(messages, tools, opts)
end
```

It hands over the messages **and the tools**, and takes back a classified result. So an app can route the loop's model calls through its own adapter — with its own tracing and cost accounting — today:

```elixir
Arcana.Loop.run(ctx,
  controller_llm: fn messages, tools, opts ->
    MyApp.LLM.complete_with_tools(messages, tools, opts)
  end
)
```

The loop's own test suite has been driving it this way all along via its `scripted_controller` helper. My first draft of this moduledoc claimed there was "nowhere to put the tools going in or the tool calls coming out" — which is exactly wrong, and I caught it only because I went looking at `call_controller` before committing.

## What is actually restricted

The **serializable** `{module, function}` tuple. That shape is called as prompt-in/text-out, so it genuinely cannot carry tools, and it is refused rather than silently misbehaving. The consequence worth stating is the one #164 cares about: a captured function does not serialize into a release's `sys.config`, so the loop's LLM has to be wired where code runs rather than in `runtime.exs` as data — the very thing `{module, function}` was added for elsewhere.

And `req_llm` is required either way: `run/2` refuses to start without it, because the messages and tools are `ReqLLM.Context` and `ReqLLM.Tool` structs. So the loop is the one part of arcana an app cannot use while leaving `req_llm` out. That is the fact to know before adopting it, and the moduledoc now leads with it.

`:answer_llm` carries the same restriction. Worth noting it is not a technical necessity there — the answerer is passed `tools: []` and asked for prose — but both roles go through the same call path, so it takes a model spec or a three-arity function too. The moduledoc says that rather than implying the answerer needs tools.

## Tests

Three, pinning what the docs now promise: the tuple is refused for `:controller_llm` and for `:answer_llm`, and a three-arity function is called **with tools** and drives the loop to an answer. That last one was previously implicit in the stub helper every other test happens to use; now it is asserted, because the moduledoc points people at it.

1353 tests pass, credo `--strict` clean, clean under `--warnings-as-errors`.

## Not done

The provider-agnostic tool-calling contract that would let the tuple work. It would mean abstracting message construction, tool definitions and tool-call parsing away from ReqLLM types across ~44 call sites including a 383-line `ReqLLM.Tool` module. Left as a design decision rather than folded into a docs fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the loop’s LLM option contracts and aligns examples/tests with actual clauses. Explains controller vs. answerer return shapes, `max_iterations` synthesis outcomes, and that only the default synthesizer enforces non-empty answers. Addresses #164.

- Rejects `{module, function}` for `:controller_llm` and `:answer_llm`; use a provider model spec or a three-arity function that returns the `ReqLLM.Response.classify/1` shapes (include `:type`).
- A three-arity controller receives `ReqLLM.Context` messages and `ReqLLM.Tool` tools and must return `{:ok, %{type: :tool_calls | :final_answer, ...}}` or `{:error, reason}`.
- `:answer_llm` is looser: `{:ok, %{text: binary}}` overrides; anything else keeps the controller’s draft silently.
- `max_iterations`: failed fallback synthesis leaves `answer: nil` but still returns `{:ok, ctx}` with `terminated_by: :max_iterations`. Only the default synthesizer enforces non-empty text; a custom `:synthesizer` stores `{:ok, ""}` verbatim, so check that the answer is present.
- `req_llm` is required; `Arcana.Loop.run/2` does not start without it.
- Tests pin tuple rejection for both options and confirm a custom three-arity controller is called with tools; docs example now includes the required `:type`. Removes a stray `deps` symlink.

**Migration**
- Replace `{module, function}` loop LLM config with a three-arity function wired in code.
- Ensure `req_llm` is installed and configured.

<sup>Written for commit a72915e87ee1bbffca2ec39c27f923a2e2e8a3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

