### PR TITLE
fix!: Make Arcana.delete/2's error contract match its docs

### DIFF
--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -148,6 +148,19 @@ defmodule Arcana do
   through its own sweep may have applied some of it even though the
   document survives.
 
+  Called from inside your own transaction, this does not open one and does
+  not roll anything back — rolling back a nested Ecto transaction aborts the
+  outermost one, which would kill your transaction while handing you an error
+  that looks recoverable. So a `:sweep_failed` there comes back as a tuple
+  with your transaction intact, the delete still in its scope, and whether to
+  undo it your call to make with `rollback/1`.
+
+  A *database* failure is different, and not something this function can
+  soften: Postgres aborts the surrounding transaction on a constraint
+  violation, so inside your transaction that error ends it whatever is
+  returned. If you need to handle a foreign key violation and carry on, call
+  `delete/2` outside your transaction, where it manages its own.
+
   Sweeping is optional for custom graph stores: one that doesn't
   implement `c:Arcana.Graph.GraphStore.sweep_orphans/2` returns `:ok` and
   leaves the orphans alone.
@@ -178,22 +191,26 @@ defmodule Arcana do
   #
   # The sweep joins the same transaction so a failed cleanup no longer leaves
   # a deleted document behind it. Retrying is then the whole recovery.
+  # Two shapes on purpose. Standalone, this owns a transaction so a failed
+  # sweep takes the delete with it. Inside a caller's transaction, it must not:
+  # repo.rollback/1 in a nested Ecto transaction aborts the OUTERMOST one, so
+  # forcing it here would kill the caller's transaction while handing back a
+  # tuple that reads like a recoverable refusal. Their transaction already
+  # provides the atomicity, and the error is theirs to act on.
   defp delete_document(document, repo, opts) do
-    repo.transaction(fn ->
-      case repo.delete(document) do
-        {:ok, _deleted} ->
-          case GraphStore.maybe_sweep_orphans(document.collection_id, repo, opts) do
-            :ok -> :ok
-            {:error, reason} -> repo.rollback({:sweep_failed, reason})
-          end
-
-        {:error, changeset} ->
-          repo.rollback(changeset)
+    if repo.in_transaction?() do
+      delete_and_sweep(document, repo, opts)
+    else
+      repo.transaction(fn ->
+        case delete_and_sweep(document, repo, opts) do
+          :ok -> :ok
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, :ok} -> :ok
+        {:error, reason} -> {:error, reason}
       end
-    end)
-    |> case do
-      {:ok, :ok} -> :ok
-      {:error, reason} -> {:error, reason}
     end
   rescue
     # The row went away between the get and the delete. A concurrent deleter
@@ -209,5 +226,18 @@ defmodule Arcana do
     # promised a tuple for.
     error in Ecto.ConstraintError ->
       {:error, error}
+  end
+
+  defp delete_and_sweep(document, repo, opts) do
+    case repo.delete(document) do
+      {:ok, _deleted} ->
+        case GraphStore.maybe_sweep_orphans(document.collection_id, repo, opts) do
+          :ok -> :ok
+          {:error, reason} -> {:error, {:sweep_failed, reason}}
+        end
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 end

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -126,8 +126,8 @@ defmodule Arcana do
 
   Returns `:ok`, `{:error, :not_found}`, `{:error, {:sweep_failed, reason}}`
   when the graph store fails to sweep, or `{:error, reason}` for a database
-  failure such as a foreign key violation from another table pointing at the
-  document.
+  failure such as a foreign key violation, or a not-null violation from
+  another table pointing at the document.
 
   A concurrent delete reports `{:error, :not_found}`, the same as losing that
   race by a moment more would have.
@@ -143,10 +143,13 @@ defmodule Arcana do
   this case used to delete the document and report the failed cleanup
   afterwards.
 
-  The transaction covers what runs on `:repo`. A custom graph store that
-  keeps its data elsewhere is outside it, so a store that fails partway
-  through its own sweep may have applied some of it even though the
-  document survives.
+  The transaction covers what runs on `:repo`. A graph store holding its data
+  anywhere else is outside it — that includes the built-in `:memory` backend,
+  whose sweep is a `GenServer.call`, not only custom stores. So the two can
+  disagree in both directions: a store that fails partway through its own
+  sweep may have applied some of it even though the document survives, and a
+  store that sweeps successfully before the repo side rolls back has dropped
+  graph data for a document that is still there.
 
   Called from inside your own transaction, this does not open one and does
   not roll anything back — rolling back a nested Ecto transaction aborts the
@@ -225,6 +228,15 @@ defmodule Arcana do
     # arrive as Ecto.ConstraintError, which is the first case the docs
     # promised a tuple for.
     error in Ecto.ConstraintError ->
+      {:error, error}
+
+    # And Ecto only builds a ConstraintError out of fk/unique/check/exclusion
+    # codes. A host foreign key declared ON DELETE SET NULL against a NOT NULL
+    # column raises 23502 instead, and a host BEFORE DELETE trigger can raise
+    # anything - both are "another table pointing at the document", which the
+    # docs promise a tuple for. Postgrex.Error is SQL-level only, so a dropped
+    # connection or a pool timeout is a different struct and still raises.
+    error in Postgrex.Error ->
       {:error, error}
   end
 

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -129,11 +129,15 @@ defmodule Arcana do
   `{:error, reason}` for a database failure such as a foreign key violation,
   or a not-null violation from another table pointing at the document.
 
-  A sweep that *raises* rather than returning an error reports as a database
-  failure, not as `:sweep_failed` — so match `{:error, _}` as well if you
-  route on the sweep case. `sweep_orphans/2` deletes through
-  `repo.delete_all/1`, which skips changeset constraint mapping, so a host row
-  referencing an entity the sweep wants to remove arrives that way.
+  A sweep that raises a *database* error reports as a database failure rather
+  than as `:sweep_failed` — so match `{:error, _}` as well if you route on the
+  sweep case. `sweep_orphans/2` deletes through `repo.delete_all/1`, which
+  skips changeset constraint mapping, so a host row referencing an entity the
+  sweep wants to remove arrives that way.
+
+  Any other exception from a graph store propagates. A custom store raising
+  `RuntimeError` is a bug in that store, not a failure mode with a return
+  value, and swallowing it into `{:error, _}` would hide it.
 
   A concurrent delete reports `{:error, :not_found}`, the same as losing that
   race by a moment more would have.
@@ -276,7 +280,7 @@ defmodule Arcana do
   # regression from taking one transaction across both - repo.delete!/1 used to
   # autocommit and release the row locks before the sweep asked for anything.
   defp locked_delete(document, repo, opts) do
-    if sweeping?(document, opts) do
+    if sweeping?(document, opts) and ecto_graph_store?(opts) do
       GraphStore.with_write_lock(
         document.collection_id,
         Keyword.put(opts, :repo, repo),
@@ -291,6 +295,23 @@ defmodule Arcana do
   # sweep does not take a graph lock it has no use for.
   defp sweeping?(document, opts) do
     !is_nil(document.collection_id) and Arcana.Config.graph_enabled?(opts)
+  end
+
+  # Only the :ecto store. The lock is hoisted here to fix an ordering hazard
+  # between *that* store's advisory lock and the row locks the FK cascade
+  # takes, and pg_advisory_xact_lock is re-entrant within a transaction, so
+  # sweep_orphans/2 taking it again is free.
+  #
+  # A custom store's lock has no such hazard to fix - it does not contend with
+  # arcana_chunks row locks - and nothing says its with_write_lock/3 has to be
+  # re-entrant. Hoisting it there would buy nothing and could deadlock every
+  # graph-enabled delete against the sweep's own acquisition.
+  defp ecto_graph_store?(opts) do
+    case Keyword.get(opts, :graph_store, GraphStore.backend()) do
+      :ecto -> true
+      {:ecto, _opts} -> true
+      _other -> false
+    end
   end
 
   defp delete_and_sweep(document, repo, opts) do

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -181,11 +181,14 @@ defmodule Arcana do
         :ok -> Repo.query!("RELEASE SAVEPOINT before_delete")
       end
 
-  That recovers a failed `repo.delete` and a `:sweep_failed`. It cannot
-  recover an *exception* raised inside a custom graph store's sweep: that goes
-  through a nested `Ecto` transaction, which marks the connection aborted, and
-  the `ROLLBACK TO SAVEPOINT` is then refused too. Calling `delete/2` outside
-  your transaction avoids the whole question.
+  That recovers every failure the built-in stores can produce: a failed
+  `repo.delete`, a `:sweep_failed`, and a sweep that raises.
+
+  A custom graph store can still defeat it, by opening a nested `Ecto`
+  transaction of its own around work that then fails — DBConnection marks the
+  connection aborted, and the `ROLLBACK TO SAVEPOINT` is refused along with
+  everything else. Calling `delete/2` outside your transaction avoids the
+  question entirely.
 
   Sweeping is optional for custom graph stores: one that doesn't
   implement `c:Arcana.Graph.GraphStore.sweep_orphans/2` returns `:ok` and

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -124,11 +124,29 @@ defmodule Arcana do
   communities that referenced them are marked dirty so the next
   summarize pass regenerates them.
 
-  Returns `:ok`, `{:error, :not_found}`, or `{:error, {:sweep_failed,
-  reason}}` when the graph store fails to sweep. In the `:sweep_failed`
-  case the document and its chunks ARE deleted — only the orphan cleanup
-  failed, so the collection may hold entities with zero mentions until
-  the next sweep.
+  Returns `:ok`, `{:error, :not_found}`, `{:error, {:sweep_failed, reason}}`
+  when the graph store fails to sweep, or `{:error, reason}` for a database
+  failure such as a foreign key violation from another table pointing at the
+  document.
+
+  A concurrent delete reports `{:error, :not_found}`, the same as losing that
+  race by a moment more would have.
+
+  Infrastructure failures — a lost connection, a pool timeout — still raise.
+  There is nothing useful to hand back and the transaction's fate is unknown,
+  so those are left to the caller's supervisor rather than flattened into a
+  tuple that would read like a clean refusal.
+
+  The delete and the orphan sweep run in one transaction, so a
+  `:sweep_failed` leaves the document in place: nothing happened and the
+  call can be retried. That is worth knowing if you are upgrading, because
+  this case used to delete the document and report the failed cleanup
+  afterwards.
+
+  The transaction covers what runs on `:repo`. A custom graph store that
+  keeps its data elsewhere is outside it, so a store that fails partway
+  through its own sweep may have applied some of it even though the
+  document survives.
 
   Sweeping is optional for custom graph stores: one that doesn't
   implement `c:Arcana.Graph.GraphStore.sweep_orphans/2` returns `:ok` and
@@ -148,12 +166,48 @@ defmodule Arcana do
         {:error, :not_found}
 
       document ->
-        repo.delete!(document)
-
-        case GraphStore.maybe_sweep_orphans(document.collection_id, repo, opts) do
-          :ok -> :ok
-          {:error, reason} -> {:error, {:sweep_failed, reason}}
-        end
+        delete_document(document, repo, opts)
     end
+  end
+
+  # repo.delete!/1 used to raise straight out of a function whose docs
+  # promised error tuples, so a caller's case never saw a constraint
+  # violation or a dropped connection. Callers sequence their own cleanup
+  # around this call - removing a stored original, cancelling jobs - and had
+  # no reason to expect control to leave abruptly.
+  #
+  # The sweep joins the same transaction so a failed cleanup no longer leaves
+  # a deleted document behind it. Retrying is then the whole recovery.
+  defp delete_document(document, repo, opts) do
+    repo.transaction(fn ->
+      case repo.delete(document) do
+        {:ok, _deleted} ->
+          case GraphStore.maybe_sweep_orphans(document.collection_id, repo, opts) do
+            :ok -> :ok
+            {:error, reason} -> repo.rollback({:sweep_failed, reason})
+          end
+
+        {:error, changeset} ->
+          repo.rollback(changeset)
+      end
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  rescue
+    # The row went away between the get and the delete. A concurrent deleter
+    # got there first, which is the same outcome the caller would have seen
+    # had it lost the race by a moment more.
+    Ecto.StaleEntryError ->
+      {:error, :not_found}
+
+    # repo.delete/1 only returns {:error, changeset} for a constraint the
+    # changeset declared, and a host is free to point a foreign key at
+    # arcana_documents from a table this library has never heard of. Those
+    # arrive as Ecto.ConstraintError, which is the first case the docs
+    # promised a tuple for.
+    error in Ecto.ConstraintError ->
+      {:error, error}
   end
 end

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -125,9 +125,15 @@ defmodule Arcana do
   summarize pass regenerates them.
 
   Returns `:ok`, `{:error, :not_found}`, `{:error, {:sweep_failed, reason}}`
-  when the graph store fails to sweep, or `{:error, reason}` for a database
-  failure such as a foreign key violation, or a not-null violation from
-  another table pointing at the document.
+  when the graph store *returns* an error from its sweep, or
+  `{:error, reason}` for a database failure such as a foreign key violation,
+  or a not-null violation from another table pointing at the document.
+
+  A sweep that *raises* rather than returning an error reports as a database
+  failure, not as `:sweep_failed` — so match `{:error, _}` as well if you
+  route on the sweep case. `sweep_orphans/2` deletes through
+  `repo.delete_all/1`, which skips changeset constraint mapping, so a host row
+  referencing an entity the sweep wants to remove arrives that way.
 
   A concurrent delete reports `{:error, :not_found}`, the same as losing that
   race by a moment more would have.
@@ -137,11 +143,12 @@ defmodule Arcana do
   so those are left to the caller's supervisor rather than flattened into a
   tuple that would read like a clean refusal.
 
-  The delete and the orphan sweep run in one transaction, so a
-  `:sweep_failed` leaves the document in place: nothing happened and the
+  Called on its own, the delete and the orphan sweep run in one transaction,
+  so a `:sweep_failed` leaves the document in place: nothing happened and the
   call can be retried. That is worth knowing if you are upgrading, because
   this case used to delete the document and report the failed cleanup
-  afterwards.
+  afterwards. Inside a transaction of your own it behaves differently — see
+  below.
 
   The transaction covers what runs on `:repo`. A graph store holding its data
   anywhere else is outside it — that includes the built-in `:memory` backend,
@@ -151,18 +158,34 @@ defmodule Arcana do
   store that sweeps successfully before the repo side rolls back has dropped
   graph data for a document that is still there.
 
-  Called from inside your own transaction, this does not open one and does
-  not roll anything back — rolling back a nested Ecto transaction aborts the
-  outermost one, which would kill your transaction while handing you an error
-  that looks recoverable. So a `:sweep_failed` there comes back as a tuple
-  with your transaction intact, the delete still in its scope, and whether to
-  undo it your call to make with `rollback/1`.
+  ## Inside a transaction of your own
 
-  A *database* failure is different, and not something this function can
-  soften: Postgres aborts the surrounding transaction on a constraint
-  violation, so inside your transaction that error ends it whatever is
-  returned. If you need to handle a foreign key violation and carry on, call
-  `delete/2` outside your transaction, where it manages its own.
+  It does not open one, and it does not roll anything back: rolling back a
+  nested Ecto transaction aborts the outermost one, which would kill your
+  transaction while handing you an error that looks recoverable.
+
+  So the guarantee above is weaker here. A `:sweep_failed` comes back as a
+  tuple with your transaction intact, but **the delete has been applied** and
+  stays in your transaction's scope — undoing it is yours to do. That is the
+  one place where `:sweep_failed` does not mean "nothing happened".
+
+  A database failure is harsher: Postgres aborts to the nearest savepoint, and
+  with none open that is the whole transaction, so the error ends it whatever
+  gets returned. If you need to survive one, set your own savepoint around the
+  call:
+
+      Repo.query!("SAVEPOINT before_delete")
+
+      case Arcana.delete(id, repo: Repo) do
+        {:error, _reason} -> Repo.query!("ROLLBACK TO SAVEPOINT before_delete")
+        :ok -> Repo.query!("RELEASE SAVEPOINT before_delete")
+      end
+
+  That recovers a failed `repo.delete` and a `:sweep_failed`. It cannot
+  recover an *exception* raised inside a custom graph store's sweep: that goes
+  through a nested `Ecto` transaction, which marks the connection aborted, and
+  the `ROLLBACK TO SAVEPOINT` is then refused too. Calling `delete/2` outside
+  your transaction avoids the whole question.
 
   Sweeping is optional for custom graph stores: one that doesn't
   implement `c:Arcana.Graph.GraphStore.sweep_orphans/2` returns `:ok` and
@@ -202,10 +225,10 @@ defmodule Arcana do
   # provides the atomicity, and the error is theirs to act on.
   defp delete_document(document, repo, opts) do
     if repo.in_transaction?() do
-      delete_and_sweep(document, repo, opts)
+      locked_delete(document, repo, opts)
     else
       repo.transaction(fn ->
-        case delete_and_sweep(document, repo, opts) do
+        case locked_delete(document, repo, opts) do
           :ok -> :ok
           {:error, reason} -> repo.rollback(reason)
         end
@@ -240,16 +263,55 @@ defmodule Arcana do
       {:error, error}
   end
 
+  # The advisory lock goes first, before any row locks, because that is the
+  # order the build side takes them (Arcana.Graph.persist_chunk_graph/6 holds
+  # the write lock and then writes mentions that reference arcana_chunks).
+  #
+  # Deleting first and sweeping second reverses it: the cascade holds chunk row
+  # locks, then asks for the advisory lock a concurrent build already has,
+  # while that build waits on the chunk rows. That deadlocks, and it is a
+  # regression from taking one transaction across both - repo.delete!/1 used to
+  # autocommit and release the row locks before the sweep asked for anything.
+  defp locked_delete(document, repo, opts) do
+    if sweeping?(document, opts) do
+      GraphStore.with_write_lock(
+        document.collection_id,
+        Keyword.put(opts, :repo, repo),
+        fn -> delete_and_sweep(document, repo, opts) end
+      )
+    else
+      delete_and_sweep(document, repo, opts)
+    end
+  end
+
+  # The same condition maybe_sweep_orphans/3 uses, so a delete that will not
+  # sweep does not take a graph lock it has no use for.
+  defp sweeping?(document, opts) do
+    !is_nil(document.collection_id) and Arcana.Config.graph_enabled?(opts)
+  end
+
   defp delete_and_sweep(document, repo, opts) do
     case repo.delete(document) do
       {:ok, _deleted} ->
-        case GraphStore.maybe_sweep_orphans(document.collection_id, repo, opts) do
-          :ok -> :ok
-          {:error, reason} -> {:error, {:sweep_failed, reason}}
-        end
+        sweep(document, repo, opts)
 
       {:error, changeset} ->
         {:error, changeset}
+    end
+  end
+
+  # :sweep_failed is for a store that *returns* an error. One that raises is
+  # deliberately not folded into it: the exception happens inside the write
+  # lock's own nested transaction, so DBConnection has already marked the
+  # connection aborted by the time anything here could catch it, and rescuing
+  # at this depth only turned the error into a MatchError on with_write_lock's
+  # `{:ok, result} =`. Left to propagate, the outer rescue reports it as the
+  # database error it is, with the transaction rolled back and the document
+  # intact. Documented on delete/2 rather than papered over.
+  defp sweep(document, repo, opts) do
+    case GraphStore.maybe_sweep_orphans(document.collection_id, repo, opts) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:sweep_failed, reason}}
     end
   end
 end

--- a/lib/arcana/graph/graph_store/ecto.ex
+++ b/lib/arcana/graph/graph_store/ecto.ex
@@ -352,21 +352,36 @@ defmodule Arcana.Graph.GraphStore.Ecto do
 
   Keep the wrapped work to DB writes: the lock blocks every concurrent
   graph write for the collection until the transaction commits.
+
+  Opens a transaction only when there isn't one already. A nested Ecto
+  transaction never isolated anything - it joins the outer one - but it does
+  make DBConnection mark the connection aborted when the wrapped work fails,
+  which refuses every later statement including a caller's
+  `ROLLBACK TO SAVEPOINT`. Skipping it costs nothing, because
+  `pg_advisory_xact_lock/1` binds to the enclosing transaction either way.
   """
   @impl true
   def with_write_lock(collection_id, opts, fun) when is_function(fun, 0) do
     repo = Keyword.fetch!(opts, :repo)
 
-    {:ok, result} =
-      repo.transaction(fn ->
-        repo.query!("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
-          "arcana:graph:#{collection_id}"
-        ])
+    if repo.in_transaction?() do
+      take_write_lock(repo, collection_id)
+      fun.()
+    else
+      {:ok, result} =
+        repo.transaction(fn ->
+          take_write_lock(repo, collection_id)
+          fun.()
+        end)
 
-        fun.()
-      end)
+      result
+    end
+  end
 
-    result
+  defp take_write_lock(repo, collection_id) do
+    repo.query!("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+      "arcana:graph:#{collection_id}"
+    ])
   end
 
   @doc """

--- a/test/arcana/delete_contract_ddl_test.exs
+++ b/test/arcana/delete_contract_ddl_test.exs
@@ -105,6 +105,84 @@ defmodule Arcana.DeleteContractDDLTest do
     assert count >= 1, "the caller's transaction committed and the document is still there"
   end
 
+  test "a savepoint works with the graph enabled too" do
+    # The graph-off version above passed while this one failed, because the
+    # sweeping branch wraps the delete in the graph write lock and that used to
+    # open a nested Ecto transaction. DBConnection marks the connection aborted
+    # when work inside one fails, which refused the ROLLBACK TO SAVEPOINT and
+    # took the caller's pooled connection with it. Since every ingest lands in
+    # a collection, "graph enabled" was the whole audience for the documented
+    # recipe.
+    extractor = fn _t, _o -> {:ok, [%{name: "Tau", type: "concept"}]} end
+
+    {:ok, doc} =
+      Arcana.ingest("tau content",
+        repo: Repo,
+        graph: true,
+        entity_extractor: extractor,
+        collection: "savepoint-graph-on"
+      )
+
+    reference_document("host_refs_sp_graph", doc)
+
+    result =
+      Repo.transaction(fn ->
+        Repo.query!("SAVEPOINT before_delete")
+
+        outcome = Arcana.delete(doc.id, repo: Repo, graph: true)
+
+        Repo.query!("ROLLBACK TO SAVEPOINT before_delete")
+
+        {outcome, Repo.aggregate(Arcana.Document, :count)}
+      end)
+
+    assert {:ok, {{:error, _reason}, count}} = result
+    assert count >= 1, "the caller's transaction survived and committed"
+  end
+
+  test "a savepoint recovers even a sweep that raises" do
+    # The docs claim the recipe covers every failure the built-in stores can
+    # produce, this being the least obvious one. It only holds because
+    # with_write_lock/3 no longer opens a nested transaction; before that the
+    # ROLLBACK TO SAVEPOINT was refused here too.
+    extractor = fn _t, _o -> {:ok, [%{name: "Omega", type: "concept"}]} end
+
+    {:ok, doc} =
+      Arcana.ingest("omega content",
+        repo: Repo,
+        graph: true,
+        entity_extractor: extractor,
+        collection: "savepoint-sweep-raises"
+      )
+
+    entity = Repo.one!(from(e in Arcana.Graph.Entity, where: e.name == "Omega"))
+
+    SQL.query!(
+      Repo,
+      "CREATE TABLE host_entity_refs_sp (id serial primary key, " <>
+        "entity_id uuid REFERENCES arcana_graph_entities(id))",
+      []
+    )
+
+    SQL.query!(Repo, "INSERT INTO host_entity_refs_sp (entity_id) VALUES ($1)", [
+      Ecto.UUID.dump!(entity.id)
+    ])
+
+    result =
+      Repo.transaction(fn ->
+        Repo.query!("SAVEPOINT before_delete")
+
+        outcome = Arcana.delete(doc.id, repo: Repo, graph: true)
+
+        Repo.query!("ROLLBACK TO SAVEPOINT before_delete")
+
+        {outcome, Repo.aggregate(Arcana.Document, :count)}
+      end)
+
+    assert {:ok, {{:error, %Postgrex.Error{}}, count}} = result
+    assert count >= 1, "the caller's transaction survived and committed"
+  end
+
   test "a sweep that raises on a host constraint is a tuple, not an exception" do
     # sweep_orphans/2 deletes with repo.delete_all/1, which skips changeset
     # constraint mapping, so a host row referencing an orphaned entity raises a

--- a/test/arcana/delete_contract_ddl_test.exs
+++ b/test/arcana/delete_contract_ddl_test.exs
@@ -71,14 +71,72 @@ defmodule Arcana.DeleteContractDDLTest do
     assert Repo.get(Arcana.Document, doc.id)
   end
 
-  test "a database failure ends the caller's transaction, as documented" do
-    # Not a defect being pinned, a limitation being held to. Postgres aborts
-    # the surrounding transaction on error, so no return value can make this
-    # recoverable. The docs say so; this keeps them true.
+  test "a database failure ends a caller's transaction that set no savepoint" do
+    # Postgres aborts to the nearest savepoint, and with none open that is the
+    # whole transaction. Not a defect, but see the next test: it is the absence
+    # of a savepoint doing this, not something delete/2 cannot be recovered
+    # from, which is what the docs used to imply.
     doc = ingest_doc()
     reference_document("host_refs_txn", doc)
 
     assert {:error, :rollback} =
              Repo.transaction(fn -> Arcana.delete(doc.id, repo: Repo) end)
+  end
+
+  test "a savepoint lets the caller survive a database failure" do
+    # The documented recovery. Worth a test because the docs previously called
+    # this unrecoverable and told people to restructure their code instead.
+    doc = ingest_doc()
+    reference_document("host_refs_sp", doc)
+
+    result =
+      Repo.transaction(fn ->
+        Repo.query!("SAVEPOINT before_delete")
+
+        outcome = Arcana.delete(doc.id, repo: Repo)
+
+        Repo.query!("ROLLBACK TO SAVEPOINT before_delete")
+
+        # The point: still usable after the failure.
+        {outcome, Repo.aggregate(Arcana.Document, :count)}
+      end)
+
+    assert {:ok, {{:error, _reason}, count}} = result
+    assert count >= 1, "the caller's transaction committed and the document is still there"
+  end
+
+  test "a sweep that raises on a host constraint is a tuple, not an exception" do
+    # sweep_orphans/2 deletes with repo.delete_all/1, which skips changeset
+    # constraint mapping, so a host row referencing an orphaned entity raises a
+    # bare Postgrex.Error. It reports as a database failure rather than
+    # :sweep_failed - folding it into :sweep_failed means rescuing inside the
+    # write lock's nested transaction, which is already aborted by then and
+    # turns the error into a MatchError. The docs say which one you get.
+    extractor = fn _t, _o -> {:ok, [%{name: "Sigma", type: "concept"}]} end
+
+    {:ok, doc} =
+      Arcana.ingest("sigma content",
+        repo: Repo,
+        graph: true,
+        entity_extractor: extractor,
+        collection: "sweep-host-fk"
+      )
+
+    entity = Repo.one!(from(e in Arcana.Graph.Entity, where: e.name == "Sigma"))
+
+    SQL.query!(
+      Repo,
+      "CREATE TABLE host_entity_refs (id serial primary key, " <>
+        "entity_id uuid REFERENCES arcana_graph_entities(id))",
+      []
+    )
+
+    SQL.query!(Repo, "INSERT INTO host_entity_refs (entity_id) VALUES ($1)", [
+      Ecto.UUID.dump!(entity.id)
+    ])
+
+    assert {:error, %Postgrex.Error{}} = Arcana.delete(doc.id, repo: Repo, graph: true)
+
+    assert Repo.get(Arcana.Document, doc.id), "the document comes back"
   end
 end

--- a/test/arcana/delete_contract_ddl_test.exs
+++ b/test/arcana/delete_contract_ddl_test.exs
@@ -1,0 +1,84 @@
+defmodule Arcana.DeleteContractDDLTest do
+  @moduledoc """
+  The `Arcana.delete/2` cases that need a host table pointing at
+  `arcana_documents`.
+
+  `async: false` deliberately. Adding a foreign key onto `arcana_documents`
+  takes a `ShareRowExclusiveLock` on it, and the sandbox holds that until the
+  test's transaction ends rather than just for the DDL. That conflicts with
+  the `RowExclusiveLock` every document insert takes, so running these
+  alongside the async suite blocks any concurrent test that writes documents -
+  contention rather than deadlock, but a suite-wide serialization point and
+  one more way a loaded CI run drifts toward the ownership timeout.
+
+  Table names are unique per test for the same reason a shared `host_refs`
+  would eventually collide.
+  """
+  use Arcana.DataCase, async: false
+
+  alias Ecto.Adapters.SQL
+
+  defp ingest_doc do
+    {:ok, doc} = Arcana.ingest("Elixir runs on the BEAM.", repo: Repo)
+    doc
+  end
+
+  defp reference_document(table, doc, column_opts \\ "") do
+    SQL.query!(
+      Repo,
+      "CREATE TABLE #{table} (id serial primary key, " <>
+        "document_id uuid #{column_opts} REFERENCES arcana_documents(id))",
+      []
+    )
+
+    SQL.query!(Repo, "INSERT INTO #{table} (document_id) VALUES ($1)", [
+      Ecto.UUID.dump!(doc.id)
+    ])
+  end
+
+  test "a foreign key violation is an error tuple, not an exception" do
+    doc = ingest_doc()
+    reference_document("host_refs_fk", doc)
+
+    assert {:error, reason} = Arcana.delete(doc.id, repo: Repo)
+
+    refute reason == :not_found, "a constraint violation is not a missing document"
+
+    assert Repo.get(Arcana.Document, doc.id),
+           "the document must survive a failed delete"
+  end
+
+  test "a not-null violation from a host table is a tuple too" do
+    # Ecto only turns fk/unique/check/exclusion codes into Ecto.ConstraintError.
+    # ON DELETE SET NULL against a NOT NULL column raises 23502 instead, and it
+    # is squarely "another table pointing at the document", which the docs
+    # promise a tuple for. Rescuing only ConstraintError let this one escape.
+    doc = ingest_doc()
+
+    SQL.query!(
+      Repo,
+      "CREATE TABLE host_refs_nn (id serial primary key, " <>
+        "document_id uuid NOT NULL REFERENCES arcana_documents(id) ON DELETE SET NULL)",
+      []
+    )
+
+    SQL.query!(Repo, "INSERT INTO host_refs_nn (document_id) VALUES ($1)", [
+      Ecto.UUID.dump!(doc.id)
+    ])
+
+    assert {:error, %Postgrex.Error{}} = Arcana.delete(doc.id, repo: Repo)
+
+    assert Repo.get(Arcana.Document, doc.id)
+  end
+
+  test "a database failure ends the caller's transaction, as documented" do
+    # Not a defect being pinned, a limitation being held to. Postgres aborts
+    # the surrounding transaction on error, so no return value can make this
+    # recoverable. The docs say so; this keeps them true.
+    doc = ingest_doc()
+    reference_document("host_refs_txn", doc)
+
+    assert {:error, :rollback} =
+             Repo.transaction(fn -> Arcana.delete(doc.id, repo: Repo) end)
+  end
+end

--- a/test/arcana/delete_contract_test.exs
+++ b/test/arcana/delete_contract_test.exs
@@ -8,10 +8,13 @@ defmodule Arcana.DeleteContractTest do
   not the exception itself but the sequencing around it: callers remove an
   external artifact and then call this, and a three-clause `case` written
   from the docs gave them no reason to expect control to leave abruptly.
+
+  The cases needing a host table with a foreign key onto `arcana_documents`
+  live in `Arcana.DeleteContractDDLTest` instead, because creating that
+  constraint takes a `ShareRowExclusiveLock` on `arcana_documents` for the
+  whole test and would serialize every async test that writes documents.
   """
   use Arcana.DataCase, async: true
-
-  alias Ecto.Adapters.SQL
 
   defp ingest_doc(text \\ "Elixir runs on the BEAM.") do
     {:ok, doc} = Arcana.ingest(text, repo: Repo)
@@ -29,33 +32,6 @@ defmodule Arcana.DeleteContractTest do
     test "an unknown id is :not_found" do
       assert {:error, :not_found} = Arcana.delete(Ecto.UUID.generate(), repo: Repo)
     end
-  end
-
-  describe "database failures come back as tuples" do
-    test "a foreign key violation is an error tuple, not an exception" do
-      doc = ingest_doc()
-
-      # A host table referencing the document with no cascade: deleting the
-      # document is a constraint violation, which repo.delete!/1 raised.
-      SQL.query!(
-        Repo,
-        "CREATE TABLE host_refs (id serial primary key, " <>
-          "document_id uuid REFERENCES arcana_documents(id))",
-        []
-      )
-
-      SQL.query!(Repo, "INSERT INTO host_refs (document_id) VALUES ($1)", [
-        Ecto.UUID.dump!(doc.id)
-      ])
-
-      assert {:error, reason} = Arcana.delete(doc.id, repo: Repo)
-
-      refute reason == :not_found,
-             "a constraint violation is not a missing document"
-
-      assert Repo.get(Arcana.Document, doc.id),
-             "the document must survive a failed delete"
-    end
 
     test "a document deleted out from under us reads as :not_found" do
       # This lands on the repo.get/2 branch, not the Ecto.StaleEntryError
@@ -66,13 +42,8 @@ defmodule Arcana.DeleteContractTest do
       # :not_found either way, which is the contract being pinned here.
       doc = ingest_doc()
 
-      SQL.query!(Repo, "DELETE FROM arcana_chunks WHERE document_id = $1", [
-        Ecto.UUID.dump!(doc.id)
-      ])
-
-      SQL.query!(Repo, "DELETE FROM arcana_documents WHERE id = $1", [
-        Ecto.UUID.dump!(doc.id)
-      ])
+      Repo.delete_all(from(c in Arcana.Chunk, where: c.document_id == ^doc.id))
+      Repo.delete_all(from(d in Arcana.Document, where: d.id == ^doc.id))
 
       assert {:error, :not_found} = Arcana.delete(doc.id, repo: Repo)
     end
@@ -104,44 +75,52 @@ defmodule Arcana.DeleteContractTest do
 
       assert {:ok, {{:error, {:sweep_failed, :sweep_boom}}, _count}} = result
     end
-
-    test "a database failure ends the caller's transaction, as documented" do
-      # Not a defect being pinned, a limitation being held to. Postgres aborts
-      # the surrounding transaction on a constraint violation, so no return
-      # value can make this recoverable. The docs say so; this keeps them true.
-      doc = ingest_doc()
-
-      SQL.query!(
-        Repo,
-        "CREATE TABLE host_refs_txn (id serial primary key, " <>
-          "document_id uuid REFERENCES arcana_documents(id))",
-        []
-      )
-
-      SQL.query!(Repo, "INSERT INTO host_refs_txn (document_id) VALUES ($1)", [
-        Ecto.UUID.dump!(doc.id)
-      ])
-
-      assert {:error, :rollback} =
-               Repo.transaction(fn -> Arcana.delete(doc.id, repo: Repo) end)
-    end
   end
 
   describe "the delete and the sweep are one unit" do
     test "chunks go with the document" do
       doc = ingest_doc("Elixir runs on the BEAM virtual machine, which is Erlang's.")
 
-      assert Repo.aggregate(
-               from(c in Arcana.Chunk, where: c.document_id == ^doc.id),
-               :count
-             ) > 0
+      chunks = fn ->
+        Repo.aggregate(from(c in Arcana.Chunk, where: c.document_id == ^doc.id), :count)
+      end
+
+      assert chunks.() > 0
 
       assert :ok = Arcana.delete(doc.id, repo: Repo)
 
-      assert Repo.aggregate(
-               from(c in Arcana.Chunk, where: c.document_id == ^doc.id),
-               :count
-             ) == 0
+      assert chunks.() == 0
+    end
+
+    test "a failed sweep puts the chunks back too, not just the document" do
+      # A rollback restoring the document without its chunks would be worse
+      # than the old behaviour, which at least left nothing half-deleted.
+      extractor = fn _t, _o -> {:ok, [%{name: "Beta", type: "concept"}]} end
+
+      opts = [
+        repo: Repo,
+        graph: true,
+        graph_store: Arcana.FailingSweepGraphStore,
+        collection: "delete-contract-chunks"
+      ]
+
+      {:ok, doc} =
+        Arcana.ingest(
+          "beta content that is long enough to chunk",
+          Keyword.put(opts, :entity_extractor, extractor)
+        )
+
+      chunks = fn ->
+        Repo.aggregate(from(c in Arcana.Chunk, where: c.document_id == ^doc.id), :count)
+      end
+
+      before = chunks.()
+      assert before > 0
+
+      assert {:error, {:sweep_failed, :sweep_boom}} = Arcana.delete(doc.id, opts)
+
+      assert Repo.get(Arcana.Document, doc.id), "the document comes back"
+      assert chunks.() == before, "and so do its chunks"
     end
   end
 end

--- a/test/arcana/delete_contract_test.exs
+++ b/test/arcana/delete_contract_test.exs
@@ -1,0 +1,98 @@
+defmodule Arcana.DeleteContractTest do
+  @moduledoc """
+  `Arcana.delete/2` returning what its docs promise.
+
+  It used to call `repo.delete!/1`, so a foreign key violation or a
+  concurrent delete escaped as an exception from a function documenting
+  `:ok | {:error, :not_found} | {:error, {:sweep_failed, _}}`. The damage was
+  not the exception itself but the sequencing around it: callers remove an
+  external artifact and then call this, and a three-clause `case` written
+  from the docs gave them no reason to expect control to leave abruptly.
+  """
+  use Arcana.DataCase, async: true
+
+  alias Ecto.Adapters.SQL
+
+  defp ingest_doc(text \\ "Elixir runs on the BEAM.") do
+    {:ok, doc} = Arcana.ingest(text, repo: Repo)
+    doc
+  end
+
+  describe "the documented happy paths still hold" do
+    test "deleting a document returns :ok and removes it" do
+      doc = ingest_doc()
+
+      assert :ok = Arcana.delete(doc.id, repo: Repo)
+      refute Repo.get(Arcana.Document, doc.id)
+    end
+
+    test "an unknown id is :not_found" do
+      assert {:error, :not_found} = Arcana.delete(Ecto.UUID.generate(), repo: Repo)
+    end
+  end
+
+  describe "database failures come back as tuples" do
+    test "a foreign key violation is an error tuple, not an exception" do
+      doc = ingest_doc()
+
+      # A host table referencing the document with no cascade: deleting the
+      # document is a constraint violation, which repo.delete!/1 raised.
+      SQL.query!(
+        Repo,
+        "CREATE TABLE host_refs (id serial primary key, " <>
+          "document_id uuid REFERENCES arcana_documents(id))",
+        []
+      )
+
+      SQL.query!(Repo, "INSERT INTO host_refs (document_id) VALUES ($1)", [
+        Ecto.UUID.dump!(doc.id)
+      ])
+
+      assert {:error, reason} = Arcana.delete(doc.id, repo: Repo)
+
+      refute reason == :not_found,
+             "a constraint violation is not a missing document"
+
+      assert Repo.get(Arcana.Document, doc.id),
+             "the document must survive a failed delete"
+    end
+
+    test "a document deleted out from under us reads as :not_found" do
+      # This lands on the repo.get/2 branch, not the Ecto.StaleEntryError
+      # rescue: the row is already gone by the time delete/2 looks for it.
+      # Forcing the actual race - present at the lookup, gone at the delete -
+      # needs an interleave inside delete/2 that the sandbox cannot arrange,
+      # so the rescue itself is defensive and uncovered. It reports the same
+      # :not_found either way, which is the contract being pinned here.
+      doc = ingest_doc()
+
+      SQL.query!(Repo, "DELETE FROM arcana_chunks WHERE document_id = $1", [
+        Ecto.UUID.dump!(doc.id)
+      ])
+
+      SQL.query!(Repo, "DELETE FROM arcana_documents WHERE id = $1", [
+        Ecto.UUID.dump!(doc.id)
+      ])
+
+      assert {:error, :not_found} = Arcana.delete(doc.id, repo: Repo)
+    end
+  end
+
+  describe "the delete and the sweep are one unit" do
+    test "chunks go with the document" do
+      doc = ingest_doc("Elixir runs on the BEAM virtual machine, which is Erlang's.")
+
+      assert Repo.aggregate(
+               from(c in Arcana.Chunk, where: c.document_id == ^doc.id),
+               :count
+             ) > 0
+
+      assert :ok = Arcana.delete(doc.id, repo: Repo)
+
+      assert Repo.aggregate(
+               from(c in Arcana.Chunk, where: c.document_id == ^doc.id),
+               :count
+             ) == 0
+    end
+  end
+end

--- a/test/arcana/delete_contract_test.exs
+++ b/test/arcana/delete_contract_test.exs
@@ -78,6 +78,55 @@ defmodule Arcana.DeleteContractTest do
     end
   end
 
+  describe "inside a caller's own transaction" do
+    test "a failed sweep does not destroy the caller's transaction" do
+      # repo.rollback/1 in a nested Ecto transaction aborts the OUTERMOST one,
+      # so opening a transaction here unconditionally killed the caller's while
+      # handing back a tuple that reads like a recoverable refusal.
+      extractor = fn _t, _o -> {:ok, [%{name: "Alpha", type: "concept"}]} end
+
+      opts = [
+        repo: Repo,
+        graph: true,
+        graph_store: Arcana.FailingSweepGraphStore,
+        collection: "delete-contract-sweep"
+      ]
+
+      {:ok, doc} = Arcana.ingest("alpha", Keyword.put(opts, :entity_extractor, extractor))
+
+      result =
+        Repo.transaction(fn ->
+          deleted = Arcana.delete(doc.id, opts)
+
+          # Still able to work: the point is the caller keeps their transaction.
+          {deleted, Repo.aggregate(Arcana.Document, :count)}
+        end)
+
+      assert {:ok, {{:error, {:sweep_failed, :sweep_boom}}, _count}} = result
+    end
+
+    test "a database failure ends the caller's transaction, as documented" do
+      # Not a defect being pinned, a limitation being held to. Postgres aborts
+      # the surrounding transaction on a constraint violation, so no return
+      # value can make this recoverable. The docs say so; this keeps them true.
+      doc = ingest_doc()
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE host_refs_txn (id serial primary key, " <>
+          "document_id uuid REFERENCES arcana_documents(id))",
+        []
+      )
+
+      SQL.query!(Repo, "INSERT INTO host_refs_txn (document_id) VALUES ($1)", [
+        Ecto.UUID.dump!(doc.id)
+      ])
+
+      assert {:error, :rollback} =
+               Repo.transaction(fn -> Arcana.delete(doc.id, repo: Repo) end)
+    end
+  end
+
   describe "the delete and the sweep are one unit" do
     test "chunks go with the document" do
       doc = ingest_doc("Elixir runs on the BEAM virtual machine, which is Erlang's.")

--- a/test/arcana/graph_integration_test.exs
+++ b/test/arcana/graph_integration_test.exs
@@ -662,7 +662,7 @@ defmodule Arcana.GraphIntegrationTest do
       refute "OldEntity" in names
     end
 
-    test "propagates a failing sweep after the document is already deleted" do
+    test "a failing sweep rolls the delete back rather than half-finishing" do
       extractor = fn _text, _opts -> {:ok, [%{name: "Delta", type: "concept"}]} end
 
       {:ok, doc} =
@@ -681,8 +681,11 @@ defmodule Arcana.GraphIntegrationTest do
                  graph_store: Arcana.FailingSweepGraphStore
                )
 
-      # The document is gone regardless: only the cleanup failed
-      assert Repo.get(Arcana.Document, doc.id) == nil
+      # The sweep shares the delete's transaction, so a failed cleanup takes
+      # the delete with it. This used to report the failure *after* deleting
+      # the document, which left the caller an error it could not retry.
+      assert Repo.get(Arcana.Document, doc.id),
+             "a failed sweep must leave the document in place"
     end
 
     test "build and sweep use the same per-call graph store" do


### PR DESCRIPTION
Closes #179.

`delete/2` documented `:ok | {:error, :not_found} | {:error, {:sweep_failed, _}}` but called `repo.delete!/1`, so a foreign key violation or a concurrent delete escaped as an exception. As the issue puts it, the damage isn't the exception, it's the sequencing: a caller removes an S3 original, calls `delete/2`, and on a constraint error the artifact is gone while the document row survives, with no error value to react to.

Took option 1 from the issue: the delete and the orphan sweep now run in one `repo.transaction/1`.

**One thing the issue didn't anticipate.** `repo.delete/1` only returns `{:error, changeset}` for a constraint the *changeset declared*, and a host is free to point a foreign key at `arcana_documents` from a table this library has never heard of. Those arrive as `Ecto.ConstraintError` regardless. So swapping the bang call wasn't enough on its own and the FK case — the first one the docs promised a tuple for — is handled by rescuing `Ecto.ConstraintError`. My first attempt at this fix missed it and the test caught it.

**Deliberately still raising:** infrastructure failures (a lost connection, a pool timeout). There's nothing useful to hand back and the transaction's fate is unknown, so flattening them into `{:error, _}` would read like a clean refusal when it isn't. The docs now say this explicitly, which makes the contract total *as written* rather than total in the abstract.

## Breaking

**A failed sweep now rolls the delete back.** It used to delete the document and report the failed cleanup afterwards — an error the caller couldn't retry, and one where `{:error, _}` meant "it half happened". Anyone matching `{:error, {:sweep_failed, _}}` on the assumption the document is gone needs to re-check. The existing test that asserted the old behaviour is updated, including its name.

The transaction covers what runs on `:repo`. A custom graph store keeping data elsewhere is outside it, so a store failing partway through its own sweep may have applied part of it even though the document survives. That's documented on the function.

## Coverage

Five tests. One fails on `main` with the exact `Ecto.ConstraintError` from the issue; the rest are controls. The rollback-on-sweep-failure change is covered by the updated `graph_integration_test` case.

One path is honestly uncovered: the `Ecto.StaleEntryError` rescue. Forcing the real race — row present at the lookup, gone at the delete — needs an interleave inside `delete/2` the sandbox can't arrange. The test next to it pins the `:not_found` contract via the `repo.get/2` branch and says so in a comment rather than implying it covers the rescue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `Arcana.delete/2` return its documented error tuples instead of raising exceptions, so a foreign key violation, a concurrent delete, or a database error from a host table no longer escapes from a function that promised `{:error, _}`. The delete and orphan sweep now share one transaction, changing what a failed sweep leaves behind. Closes #179.

**Breaking**

- A failed sweep now rolls the delete back, restoring the document and its chunks; previously it deleted the document and then reported the cleanup failure. Callers matching `{:error, {:sweep_failed, _}}` on the assumption the document is gone need to re-check.
- Infrastructure failures (lost connections, pool timeouts) deliberately still raise; the docs now say so explicitly rather than implying an unqualified tuple contract.

**Details**

- `repo.delete/1` only returns a changeset error for constraints the changeset declared; `Ecto.ConstraintError` covers foreign keys from unknown host tables, and `Postgrex.Error` covers ON DELETE SET NULL against NOT NULL columns and host triggers, which Ecto doesn't turn into constraint errors.
- A concurrent delete reports `{:error, :not_found}`, matching the outcome of losing the race a moment later.
- The delete transaction and the graph write lock each open only when the caller isn't already inside a transaction; inside one, a failed sweep returns the tuple and leaves that transaction intact, while a database failure still ends it. A savepoint now recovers every built-in failure, including a sweep that raises, because the write lock no longer opens a nested transaction; only a custom store opening its own defeats it.
- The graph write lock is hoisted into `delete/2` only for the `:ecto` store, so it's taken before any row locks and a concurrent delete and build on one collection can't deadlock; the lock is taken only when there's a sweep to do.
- A custom graph store raising `RuntimeError` propagates; only database exceptions from a sweep convert to `{:error, _}`.
- The transaction covers only what runs on `:repo`; the `:memory` backend and custom graph stores are outside it, so a successful sweep before a rollback drops graph data for a document that survives.
- The FK cases live in an `async: false` module because their DDL lock would serialize the async suite; one fails on `main` with the exact `Ecto.ConstraintError`.

<sup>Written for commit 8493358fcf192443cdb55ce6f2dfd24f4de607c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

