### PR TITLE
fix: Explain a blocked rollback instead of surfacing a raw 2BP01

### DIFF
--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -187,9 +187,27 @@ defmodule Arcana.Migration do
     materialized view or a generated column reading these tables are the usual
     ones - so it has to be dropped or altered by hand first.
 
-    #{qualify("arcana_chunks", prefix)} and its siblings are otherwise ready to
-    go; nothing was changed.
+    #{state_after_failure(prefix)}
     """
+  end
+
+  # Only claim nothing happened when that is actually true. The migration runs
+  # in a transaction unless the host set @disable_ddl_transaction true, and
+  # without one each DROP has already committed on its own: earlier tables are
+  # gone, the version marker was never updated, and telling the operator
+  # nothing changed would send them looking in the wrong place.
+  defp state_after_failure(prefix) do
+    if repo().in_transaction?() do
+      "#{qualify("arcana_chunks", prefix)} and its siblings are otherwise " <>
+        "ready to go; this migration is transactional, so nothing was changed."
+    else
+      """
+      This migration runs with @disable_ddl_transaction true, so the drops that
+      came before this one have already been committed and the version marker
+      was not updated. The schema is part-way removed. Clear the dependency,
+      then run the rollback again to finish it.
+      """
+    end
   end
 
   # Version 0 means "no marker found", which covers two different states:

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -82,6 +82,8 @@ defmodule Arcana.Migration do
 
   use Ecto.Migration
 
+  require Logger
+
   alias Arcana.Migration.Dimensions
   alias Arcana.Migration.UniqueIndex
 
@@ -139,6 +141,7 @@ defmodule Arcana.Migration do
     if current >= 1 and target == 0, do: refuse_dependent_drop!(prefix)
 
     if current > target do
+      warn_if_untransacted()
       run_rollback(current, target, prefix, opts)
       record_version(target, prefix)
     end
@@ -153,6 +156,23 @@ defmodule Arcana.Migration do
   # bare 2BP01 - the thing this is all here to avoid. Postgres already knows
   # what depends on what, so let it say, and add the context it has no way to
   # know.
+  # Said before the drops rather than only after one fails. Without a
+  # transaction each DROP commits on its own, so an error part-way leaves the
+  # schema half removed with a stale version marker, and the operator should
+  # know that going in. Not refused outright: a host may have
+  # @disable_ddl_transaction set for unrelated reasons in the same migration,
+  # and refusing would break a rollback that works today.
+  defp warn_if_untransacted do
+    unless repo().in_transaction?() do
+      Logger.warning(
+        "Arcana.Migration.down/1 is running without a transaction " <>
+          "(@disable_ddl_transaction). Each DROP commits on its own, so a " <>
+          "failure part-way leaves the schema partly removed and the version " <>
+          "marker stale. Prefer a transactional migration for rollbacks."
+      )
+    end
+  end
+
   defp run_rollback(current, target, prefix, opts) do
     for version <- current..(target + 1)//-1, do: change(version, :down, opts)
 

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -201,10 +201,13 @@ defmodule Arcana.Migration do
       "#{qualify("arcana_chunks", prefix)} and its siblings are otherwise " <>
         "ready to go; this migration is transactional, so nothing was changed."
     else
+      # Deliberately not saying how much is gone: the failure can land on the
+      # first DROP, in which case nothing was, and claiming a part-way schema
+      # would be its own wrong answer.
       """
-      This migration runs with @disable_ddl_transaction true, so the drops that
-      came before this one have already been committed and the version marker
-      was not updated. The schema is part-way removed. Clear the dependency,
+      This migration runs with @disable_ddl_transaction true, so any drops that
+      ran before this one are already committed and the version marker was not
+      updated. Check what is still there before retrying. Clear the dependency,
       then run the rollback again to finish it.
       """
     end

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -139,11 +139,57 @@ defmodule Arcana.Migration do
     if current >= 1 and target == 0, do: refuse_dependent_drop!(prefix)
 
     if current > target do
-      for version <- current..(target + 1)//-1, do: change(version, :down, opts)
+      run_rollback(current, target, prefix, opts)
       record_version(target, prefix)
     end
 
     :ok
+  end
+
+  # The foreign key preflight above catches the case worth naming a next action
+  # for, and it is the common one. It cannot be the whole story: a view, a
+  # materialized view or a generated column referencing these tables blocks the
+  # DROP just as hard and is not a constraint, so it would still surface as a
+  # bare 2BP01 - the thing this is all here to avoid. Postgres already knows
+  # what depends on what, so let it say, and add the context it has no way to
+  # know.
+  defp run_rollback(current, target, prefix, opts) do
+    for version <- current..(target + 1)//-1, do: change(version, :down, opts)
+
+    # Ecto's migration runner queues DDL and flushes it after the migration
+    # function returns, which is outside this rescue. Flushing here is what
+    # brings the DROPs inside it.
+    flush()
+  rescue
+    error in Postgrex.Error ->
+      case error.postgres do
+        %{code: :dependent_objects_still_exist} = pg ->
+          reraise dependent_object_message(pg, prefix), __STACKTRACE__
+
+        _ ->
+          reraise error, __STACKTRACE__
+      end
+  end
+
+  defp dependent_object_message(pg, prefix) do
+    detail = pg[:detail] || pg[:message]
+
+    """
+    Arcana.Migration.down/1 could not drop its tables: something in the
+    database still depends on them.
+
+    Postgres reported:
+
+        #{detail}
+
+    Foreign keys from other tables are checked before the rollback starts and
+    reported with the call that clears them. This is something else - a view, a
+    materialized view or a generated column reading these tables are the usual
+    ones - so it has to be dropped or altered by hand first.
+
+    #{qualify("arcana_chunks", prefix)} and its siblings are otherwise ready to
+    go; nothing was changed.
+    """
   end
 
   # Version 0 means "no marker found", which covers two different states:

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -278,7 +278,8 @@ defmodule Arcana.Migration do
     # install and must not send the operator to Graph.Migration.down/1.
     {graph, host} =
       Enum.split_with(dependents, fn d ->
-        d.table in @graph_tables and d.schema == target_schema
+        d.table in @graph_tables and not is_nil(target_schema) and
+          d.schema == target_schema
       end)
 
     next =
@@ -357,9 +358,15 @@ defmodule Arcana.Migration do
     """
   end
 
+  # current_schema() is NULL when search_path names only schemas that do not
+  # exist. Nothing reaches this in that state today - the guard's own query
+  # returns no rows, so no message is built - but a nil here would quietly
+  # class every graph table as "not Arcana's", so it is not left to chance.
   defp current_schema do
-    %{rows: [[schema]]} = repo().query!("SELECT current_schema()", [])
-    schema
+    case repo().query!("SELECT current_schema()", []) do
+      %{rows: [[schema]]} when is_binary(schema) -> schema
+      _ -> nil
+    end
   end
 
   # Exactly what change(1, :down, _) drops. Both rollback guards read this, so

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -134,6 +134,10 @@ defmodule Arcana.Migration do
 
     if current == 0, do: refuse_blind_rollback!(prefix)
 
+    # Only version 1's down drops the core tables, so only a rollback that
+    # reaches 0 can trip over something referencing them.
+    if current >= 1 and target == 0, do: refuse_dependent_drop!(prefix)
+
     if current > target do
       for version <- current..(target + 1)//-1, do: change(version, :down, opts)
       record_version(target, prefix)
@@ -163,6 +167,82 @@ defmodule Arcana.Migration do
       present ->
         raise blind_rollback_message(present, prefix)
     end
+  end
+
+  # The graph schema installs on its own migration version and points foreign
+  # keys at arcana_chunks. `on_delete:` governs row deletes, so it does nothing
+  # for a DROP TABLE, and this module would otherwise walk into a bare 2BP01
+  # naming a constraint the operator may never have heard of.
+  #
+  # Asked of Postgres rather than matched against a list of known graph table
+  # names: a host is free to reference arcana_chunks from its own schema too,
+  # and that fails identically and deserves the same message.
+  defp refuse_dependent_drop!(prefix) do
+    case dependent_tables(prefix) do
+      [] -> :ok
+      dependents -> raise dependent_drop_message(dependents, prefix)
+    end
+  end
+
+  # Foreign keys pointing at a table this module drops, from a table it does
+  # not. The owned tables reference each other and are dropped together, so
+  # those are excluded or every install would look blocked.
+  defp dependent_tables(prefix) do
+    %{rows: rows} =
+      repo().query!(
+        "SELECT DISTINCT dn.nspname, dependent.relname, referenced.relname " <>
+          "FROM pg_constraint con " <>
+          "JOIN pg_class dependent ON dependent.oid = con.conrelid " <>
+          "JOIN pg_namespace dn ON dn.oid = dependent.relnamespace " <>
+          "JOIN pg_class referenced ON referenced.oid = con.confrelid " <>
+          "JOIN pg_namespace rn ON rn.oid = referenced.relnamespace " <>
+          "WHERE con.contype = 'f' " <>
+          "AND referenced.relname = ANY($1) " <>
+          "AND dependent.relname <> ALL($1) " <>
+          "AND rn.nspname = COALESCE($2, current_schema())",
+        [owned_table_names(), prefix]
+      )
+
+    Enum.map(rows, fn [schema, dependent, referenced] ->
+      {schema, dependent, referenced}
+    end)
+  end
+
+  @graph_tables ~w(arcana_graph_entities arcana_graph_entity_mentions
+                   arcana_graph_relationships arcana_graph_communities)
+
+  defp dependent_drop_message(dependents, prefix) do
+    listed =
+      dependents
+      |> Enum.sort()
+      |> Enum.map_join("\n", fn {schema, dependent, referenced} ->
+        "        #{schema}.#{dependent} -> #{referenced}"
+      end)
+
+    next =
+      if Enum.any?(dependents, fn {_s, d, _r} -> d in @graph_tables end) do
+        """
+        The GraphRAG schema is installed. Roll it back first, then retry:
+
+            Arcana.Graph.Migration.down(#{inspect(prefix: prefix)})
+        """
+      else
+        """
+        These are not Arcana's tables. Drop them, or remove the foreign keys,
+        before rolling Arcana's schema back.
+        """
+      end
+
+    """
+    Arcana.Migration.down/1 can't drop its tables: other tables reference them.
+
+    Postgres would refuse this with a dependent_objects_still_exist error
+    (2BP01), so nothing was changed. These foreign keys are in the way:
+
+    #{listed}
+
+    #{next}
+    """
   end
 
   defp blind_rollback_message(present, prefix) do
@@ -201,6 +281,19 @@ defmodule Arcana.Migration do
     """
   end
 
+  # Exactly what change(1, :down, _) drops. Both rollback guards read this, so
+  # a table added to that function has one place to be listed.
+  defp owned_table_names do
+    ~w(
+      arcana_collections
+      arcana_documents
+      arcana_chunks
+      arcana_evaluation_test_cases
+      arcana_evaluation_test_case_chunks
+      arcana_evaluation_runs
+    )
+  end
+
   # The tables change(1, :down, _) drops. Any of them being present means a
   # rollback has something to do, so the version table alone is not enough
   # evidence: it can be gone while its siblings remain.
@@ -214,17 +307,7 @@ defmodule Arcana.Migration do
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
           "AND n.nspname = COALESCE($2, current_schema())",
-        [
-          ~w(
-                   arcana_collections
-                   arcana_documents
-                   arcana_chunks
-                   arcana_evaluation_test_cases
-                   arcana_evaluation_test_case_chunks
-                   arcana_evaluation_runs
-          ),
-          prefix
-        ]
+        [owned_table_names(), prefix]
       )
 
     List.flatten(rows)

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -190,21 +190,27 @@ defmodule Arcana.Migration do
   defp dependent_tables(prefix) do
     %{rows: rows} =
       repo().query!(
-        "SELECT DISTINCT dn.nspname, dependent.relname, referenced.relname " <>
+        # Scoped to the target schema, not matched on name alone: the owned
+        # tables reference each other and go together, but a table of the
+        # same name in ANOTHER schema is a real dependent, and excluding it
+        # by name hid the foreign key and handed back the 2BP01 anyway.
+        "SELECT DISTINCT dn.nspname, dependent.relname, referenced.relname, con.conname " <>
           "FROM pg_constraint con " <>
           "JOIN pg_class dependent ON dependent.oid = con.conrelid " <>
           "JOIN pg_namespace dn ON dn.oid = dependent.relnamespace " <>
           "JOIN pg_class referenced ON referenced.oid = con.confrelid " <>
           "JOIN pg_namespace rn ON rn.oid = referenced.relnamespace " <>
           "WHERE con.contype = 'f' " <>
+          "AND dependent.relkind IN ('r', 'p') " <>
           "AND referenced.relname = ANY($1) " <>
-          "AND dependent.relname <> ALL($1) " <>
-          "AND rn.nspname = COALESCE($2, current_schema())",
+          "AND rn.nspname = COALESCE($2, current_schema()) " <>
+          "AND NOT (dn.nspname = COALESCE($2, current_schema()) " <>
+          "AND dependent.relname = ANY($1))",
         [owned_table_names(), prefix]
       )
 
-    Enum.map(rows, fn [schema, dependent, referenced] ->
-      {schema, dependent, referenced}
+    Enum.map(rows, fn [schema, dependent, referenced, constraint] ->
+      %{schema: schema, table: dependent, referenced: referenced, constraint: constraint}
     end)
   end
 
@@ -214,23 +220,47 @@ defmodule Arcana.Migration do
   defp dependent_drop_message(dependents, prefix) do
     listed =
       dependents
-      |> Enum.sort()
-      |> Enum.map_join("\n", fn {schema, dependent, referenced} ->
-        "        #{schema}.#{dependent} -> #{referenced}"
+      |> Enum.sort_by(&{&1.schema, &1.table, &1.constraint})
+      |> Enum.map_join("\n", fn d ->
+        "        #{d.schema}.#{d.table} -> #{d.referenced} (#{d.constraint})"
+      end)
+
+    target_schema = prefix || current_schema()
+
+    # Graph tables in the schema being rolled back. A host table that happens
+    # to carry one of these names in a different schema is not the GraphRAG
+    # install and must not send the operator to Graph.Migration.down/1.
+    {graph, host} =
+      Enum.split_with(dependents, fn d ->
+        d.table in @graph_tables and d.schema == target_schema
       end)
 
     next =
-      if Enum.any?(dependents, fn {_s, d, _r} -> d in @graph_tables end) do
-        """
-        The GraphRAG schema is installed. Roll it back first, then retry:
+      case {graph, host} do
+        {[_ | _], []} ->
+          """
+          The GraphRAG schema is installed. Roll it back first, then retry:
 
-            Arcana.Graph.Migration.down(#{inspect(prefix: prefix)})
-        """
-      else
-        """
-        These are not Arcana's tables. Drop them, or remove the foreign keys,
-        before rolling Arcana's schema back.
-        """
+              Arcana.Graph.Migration.down(#{inspect(prefix: prefix)})
+          """
+
+        {[], _} ->
+          """
+          These are not Arcana's tables. Drop them, or remove the foreign keys,
+          before rolling Arcana's schema back.
+          """
+
+        {[_ | _], [_ | _]} ->
+          # Both, so naming only the graph step would send them round for a
+          # second failure on the ones it does not clear.
+          """
+          Two things are in the way. Roll the GraphRAG schema back:
+
+              Arcana.Graph.Migration.down(#{inspect(prefix: prefix)})
+
+          and drop the non-Arcana tables above, or remove their foreign keys.
+          Clearing only one of the two leaves the rollback blocked.
+          """
       end
 
     """
@@ -279,6 +309,11 @@ defmodule Arcana.Migration do
     #{recovery}
     See "Where the version is recorded" in Arcana.Migration for how this is stored.
     """
+  end
+
+  defp current_schema do
+    %{rows: [[schema]]} = repo().query!("SELECT current_schema()", [])
+    schema
   end
 
   # Exactly what change(1, :down, _) drops. Both rollback guards read this, so

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -1276,16 +1276,107 @@ defmodule Arcana.MigrationTest do
       refute table_exists?("arcana_collections")
     end
 
-    test "a partial rollback that keeps the core tables is unaffected" do
-      # Only version 1's down drops them, so a rollback stopping above it has
-      # nothing to conflict with and must not be blocked.
+    test "the guard does not fire for a rollback that stops above version 1" do
+      # With @current_version at 1 this rollback is a no-op: current > target
+      # is 1 > 1, so the loop never runs and nothing is dropped. What it pins
+      # is the gating - the guard is skipped for a non-zero target, and would
+      # raise here if it ran, because the graph schema is installed.
       assert :ok = migrate(Arcana.Migration)
       assert :ok = migrate(Arcana.Graph.Migration)
 
       assert :ok = migrate_down(Arcana.Migration, version: 1)
+    end
 
-      assert table_exists?("arcana_chunks")
-      assert table_exists?("arcana_graph_entities")
+    test "names the blocking constraint, not just the tables" do
+      # The operator has to be able to find the foreign key. A table pair on
+      # its own does not identify which constraint to drop.
+      assert :ok = migrate(Arcana.Migration)
+      assert :ok = migrate(Arcana.Graph.Migration)
+
+      error = assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
+
+      assert error.message =~ "arcana_graph_entities_chunk_id_fkey",
+             "the constraint name is what Postgres would have reported"
+    end
+
+    test "a same-named table in another schema is not mistaken for an owned one" do
+      # The exclusion is scoped to the target schema. Matching on name alone
+      # hid this foreign key and let the rollback fail with the raw 2BP01.
+      assert :ok = migrate(Arcana.Migration)
+
+      SQL.query!(Repo, ~s(CREATE SCHEMA IF NOT EXISTS "other_tenant"), [])
+      SQL.query!(Repo, "DROP TABLE IF EXISTS other_tenant.arcana_documents CASCADE", [])
+
+      on_exit(fn ->
+        SQL.query!(Repo, "DROP SCHEMA IF EXISTS \"other_tenant\" CASCADE", [])
+      end)
+
+      # Named exactly like an owned table, but in a different schema, so it is
+      # a genuine dependent rather than something dropped alongside.
+      SQL.query!(
+        Repo,
+        "CREATE TABLE other_tenant.arcana_documents (id serial primary key, " <>
+          "chunk_id uuid REFERENCES public.arcana_chunks(id))",
+        []
+      )
+
+      error = assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
+
+      assert error.message =~ "other_tenant.arcana_documents -> arcana_chunks"
+
+      assert error.message =~ "not Arcana's tables",
+             "a same-named table in a foreign schema is not the GraphRAG install"
+    end
+
+    test "a host table wearing a graph table's name does not get graph advice" do
+      # @graph_tables is matched against the target schema. A coincidental name
+      # elsewhere must not send the operator to Graph.Migration.down/1, which
+      # would not clear it.
+      assert :ok = migrate(Arcana.Migration)
+
+      SQL.query!(Repo, ~s(CREATE SCHEMA IF NOT EXISTS "impostor"), [])
+
+      on_exit(fn ->
+        SQL.query!(Repo, "DROP SCHEMA IF EXISTS \"impostor\" CASCADE", [])
+      end)
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE impostor.arcana_graph_entities (id serial primary key, " <>
+          "chunk_id uuid REFERENCES public.arcana_chunks(id))",
+        []
+      )
+
+      error = assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
+
+      refute error.message =~ "Arcana.Graph.Migration.down(",
+             "there is no GraphRAG install here to roll back"
+
+      assert error.message =~ "not Arcana's tables"
+    end
+
+    test "both a graph and a host dependency name both steps" do
+      assert :ok = migrate(Arcana.Migration)
+      assert :ok = migrate(Arcana.Graph.Migration)
+
+      SQL.query!(Repo, "DROP TABLE IF EXISTS host_both CASCADE", [])
+
+      on_exit(fn -> SQL.query!(Repo, "DROP TABLE IF EXISTS host_both CASCADE", []) end)
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE host_both (id serial primary key, " <>
+          "chunk_id uuid REFERENCES arcana_chunks(id))",
+        []
+      )
+
+      error = assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
+
+      assert error.message =~ "Arcana.Graph.Migration.down(",
+             "the graph step is still needed"
+
+      assert error.message =~ "Clearing only one of the two",
+             "and so is the host one, or the retry just fails differently"
     end
   end
 end

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -73,30 +73,18 @@ defmodule Arcana.MigrationTest do
   # generated module rather than passed as a closure. Both directions go
   # through Migrator.up/4: `down` here means "the thing this migration
   # does is call Arcana.Migration.down/1", not a rollback of it.
-  # Same as run/3 but with @disable_ddl_transaction, so the DDL autocommits
+  defp run(module, direction, opts), do: run(module, direction, opts, transactional: true)
+
+  # transactional: false sets @disable_ddl_transaction, so the DDL autocommits
   # statement by statement instead of rolling back as a unit.
-  defp run_untransacted(module, direction, opts) do
-    name = :"Elixir.MigTestNT#{System.unique_integer([:positive])}"
-
-    body =
-      quote do
-        use Ecto.Migration
-
-        @disable_ddl_transaction true
-
-        def up, do: unquote(module).unquote(direction)(unquote(Macro.escape(opts)))
-      end
-
-    Module.create(name, body, Macro.Env.location(__ENV__))
-    Ecto.Migrator.up(Repo, System.unique_integer([:positive]), name, log: false)
-  end
-
-  defp run(module, direction, opts) do
+  defp run(module, direction, opts, transactional: transactional?) do
     name = :"Elixir.MigTest#{System.unique_integer([:positive])}"
 
     body =
       quote do
         use Ecto.Migration
+
+        unless unquote(transactional?), do: @disable_ddl_transaction(true)
 
         def up, do: unquote(module).unquote(direction)(unquote(Macro.escape(opts)))
       end
@@ -1440,17 +1428,23 @@ defmodule Arcana.MigrationTest do
       SQL.query!(Repo, "CREATE VIEW chunk_nt AS SELECT id FROM arcana_chunks", [])
 
       error =
-        assert_raise RuntimeError, fn -> run_untransacted(Arcana.Migration, :down, []) end
+        assert_raise RuntimeError, fn ->
+          run(Arcana.Migration, :down, [], transactional: false)
+        end
 
       assert error.message =~ "still depends on them"
 
       assert error.message =~ "@disable_ddl_transaction",
              "the operator needs to know which situation they are in"
 
-      assert error.message =~ "part-way removed"
+      assert error.message =~ "already committed",
+             "and that earlier drops are not coming back"
 
       refute error.message =~ "nothing was changed",
              "that would be false here"
+
+      refute error.message =~ "part-way removed",
+             "the failure can land on the first drop, so do not assert how much is gone"
     end
 
     test "both a graph and a host dependency name both steps" do

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -1221,14 +1221,22 @@ defmodule Arcana.MigrationTest do
              "the point is to replace the raw Postgres error, not quote it back"
     end
 
-    test "nothing was dropped when it refuses" do
+    test "it refuses before dropping anything" do
       assert :ok = migrate(Arcana.Migration)
       assert :ok = migrate(Arcana.Graph.Migration)
 
       assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
 
-      assert table_exists?("arcana_chunks"), "a refused rollback must change nothing"
-      assert table_exists?("arcana_documents")
+      # Ordering, not atomicity: the migration runs in a transaction, so a
+      # raise after a partial drop would roll back and these would still hold.
+      # What this pins is that the guard runs before any DDL does.
+      for table <- ~w(arcana_collections arcana_documents arcana_chunks
+                      arcana_evaluation_test_cases
+                      arcana_evaluation_test_case_chunks
+                      arcana_evaluation_runs) do
+        assert table_exists?(table), "#{table} should be untouched by a refused rollback"
+      end
+
       assert Arcana.Migration.recorded_version(Repo) == Arcana.Migration.current_version()
     end
 
@@ -1375,6 +1383,30 @@ defmodule Arcana.MigrationTest do
 
       assert error.message =~ "view",
              "and say what kind of thing this usually is"
+    end
+
+    test "a materialized view is explained too" do
+      # Same class as the plain view, different relkind. Worth its own case
+      # because the fix works by translating Postgres's error rather than by
+      # enumerating dependency kinds, and this is the check on that claim.
+      assert :ok = migrate(Arcana.Migration)
+
+      SQL.query!(Repo, "DROP MATERIALIZED VIEW IF EXISTS chunk_mv CASCADE", [])
+
+      on_exit(fn ->
+        SQL.query!(Repo, "DROP MATERIALIZED VIEW IF EXISTS chunk_mv CASCADE", [])
+      end)
+
+      SQL.query!(
+        Repo,
+        "CREATE MATERIALIZED VIEW chunk_mv AS SELECT id FROM arcana_chunks",
+        []
+      )
+
+      error = assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
+
+      assert error.message =~ "still depends on them"
+      assert error.message =~ "chunk_mv"
     end
 
     test "both a graph and a host dependency name both steps" do

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -73,6 +73,24 @@ defmodule Arcana.MigrationTest do
   # generated module rather than passed as a closure. Both directions go
   # through Migrator.up/4: `down` here means "the thing this migration
   # does is call Arcana.Migration.down/1", not a rollback of it.
+  # Same as run/3 but with @disable_ddl_transaction, so the DDL autocommits
+  # statement by statement instead of rolling back as a unit.
+  defp run_untransacted(module, direction, opts) do
+    name = :"Elixir.MigTestNT#{System.unique_integer([:positive])}"
+
+    body =
+      quote do
+        use Ecto.Migration
+
+        @disable_ddl_transaction true
+
+        def up, do: unquote(module).unquote(direction)(unquote(Macro.escape(opts)))
+      end
+
+    Module.create(name, body, Macro.Env.location(__ENV__))
+    Ecto.Migrator.up(Repo, System.unique_integer([:positive]), name, log: false)
+  end
+
   defp run(module, direction, opts) do
     name = :"Elixir.MigTest#{System.unique_integer([:positive])}"
 
@@ -1407,6 +1425,32 @@ defmodule Arcana.MigrationTest do
 
       assert error.message =~ "still depends on them"
       assert error.message =~ "chunk_mv"
+    end
+
+    test "a non-transactional rollback admits it left the schema part-way" do
+      # With @disable_ddl_transaction the earlier DROPs have already committed
+      # by the time a later one hits the dependency, so the schema really is
+      # part-way removed. Claiming "nothing was changed" there would send the
+      # operator looking in the wrong place.
+      assert :ok = migrate(Arcana.Migration)
+
+      SQL.query!(Repo, "DROP VIEW IF EXISTS chunk_nt CASCADE", [])
+      on_exit(fn -> SQL.query!(Repo, "DROP VIEW IF EXISTS chunk_nt CASCADE", []) end)
+
+      SQL.query!(Repo, "CREATE VIEW chunk_nt AS SELECT id FROM arcana_chunks", [])
+
+      error =
+        assert_raise RuntimeError, fn -> run_untransacted(Arcana.Migration, :down, []) end
+
+      assert error.message =~ "still depends on them"
+
+      assert error.message =~ "@disable_ddl_transaction",
+             "the operator needs to know which situation they are in"
+
+      assert error.message =~ "part-way removed"
+
+      refute error.message =~ "nothing was changed",
+             "that would be false here"
     end
 
     test "both a graph and a host dependency name both steps" do

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -1355,6 +1355,28 @@ defmodule Arcana.MigrationTest do
       assert error.message =~ "not Arcana's tables"
     end
 
+    test "a view is explained too, not just foreign keys" do
+      # A view is not a constraint, so the preflight cannot see it, and it
+      # blocks the DROP just as hard. Without the rescue this came back as a
+      # bare 2BP01 - exactly what this guard exists to replace.
+      assert :ok = migrate(Arcana.Migration)
+
+      SQL.query!(Repo, "DROP VIEW IF EXISTS chunk_peek CASCADE", [])
+      on_exit(fn -> SQL.query!(Repo, "DROP VIEW IF EXISTS chunk_peek CASCADE", []) end)
+
+      SQL.query!(Repo, "CREATE VIEW chunk_peek AS SELECT id FROM arcana_chunks", [])
+
+      error = assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
+
+      assert error.message =~ "still depends on them"
+
+      assert error.message =~ "chunk_peek",
+             "Postgres names the dependent object; the message should carry it through"
+
+      assert error.message =~ "view",
+             "and say what kind of thing this usually is"
+    end
+
     test "both a graph and a host dependency name both steps" do
       assert :ok = migrate(Arcana.Migration)
       assert :ok = migrate(Arcana.Graph.Migration)

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -1198,4 +1198,94 @@ defmodule Arcana.MigrationTest do
 
     match?([[true]], rows)
   end
+
+  describe "down/1 with tables that reference Arcana's" do
+    test "explains the GraphRAG schema instead of raising 2BP01" do
+      assert :ok = migrate(Arcana.Migration)
+      assert :ok = migrate(Arcana.Graph.Migration)
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Migration, [])
+        end
+
+      assert error.message =~ "other tables reference them"
+
+      assert error.message =~ "arcana_graph_entities -> arcana_chunks",
+             "the message should name the foreign key in the way"
+
+      assert error.message =~ "Arcana.Graph.Migration.down(",
+             "and name the call that unblocks it"
+
+      refute error.message =~ "2BP01 (dependent_objects_still_exist)",
+             "the point is to replace the raw Postgres error, not quote it back"
+    end
+
+    test "nothing was dropped when it refuses" do
+      assert :ok = migrate(Arcana.Migration)
+      assert :ok = migrate(Arcana.Graph.Migration)
+
+      assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
+
+      assert table_exists?("arcana_chunks"), "a refused rollback must change nothing"
+      assert table_exists?("arcana_documents")
+      assert Arcana.Migration.recorded_version(Repo) == Arcana.Migration.current_version()
+    end
+
+    test "a host table referencing arcana_chunks gets its own message" do
+      assert :ok = migrate(Arcana.Migration)
+
+      # on_exit rather than a drop at the end of the test: this test asserts a
+      # raise, so anything after it only runs when the assertion fails, and a
+      # leftover table then breaks every later run with a duplicate_table.
+      on_exit(fn ->
+        SQL.query!(Repo, "DROP TABLE IF EXISTS host_annotations CASCADE", [])
+      end)
+
+      # Dropped first as well as after: a stale one from an earlier failed run
+      # survives with its foreign key already cascaded away, so CREATE IF NOT
+      # EXISTS would leave this test with nothing to detect.
+      SQL.query!(Repo, "DROP TABLE IF EXISTS host_annotations CASCADE", [])
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE host_annotations (id serial primary key, " <>
+          "chunk_id uuid REFERENCES arcana_chunks(id))",
+        []
+      )
+
+      error = assert_raise RuntimeError, fn -> migrate_down(Arcana.Migration, []) end
+
+      assert error.message =~ "host_annotations -> arcana_chunks"
+
+      assert error.message =~ "not Arcana's tables",
+             "a host's own foreign key is not a GraphRAG problem"
+
+      refute error.message =~ "Arcana.Graph.Migration.down("
+    end
+
+    test "rolls back normally once the graph schema is gone" do
+      # The control: the guard has to let the supported order through, or it
+      # would just be a different way of making down/1 not work.
+      assert :ok = migrate(Arcana.Migration)
+      assert :ok = migrate(Arcana.Graph.Migration)
+      assert :ok = migrate_down(Arcana.Graph.Migration, [])
+      assert :ok = migrate_down(Arcana.Migration, [])
+
+      refute table_exists?("arcana_chunks")
+      refute table_exists?("arcana_collections")
+    end
+
+    test "a partial rollback that keeps the core tables is unaffected" do
+      # Only version 1's down drops them, so a rollback stopping above it has
+      # nothing to conflict with and must not be blocked.
+      assert :ok = migrate(Arcana.Migration)
+      assert :ok = migrate(Arcana.Graph.Migration)
+
+      assert :ok = migrate_down(Arcana.Migration, version: 1)
+
+      assert table_exists?("arcana_chunks")
+      assert table_exists?("arcana_graph_entities")
+    end
+  end
 end


### PR DESCRIPTION
`Arcana.Migration.down()` can't drop `arcana_chunks` while the GraphRAG schema is installed: the graph tables hold foreign keys onto it, and `on_delete:` governs row deletes so it does nothing for a `DROP TABLE`. You get this, naming a constraint you may never have heard of:

```
** (Postgrex.Error) ERROR 2BP01 (dependent_objects_still_exist)
cannot drop table arcana_chunks because other objects depend on it
constraint arcana_graph_entities_chunk_id_fkey on table arcana_graph_entities
depends on table arcana_chunks
```

Easy to reach by accident, too: an app that installed the graph earlier and has since stopped using GraphRAG still has the tables, so a routine `mix ecto.rollback` fails and the fix (`Arcana.Graph.Migration.down()` first) is only discoverable by reading library source.

`down/1` now looks for foreign keys pointing at the tables it is about to drop and raises a message naming both the constraints in the way and the call that clears them. Same spirit as `refuse_blind_rollback!/1` right next door, which already exists so that "you asked to remove tables that are really there" can't fail silently.

Two deliberate choices:

**Asked of `pg_constraint`, not matched against a list of graph table names.** A host is free to reference `arcana_chunks` from its own schema, and that fails identically today. It now gets the same explanation, with wording that doesn't blame GraphRAG.

**Only when the rollback target is 0.** Version 1's down is the only one that drops these tables, so `down(version: 1)` has nothing to conflict with and isn't blocked.

The owned-table list is now shared with `owned_tables_present/1` instead of being written out twice, so a table added to `change(1, :down, _)` has one place to be listed.

Five tests, in the existing real-database migration harness. Three fail on `main` with exactly the `2BP01` above; the other two are controls that pass either way (rolling back in the supported order still works, and a partial rollback to version 1 is untouched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Arcana.Migration.down/1` so a rollback blocked by anything depending on Arcana's tables gets an explanation instead of a raw Postgres 2BP01 error. A preflight names blocking foreign keys, their constraints, and the call that clears them; dependents the preflight can't see (views, materialized views, generated columns) are caught at DROP time and explained from Postgres's own report.

**Bug Fixes**
- The guard only runs when the rollback target is 0; partial rollbacks are unaffected.
- Host tables referencing `arcana_chunks` get the same explanation instead of a raw error.
- Dependency checks and graph detection are scoped to the target schema, so same-named tables elsewhere aren't mistaken for owned or graph tables; `current_schema/0` is NULL-guarded as well.
- When both graph and host tables block, the message names both clear steps.
- The owned-table list is shared between rollback guards to avoid duplication.
- The rescue flushes DDL inside the migration, safe because all migrations use `def up`/`def down`.
- Non-transactional rollbacks are warned before any drops; on failure, the message says earlier drops already committed and tells the operator to re-run after clearing the dependency, while a transactional failure says nothing was changed.

<sup>Written for commit fdb3ce1f6b816f04c34620327c9fa70027ca5606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

