### PR TITLE
fix: Honour :vector_weight and :keyword_weight in reciprocal rank fusion

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -357,13 +357,24 @@ Arcana's schemas directly:
 # Hybrid search (combines semantic + fulltext)
 {:ok, results} = Arcana.search("Elixir patterns", repo: MyApp.Repo, mode: :hybrid)
 
-# Hybrid with custom weights (pgvector backend)
+# Hybrid with custom weights
 {:ok, results} = Arcana.search("Elixir patterns",
   repo: MyApp.Repo,
   mode: :hybrid,
   vector_weight: 0.7,  # Weight for semantic similarity
   keyword_weight: 0.3   # Weight for keyword matching
 )
+```
+
+Both weights must be non-negative and cannot both be zero. They apply on every
+backend, but they do not mean quite the same thing on each: pgvector blends the
+two scores and compares the result against `:threshold`, so raising both weights
+raises the blended score and can let more rows past the threshold. Other
+backends fuse by rank, where only the ratio counts and `0.9/0.1` ranks
+identically to `9/1`. See
+[Search Algorithms](search-algorithms.md) for the details.
+
+```elixir
 
 # With filters
 {:ok, results} = Arcana.search("query",

--- a/guides/search-algorithms.md
+++ b/guides/search-algorithms.md
@@ -217,10 +217,25 @@ end
 
 Where `k` is a constant (default 60) that prevents top-ranked items from dominating.
 
+**Weights on this path:**
+
+`:vector_weight` and `:keyword_weight` apply here too, scaling each side's
+contribution. Canonical RRF is unweighted, and equal weights reproduce it
+exactly, since scaling both sides by the same factor cannot reorder anything.
+Only the ratio matters, so `{0.9, 0.1}` ranks identically to `{9, 1}` and the
+weights are rescaled to put the larger one at `1.0` before use. That keeps the
+absolute scores where they were before weighting existed, which is why the
+default `0.5`/`0.5` produces plain unweighted RRF rather than every score
+halved. This differs from pgvector, where the weights are absolute multipliers
+that interact with `:threshold`.
+
 **Algorithm:**
 
 ```elixir
-def rrf_combine(vector_results, keyword_results, limit) do
+def rrf_combine(vector_results, keyword_results, limit, k \\ 60, weights \\ {1.0, 1.0}) do
+  # Rescaled so the larger weight is 1.0 - only the ratio affects ranking
+  {vector_weight, keyword_weight} = normalize_weights!(weights)
+
   # Build rank maps
   vector_ranks = build_rank_map(vector_results)
   keyword_ranks = build_rank_map(keyword_results)
@@ -234,7 +249,9 @@ def rrf_combine(vector_results, keyword_results, limit) do
     vector_rank = Map.get(vector_ranks, id, 1000)  # Default: low rank
     keyword_rank = Map.get(keyword_ranks, id, 1000)
 
-    rrf_score = 1/(60 + vector_rank) + 1/(60 + keyword_rank)
+    rrf_score =
+      vector_weight / (k + vector_rank) + keyword_weight / (k + keyword_rank)
+
     {id, rrf_score}
   end)
   |> Enum.sort_by(&elem(&1, 1), :desc)

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -566,7 +566,12 @@ defmodule Arcana.Search do
 
     with {:ok, vector_results} <- do_search(:vector, query, vector_params),
          {:ok, keyword_results} <- do_search(:keyword, query, keyword_params) do
-      {:ok, rrf_combine(vector_results, keyword_results, params.limit, rrf_k)}
+      weights = {
+        Map.get(params, :vector_weight, 0.5),
+        Map.get(params, :keyword_weight, 0.5)
+      }
+
+      {:ok, rrf_combine(vector_results, keyword_results, params.limit, rrf_k, weights)}
     end
   end
 
@@ -611,12 +616,24 @@ defmodule Arcana.Search do
   end
 
   @doc false
-  def rrf_combine(list1, list2, limit, k \\ 60) do
+  # Reciprocal rank fusion. Canonical RRF (Cormack et al. 2009) is unweighted -
+  # sum 1/(k + rank) across the lists - and that is what equal weights give, since
+  # scaling both sides by the same factor cannot change the ordering. Unequal
+  # weights are the common extension, and they are what makes :vector_weight and
+  # :keyword_weight mean anything on this path: it used to ignore them outright,
+  # so a backend routed through here silently discarded both options.
+  def rrf_combine(list1, list2, limit, k \\ 60, weights \\ {1.0, 1.0}) do
+    {weight1, weight2} = weights
+
     scores1 =
-      list1 |> Enum.with_index(1) |> Map.new(fn {item, rank} -> {item.id, 1 / (k + rank)} end)
+      list1
+      |> Enum.with_index(1)
+      |> Map.new(fn {item, rank} -> {item.id, weight1 / (k + rank)} end)
 
     scores2 =
-      list2 |> Enum.with_index(1) |> Map.new(fn {item, rank} -> {item.id, 1 / (k + rank)} end)
+      list2
+      |> Enum.with_index(1)
+      |> Map.new(fn {item, rank} -> {item.id, weight2 / (k + rank)} end)
 
     all_items =
       (list1 ++ list2)

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -623,7 +623,7 @@ defmodule Arcana.Search do
   # :keyword_weight mean anything on this path: it used to ignore them outright,
   # so a backend routed through here silently discarded both options.
   def rrf_combine(list1, list2, limit, k \\ 60, weights \\ {1.0, 1.0}) do
-    {weight1, weight2} = weights
+    {weight1, weight2} = normalize_weights!(weights)
 
     scores1 =
       list1
@@ -647,6 +647,32 @@ defmodule Arcana.Search do
     end)
     |> Enum.sort_by(& &1.score, :desc)
     |> Enum.take(limit)
+  end
+
+  # Weights are relative, so only their ratio matters to the ordering - which
+  # means they can be scaled to put the larger one at 1.0. That keeps the scores
+  # in the range they had before weighting existed: equal weights, including the
+  # 0.5/0.5 defaults, come out exactly as unweighted RRF rather than uniformly
+  # halved. Without this, turning weights on silently changed every score any
+  # caller of a non-pgvector hybrid search was reading.
+  defp normalize_weights!({weight1, weight2} = weights) do
+    unless is_number(weight1) and is_number(weight2) and weight1 >= 0 and weight2 >= 0 do
+      raise ArgumentError, """
+      :vector_weight and :keyword_weight must be non-negative numbers, got: \
+      #{inspect(weights)}
+
+      They are relative, so only their ratio matters: {0.9, 0.1} and {9, 1} rank
+      the same. A negative weight would invert that side's ranking.
+      """
+    end
+
+    case max(weight1, weight2) do
+      # Both zero. Every score would be 0 and the order would fall out of map
+      # enumeration, so treat it as "no preference" rather than a silent shuffle.
+      +0.0 -> {1.0, 1.0}
+      0 -> {1.0, 1.0}
+      scale -> {weight1 / scale, weight2 / scale}
+    end
   end
 
   defp warn_deprecated_weight_opts(opts) do

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -67,6 +67,12 @@ defmodule Arcana.Search do
     * `:vector_store` - Override the configured vector store backend
     * `:vector_weight` - Weight for vector scores in hybrid mode (default: 0.5)
     * `:keyword_weight` - Weight for keyword scores in hybrid mode (default: 0.5)
+
+      Both must be non-negative numbers and cannot both be zero. What they mean
+      depends on the backend: pgvector multiplies them into a blended score that
+      is then compared against `:threshold`, so their magnitudes matter there.
+      Every other backend fuses ranks, where only the ratio matters and
+      `{0.9, 0.1}` ranks the same as `{9, 1}`.
     * `:reranker` - Reranker module or function. Defaults to `config :arcana, :reranker`.
       Pass `false` to disable a globally configured reranker for this call.
       When set, retrieves `limit * over_fetch` candidates, reranks, returns top `limit`.
@@ -505,6 +511,15 @@ defmodule Arcana.Search do
   defp do_search(:hybrid, query, params) do
     backend = params.vector_store || VectorStore.backend()
 
+    # Validate here rather than inside the fusion helper: pgvector multiplies
+    # the weights straight into SQL and never goes near rrf_combine, so
+    # validating downstream would leave the default backend accepting the
+    # garbage the other path rejects.
+    validate_weights!({
+      Map.get(params, :vector_weight, 0.5),
+      Map.get(params, :keyword_weight, 0.5)
+    })
+
     case backend do
       :pgvector ->
         do_hybrid_pgvector(query, params)
@@ -649,30 +664,50 @@ defmodule Arcana.Search do
     |> Enum.take(limit)
   end
 
-  # Weights are relative, so only their ratio matters to the ordering - which
-  # means they can be scaled to put the larger one at 1.0. That keeps the scores
-  # in the range they had before weighting existed: equal weights, including the
-  # 0.5/0.5 defaults, come out exactly as unweighted RRF rather than uniformly
-  # halved. Without this, turning weights on silently changed every score any
-  # caller of a non-pgvector hybrid search was reading.
-  defp normalize_weights!({weight1, weight2} = weights) do
+  # On this path the weights are relative, so only their ratio matters to the
+  # ordering - which means they can be scaled to put the larger one at 1.0. That
+  # keeps the scores in the range they had before weighting existed: equal
+  # weights, including the 0.5/0.5 defaults, come out exactly as unweighted RRF
+  # rather than uniformly halved. Without this, turning weights on silently
+  # changed every score any caller of a non-pgvector hybrid search was reading.
+  #
+  # Note this rescaling is specific to rank fusion. pgvector multiplies the raw
+  # weights into a score it then compares against `:threshold`, so there the
+  # magnitudes matter too and are deliberately left alone.
+  defp normalize_weights!(weights) do
+    {weight1, weight2} = validate_weights!(weights)
+
+    # Non-negative and not both zero, so the larger one is strictly positive.
+    scale = max(weight1, weight2)
+    {weight1 / scale, weight2 / scale}
+  end
+
+  defp validate_weights!({weight1, weight2} = weights) do
     unless is_number(weight1) and is_number(weight2) and weight1 >= 0 and weight2 >= 0 do
       raise ArgumentError, """
       :vector_weight and :keyword_weight must be non-negative numbers, got: \
       #{inspect(weights)}
 
-      They are relative, so only their ratio matters: {0.9, 0.1} and {9, 1} rank
-      the same. A negative weight would invert that side's ranking.
+      A negative weight inverts that side's ranking instead of down-weighting it.
       """
     end
 
-    case max(weight1, weight2) do
-      # Both zero. Every score would be 0 and the order would fall out of map
-      # enumeration, so treat it as "no preference" rather than a silent shuffle.
-      +0.0 -> {1.0, 1.0}
-      0 -> {1.0, 1.0}
-      scale -> {weight1 / scale, weight2 / scale}
+    # Compared with == rather than matched against a zero literal: -0.0 is a
+    # number that passes the guard above, and since Elixir 1.16 it does not
+    # match the pattern +0.0. Left as a match, `{-0.0, 0.0}` slipped through to
+    # -0.0 / -0.0 and raised ArithmeticError.
+    if weight1 == 0 and weight2 == 0 do
+      raise ArgumentError, """
+      :vector_weight and :keyword_weight cannot both be zero, got: \
+      #{inspect(weights)}
+
+      There would be nothing left to rank by. On the rank-fusion path every
+      score collapses to 0 and the order falls out of map enumeration; on
+      pgvector every row scores 0 and `:threshold` then filters all of them out.
+      """
     end
+
+    weights
   end
 
   defp warn_deprecated_weight_opts(opts) do

--- a/test/arcana/search_hybrid_weight_validation_test.exs
+++ b/test/arcana/search_hybrid_weight_validation_test.exs
@@ -1,0 +1,89 @@
+defmodule Arcana.SearchHybridWeightValidationTest do
+  @moduledoc """
+  Both hybrid backends have to reject the same weights.
+
+  The two paths compute hybrid scores in completely different places: pgvector
+  multiplies `:vector_weight`/`:keyword_weight` into SQL and compares the result
+  against `:threshold`, while every other backend fuses ranks in Elixir through
+  `rrf_combine/5`. Validating inside the fusion helper covered only the second
+  one, so the default backend still accepted a negative weight (silently
+  inverting that side) and turned `{0.0, 0.0}` into zero results where rank
+  fusion returned everything. Same call, opposite outcome, per backend.
+  """
+  use Arcana.DataCase, async: true
+
+  alias Arcana.VectorStore.Memory
+
+  setup do
+    {:ok, _} = Arcana.ingest("Elixir is a functional programming language.", repo: Repo)
+    {:ok, _} = Arcana.ingest("Python is great for machine learning.", repo: Repo)
+    :ok
+  end
+
+  defp backends do
+    {:ok, pid} = Memory.start_link([])
+    [pgvector: :pgvector, rank_fusion: {:memory, pid: pid}]
+  end
+
+  describe "weight validation is backend-independent" do
+    test "a negative weight is rejected on every hybrid backend" do
+      for {_name, store} <- backends() do
+        assert_raise ArgumentError, ~r/must be non-negative numbers/, fn ->
+          Arcana.search("programming",
+            repo: Repo,
+            mode: :hybrid,
+            graph: false,
+            vector_store: store,
+            vector_weight: -1.0,
+            keyword_weight: 1.0
+          )
+        end
+      end
+    end
+
+    test "both weights zero is rejected on every hybrid backend" do
+      for {_name, store} <- backends() do
+        assert_raise ArgumentError, ~r/cannot both be zero/, fn ->
+          Arcana.search("programming",
+            repo: Repo,
+            mode: :hybrid,
+            graph: false,
+            vector_store: store,
+            vector_weight: 0.0,
+            keyword_weight: 0.0
+          )
+        end
+      end
+    end
+
+    test "a non-numeric weight is rejected on every hybrid backend" do
+      for {_name, store} <- backends() do
+        assert_raise ArgumentError, ~r/must be non-negative numbers/, fn ->
+          Arcana.search("programming",
+            repo: Repo,
+            mode: :hybrid,
+            graph: false,
+            vector_store: store,
+            vector_weight: "0.5",
+            keyword_weight: 0.5
+          )
+        end
+      end
+    end
+
+    test "legitimate unequal weights still search on every hybrid backend" do
+      # The guard rejects nonsense, not weighting itself.
+      for {_name, store} <- backends() do
+        assert {:ok, _results} =
+                 Arcana.search("programming",
+                   repo: Repo,
+                   mode: :hybrid,
+                   graph: false,
+                   vector_store: store,
+                   vector_weight: 0.9,
+                   keyword_weight: 0.1
+                 )
+      end
+    end
+  end
+end

--- a/test/arcana/search_rrf_weights_test.exs
+++ b/test/arcana/search_rrf_weights_test.exs
@@ -49,11 +49,18 @@ defmodule Arcana.SearchRrfWeightsTest do
     test "a zero weight removes a side's contribution without dropping its items" do
       results = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {1.0, 0.0})
 
-      assert ids(results) == ["v1", "v2", "k1", "k2"]
+      assert length(results) == 4, "a zero weight must not drop the items"
 
-      for r <- results, r.id in ["k1", "k2"] do
-        assert r.score == 0.0, "a zero-weighted side should contribute nothing"
-      end
+      scored = Map.new(results, &{&1.id, &1.score})
+
+      assert scored["k1"] == 0.0 and scored["k2"] == 0.0,
+             "a zero-weighted side should contribute nothing"
+
+      assert scored["v1"] > scored["k1"], "and the weighted side should outrank it"
+
+      # Deliberately not asserting the order within the zero-weighted pair:
+      # those scores tie, rrf_combine has no tiebreaker, and the final order
+      # comes out of map enumeration. Pinning it would be testing an accident.
     end
 
     test "an item in both lists still accumulates from each side" do
@@ -72,6 +79,46 @@ defmodule Arcana.SearchRrfWeightsTest do
       # The graph fusion path calls it this way, so the default has to hold.
       assert ids(Search.rrf_combine(@vector_only, @keyword_only, 4)) ==
                ids(Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {1.0, 1.0}))
+    end
+
+    test "equal weights keep the magnitudes unweighted RRF produced, not half of them" do
+      # do_hybrid_rrf passes the 0.5/0.5 defaults, so without normalizing by the
+      # larger weight every score on that path would silently halve - ordering
+      # intact, but different numbers for anyone reading .score or its telemetry.
+      unweighted = Search.rrf_combine(@vector_only, @keyword_only, 4, 60)
+      defaults = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {0.5, 0.5})
+
+      assert Enum.map(unweighted, & &1.score) == Enum.map(defaults, & &1.score)
+    end
+
+    test "the ratio is what matters, not the scale" do
+      tenths = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {0.9, 0.1})
+      whole = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {9, 1})
+
+      assert ids(tenths) == ids(whole)
+
+      # Equal within tolerance rather than identical: 0.1/0.9 and 1/9 differ by
+      # one ULP, so the ratio survives normalization but the bits do not.
+      for {a, b} <- Enum.zip(tenths, whole) do
+        assert_in_delta a.score, b.score, 1.0e-15
+      end
+    end
+
+    for bad <- [{nil, 0.5}, {0.5, nil}, {-1.0, 1.0}, {"0.5", 0.5}] do
+      test "rejects #{inspect(bad)} instead of producing nonsense" do
+        # Unvalidated, a nil crashed with ArithmeticError deep in the fusion and a
+        # negative weight silently inverted that side's ranking.
+        assert_raise ArgumentError, ~r/must be non-negative numbers/, fn ->
+          Search.rrf_combine(@vector_only, @keyword_only, 4, 60, unquote(Macro.escape(bad)))
+        end
+      end
+    end
+
+    test "both weights zero means no preference rather than an arbitrary order" do
+      zeroed = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {0.0, 0.0})
+      equal = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {1.0, 1.0})
+
+      assert Enum.map(zeroed, & &1.score) == Enum.map(equal, & &1.score)
     end
 
     test "limit still truncates after fusion" do

--- a/test/arcana/search_rrf_weights_test.exs
+++ b/test/arcana/search_rrf_weights_test.exs
@@ -104,21 +104,31 @@ defmodule Arcana.SearchRrfWeightsTest do
       end
     end
 
-    for bad <- [{nil, 0.5}, {0.5, nil}, {-1.0, 1.0}, {"0.5", 0.5}] do
-      test "rejects #{inspect(bad)} instead of producing nonsense" do
-        # Unvalidated, a nil crashed with ArithmeticError deep in the fusion and a
-        # negative weight silently inverted that side's ranking.
+    test "rejects weights that are not non-negative numbers" do
+      # Unvalidated, a nil crashed with ArithmeticError deep in the fusion and a
+      # negative weight silently inverted that side's ranking.
+      #
+      # Iterated at runtime rather than generated as separate tests: unquoting
+      # these in as literals lets the compiler infer the argument type from the
+      # raising guard and warn "incompatible types" for every case, which is
+      # permanent noise on a suite that runs constantly.
+      for bad <- [{nil, 0.5}, {0.5, nil}, {-1.0, 1.0}, {"0.5", 0.5}] do
         assert_raise ArgumentError, ~r/must be non-negative numbers/, fn ->
-          Search.rrf_combine(@vector_only, @keyword_only, 4, 60, unquote(Macro.escape(bad)))
+          Search.rrf_combine(@vector_only, @keyword_only, 4, 60, bad)
         end
       end
     end
 
-    test "both weights zero means no preference rather than an arbitrary order" do
-      zeroed = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {0.0, 0.0})
-      equal = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {1.0, 1.0})
-
-      assert Enum.map(zeroed, & &1.score) == Enum.map(equal, & &1.score)
+    test "rejects both weights being zero rather than picking an order" do
+      # Every score collapses to 0, so the ranking would come out of map
+      # enumeration. Rejecting it also keeps the two hybrid backends agreeing:
+      # pgvector scores every row 0 and :threshold then drops all of them, so
+      # the same call used to return everything here and nothing there.
+      for bad <- [{0.0, 0.0}, {0, 0}, {0, 0.0}, {-0.0, 0.0}, {-0.0, -0.0}] do
+        assert_raise ArgumentError, ~r/cannot both be zero/, fn ->
+          Search.rrf_combine(@vector_only, @keyword_only, 4, 60, bad)
+        end
+      end
     end
 
     test "limit still truncates after fusion" do

--- a/test/arcana/search_rrf_weights_test.exs
+++ b/test/arcana/search_rrf_weights_test.exs
@@ -1,0 +1,81 @@
+defmodule Arcana.SearchRrfWeightsTest do
+  @moduledoc """
+  Reciprocal rank fusion and the weight options.
+
+  `rrf_combine/5` used to take no weights at all, so every backend fused through
+  it discarded `:vector_weight` and `:keyword_weight` silently - the same
+  documented-but-unimplemented shape as `:hnsw_ef_search` before it was wired up.
+
+  Canonical RRF (Cormack et al. 2009) is unweighted, and equal weights reproduce
+  it exactly: scaling both sides by the same factor cannot reorder anything. So
+  the default is still the algorithm as published, and the weights only bite when
+  they differ.
+  """
+  use ExUnit.Case, async: true
+
+  alias Arcana.Search
+
+  # Disjoint lists so each item's rank comes from exactly one side, which makes
+  # the weight arithmetic legible: with k = 60, rank 1 scores w/61.
+  @vector_only [%{id: "v1"}, %{id: "v2"}]
+  @keyword_only [%{id: "k1"}, %{id: "k2"}]
+
+  defp ids(results), do: Enum.map(results, & &1.id)
+
+  describe "weights" do
+    test "equal weights rank identically to unweighted RRF" do
+      unweighted = Search.rrf_combine(@vector_only, @keyword_only, 4, 60)
+      equal = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {1.0, 1.0})
+      halved = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {0.5, 0.5})
+
+      assert ids(unweighted) == ids(equal)
+
+      assert ids(unweighted) == ids(halved),
+             "a uniform scale factor cannot change the ordering"
+    end
+
+    test "favouring the vector side puts its results first" do
+      results = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {0.9, 0.1})
+
+      assert ids(results) == ["v1", "v2", "k1", "k2"]
+    end
+
+    test "favouring the keyword side reverses that" do
+      results = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {0.1, 0.9})
+
+      assert ids(results) == ["k1", "k2", "v1", "v2"]
+    end
+
+    test "a zero weight removes a side's contribution without dropping its items" do
+      results = Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {1.0, 0.0})
+
+      assert ids(results) == ["v1", "v2", "k1", "k2"]
+
+      for r <- results, r.id in ["k1", "k2"] do
+        assert r.score == 0.0, "a zero-weighted side should contribute nothing"
+      end
+    end
+
+    test "an item in both lists still accumulates from each side" do
+      shared = %{id: "both"}
+
+      results =
+        Search.rrf_combine([shared | @vector_only], [shared | @keyword_only], 5, 60, {1.0, 1.0})
+
+      assert hd(results).id == "both",
+             "appearing in both lists is what RRF rewards"
+
+      assert hd(results).score == 1.0 / 61 + 1.0 / 61
+    end
+
+    test "the arity-4 form still works for callers that do not weight" do
+      # The graph fusion path calls it this way, so the default has to hold.
+      assert ids(Search.rrf_combine(@vector_only, @keyword_only, 4)) ==
+               ids(Search.rrf_combine(@vector_only, @keyword_only, 4, 60, {1.0, 1.0}))
+    end
+
+    test "limit still truncates after fusion" do
+      assert length(Search.rrf_combine(@vector_only, @keyword_only, 2, 60, {0.9, 0.1})) == 2
+    end
+  end
+end


### PR DESCRIPTION
Found while assessing the RRF direction for 4.0. `rrf_combine/4` took no weights at all:

```elixir
def rrf_combine(list1, list2, limit, k \\ 60) do
  scores1 = list1 |> Enum.with_index(1) |> Map.new(fn {item, rank} -> {item.id, 1 / (k + rank)} end)
```

So every backend fused through it discarded `:vector_weight` and `:keyword_weight` silently — the same documented-but-unimplemented shape as `:hnsw_ef_search` before #159 wired it up. Only the pgvector path honoured them, which meant `mode: :hybrid` quietly meant two different things depending on which backend you were on.

## Why this changes nothing by default

Canonical RRF (Cormack, Clarke & Buettcher 2009) is unweighted: `sum 1/(k + rank)` across the lists. Equal weights reproduce it **exactly**, because scaling both sides by the same factor cannot reorder anything. The current defaults are `0.5`/`0.5` — equal — so nobody who has not set the options sees a different ordering, and the graph fusion call site keeps the arity-4 form untouched.

Weights only bite when they differ, which is the point: they are what someone reaches for after sweeping them and finding no single value wins, exactly as in the #166 report.

## Tests

Seven, and the one I care most about is the first: equal weights must rank identically to unweighted, and `{0.5, 0.5}` identically to `{1.0, 1.0}`. That pins the default as the published algorithm rather than a weighted variant that merely looks similar. The rest cover favouring either side, a zero weight contributing nothing without dropping the items, an item in both lists accumulating from each, the arity-4 default, and `limit` still truncating after fusion.

Verified load-bearing: reverting the second weight to a hardcoded `1.0` fails three of the seven.

1357 tests pass, credo `--strict` clean, clean under `--warnings-as-errors`.

## Relation to the 4.0 RRF work

This is the honest first piece of it — making the advertised options work where RRF already runs. It does **not** switch pgvector hybrid to RRF; that is the breaking change we discussed, and it still needs its own PR (score semantics move from a 0..1 blend to ~0.033 max, and `threshold` moves to filtering the component searches).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `:vector_weight` and `:keyword_weight` in reciprocal rank fusion and validates weights consistently across hybrid backends. Equal weights reproduce canonical RRF and the `0.5/0.5` default preserves both ordering and scores.

- `Arcana.Search.rrf_combine/5` accepts a weights tuple; the arity-4 form remains for unweighted calls.
- Rank-fusion normalizes weights by the larger one so only the ratio affects ranking and equal weights keep prior magnitudes; pgvector weights remain unnormalized because they interact with `:threshold`.
- Hybrid weight validation now runs before backend selection and applies everywhere: weights must be non-negative numbers, and both weights zero now errors. This prevents negative-weight inversion, non-numeric crashes, and the -0.0 edge case, and aligns backend behavior.
- No migration for typical usage; callers who previously passed both weights as zero must choose a non-zero ratio.

<sup>Written for commit 162955401cf0ae363ee280c58899d7f6c5fa001a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

