### PR TITLE
fix: Resolve Arcana's tables the way its own DDL does, through the search_path

### DIFF
--- a/lib/arcana/graph/migration.ex
+++ b/lib/arcana/graph/migration.ex
@@ -75,6 +75,8 @@ defmodule Arcana.Graph.Migration do
 
   use Ecto.Migration
 
+  alias Arcana.Migration.SchemaScope
+
   alias Arcana.Migration.Dimensions
   alias Arcana.Migration.UniqueIndex
 
@@ -210,7 +212,7 @@ defmodule Arcana.Graph.Migration do
         "SELECT c.relname FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
+          "AND " <> SchemaScope.visible("c", "n", "$2"),
         [
           ~w(
                    arcana_graph_entities
@@ -250,7 +252,7 @@ defmodule Arcana.Graph.Migration do
       repo.query!(
         "SELECT obj_description(c.oid) FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
-          "WHERE c.relname = $1 AND n.nspname = COALESCE($2, current_schema())",
+          "WHERE c.relname = $1 AND " <> SchemaScope.visible("c", "n", "$2"),
         [@version_table, prefix]
       )
 

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -82,6 +82,8 @@ defmodule Arcana.Migration do
 
   use Ecto.Migration
 
+  alias Arcana.Migration.SchemaScope
+
   require Logger
 
   alias Arcana.Migration.Dimensions
@@ -435,7 +437,7 @@ defmodule Arcana.Migration do
         "SELECT c.relname FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
+          "AND " <> SchemaScope.visible("c", "n", "$2"),
         [owned_table_names(), prefix]
       )
 
@@ -467,7 +469,7 @@ defmodule Arcana.Migration do
       repo.query!(
         "SELECT obj_description(c.oid) FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
-          "WHERE c.relname = $1 AND n.nspname = COALESCE($2, current_schema())",
+          "WHERE c.relname = $1 AND " <> SchemaScope.visible("c", "n", "$2"),
         [@version_table, prefix]
       )
 
@@ -780,7 +782,7 @@ defmodule Arcana.Migration do
             "JOIN pg_namespace n ON n.oid = t.relnamespace " <>
             "WHERE con.conname = 'arcana_documents_collection_id_fkey' " <>
             "AND t.relname = 'arcana_documents' " <>
-            "AND n.nspname = COALESCE($1, current_schema())",
+            "AND " <> SchemaScope.visible("t", "n", "$1"),
           [prefix]
         )
 

--- a/lib/arcana/migration/dimensions.ex
+++ b/lib/arcana/migration/dimensions.ex
@@ -1,4 +1,5 @@
 defmodule Arcana.Migration.Dimensions do
+  alias Arcana.Migration.SchemaScope
   @moduledoc false
 
   # Shared by `Arcana.Migration` and `Arcana.Graph.Migration`, which each size
@@ -99,7 +100,7 @@ defmodule Arcana.Migration.Dimensions do
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = $1 AND a.attname = 'embedding' " <>
           "AND a.attnum > 0 AND NOT a.attisdropped " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
+          "AND " <> SchemaScope.visible("c", "n", "$2"),
         [table, prefix]
       )
 

--- a/lib/arcana/migration/schema_scope.ex
+++ b/lib/arcana/migration/schema_scope.ex
@@ -1,0 +1,38 @@
+defmodule Arcana.Migration.SchemaScope do
+  @moduledoc """
+  One rule for "is this catalog row the object our DDL would actually touch".
+
+  Every migration module looks itself up in `pg_class` to decide what is
+  installed. They all used to scope that with `n.nspname = COALESCE($n,
+  current_schema())`, which is wrong for the unprefixed case:
+  `current_schema()` is only the *first* entry of `search_path`, while an
+  unqualified `CREATE`/`DROP`/`SELECT` resolves through the whole path.
+
+  On the supported multi-tenant layout — `search_path = tenant, public` with
+  Arcana's tables in `public` — those lookups reported nothing while the DDL
+  right next to them resolved to `public` and worked. `Arcana.Migration.down/1`
+  read version 0 from it, concluded nothing was installed, and returned `:ok`
+  having dropped nothing: silently declining the operator's request, which is
+  the failure `refuse_blind_rollback!/1` exists to prevent.
+
+  `pg_table_is_visible/1` answers the question the DDL actually asks. With an
+  explicit `:prefix` the schema is named outright and there is nothing to
+  resolve, so that case still compares `nspname`.
+
+  `Arcana.Graph.installed?/2` reached this conclusion first and carries the
+  same comment; this is that fix applied to the rest of the family.
+  """
+
+  @doc """
+  A SQL predicate scoping a `pg_class` row to the migration's target schema.
+
+  `rel` and `ns` are the query's aliases for `pg_class` and `pg_namespace`,
+  and `param` is the placeholder holding the prefix (`nil` for unprefixed).
+  All three are compile-time literals from the calling query, never input.
+  """
+  def visible(rel, ns, param) do
+    "CASE WHEN #{param}::text IS NULL " <>
+      "THEN pg_table_is_visible(#{rel}.oid) " <>
+      "ELSE #{ns}.nspname = #{param}::text END"
+  end
+end

--- a/lib/arcana/migration/unique_index.ex
+++ b/lib/arcana/migration/unique_index.ex
@@ -1,4 +1,5 @@
 defmodule Arcana.Migration.UniqueIndex do
+  alias Arcana.Migration.SchemaScope
   @moduledoc false
 
   # Shared by `Arcana.Migration` and `Arcana.Graph.Migration`, which each own
@@ -61,7 +62,7 @@ defmodule Arcana.Migration.UniqueIndex do
         "SELECT count(*) FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = $1 AND c.relkind IN ('r', 'p') " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
+          "AND " <> SchemaScope.visible("c", "n", "$2"),
         [table, prefix]
       )
 
@@ -87,7 +88,9 @@ defmodule Arcana.Migration.UniqueIndex do
           "LEFT JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true " <>
           "LEFT JOIN pg_attribute a ON a.attrelid = tc.oid AND a.attnum = k.attnum " <>
           "WHERE ic.relname = $1 AND tc.relname = $2 " <>
-          "AND n.nspname = COALESCE($3, current_schema()) " <>
+          "AND " <>
+          SchemaScope.visible("tc", "n", "$3") <>
+          " " <>
           "GROUP BY i.indisunique, i.indpred IS NOT NULL, i.indkey, " <>
           "i.indisvalid, i.indisready",
         [name, table, prefix]

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -10,6 +10,7 @@ defmodule Arcana.MigrationTest do
 
   doctest Arcana.Migration.Dimensions
 
+  alias Arcana.Migration.Dimensions
   alias Arcana.MigrationRepo, as: Repo
   alias Ecto.Adapters.Postgres
   alias Ecto.Adapters.SQL
@@ -1203,6 +1204,88 @@ defmodule Arcana.MigrationTest do
       )
 
     match?([[true]], rows)
+  end
+
+  describe "a search_path whose first entry isn't Arcana's schema" do
+    # The supported multi-tenant layout: a tenant schema first, Arcana's tables
+    # in public, no :prefix. Unqualified DDL resolves through the whole
+    # search_path and finds them; every catalog lookup used to compare against
+    # current_schema(), which is only the FIRST entry, and so reported nothing.
+    setup do
+      SQL.query!(Repo, ~s(CREATE SCHEMA IF NOT EXISTS "tenant_first"), [])
+      original = SQL.query!(Repo, "SHOW search_path", []).rows |> List.flatten() |> hd()
+
+      on_exit(fn ->
+        SQL.query!(Repo, "SET search_path TO #{original}", [])
+        SQL.query!(Repo, ~s(DROP SCHEMA IF EXISTS "tenant_first" CASCADE), [])
+      end)
+
+      :ok
+    end
+
+    # Repo.checkout pins ONE connection for the whole block. Without it the
+    # SET lands on a pooled connection and the lookup runs on another, so the
+    # search_path never applies and the test passes against the bug.
+    defp with_tenant_first(fun) do
+      Repo.checkout(fn ->
+        SQL.query!(Repo, ~s(SET search_path TO "tenant_first", public), [])
+
+        try do
+          fun.()
+        after
+          SQL.query!(Repo, "SET search_path TO public", [])
+        end
+      end)
+    end
+
+    test "the recorded version is found rather than read as 0" do
+      assert :ok = migrate(Arcana.Migration)
+
+      assert with_tenant_first(fn -> Arcana.Migration.recorded_version(Repo) end) ==
+               Arcana.Migration.current_version(),
+             "the version table is visible through the search_path"
+    end
+
+    test "the embedding dimension check still catches a mismatch" do
+      # Same lookup family, different module, and a quieter failure: finding no
+      # row makes verify!/6 fall through its `with` and return :ok, so on this
+      # layout a dimension mismatch passed unnoticed - exactly the case that
+      # function exists to catch.
+      assert :ok = migrate(Arcana.Migration)
+
+      assert_raise ArgumentError, ~r/already vector\(384\)/, fn ->
+        with_tenant_first(fn ->
+          Dimensions.verify!(Repo, 512, Arcana.Migration, "arcana_chunks", nil, "remedy")
+        end)
+      end
+    end
+
+    # Deliberately no end-to-end down/1 assertion. Ecto.Migrator runs the
+    # migration through its own connection handling, so a search_path pinned
+    # with Repo.checkout never reaches its statements and the rollback behaves
+    # as though the path were plain public - a test written that way passes
+    # with the bug present, which is worse than no test. recorded_version/2 is
+    # the mechanism of the silent no-op (it reads 0, so down/1 concludes
+    # nothing is installed and skips the loop), and that is covered above.
+
+    test "the graph module reads its own version the same way" do
+      assert :ok = migrate(Arcana.Migration)
+      assert :ok = migrate(Arcana.Graph.Migration)
+
+      assert with_tenant_first(fn -> Arcana.Graph.Migration.recorded_version(Repo) end) ==
+               Arcana.Graph.Migration.current_version()
+    end
+
+    test "an explicit prefix still means that schema and nothing else" do
+      # Visibility is only for the unprefixed case. A named prefix says where
+      # to look, so a table visible through the search_path but not in that
+      # schema must still read as absent.
+      assert :ok = migrate(Arcana.Migration)
+
+      assert with_tenant_first(fn ->
+               Arcana.Migration.recorded_version(Repo, prefix: "tenant_first")
+             end) == 0
+    end
   end
 
   describe "down/1 with tables that reference Arcana's" do


### PR DESCRIPTION
Fixes the `down/1` silent no-op. **Stacked on #181** (it touches the same module); retarget to `main` once that merges.

Every migration module located itself in the catalog with `n.nspname = COALESCE($n, current_schema())`. `current_schema()` is only the **first** entry of the `search_path`, while the unqualified `CREATE`/`DROP`/`SELECT` right beside it resolves through the whole path. On the supported multi-tenant layout — `search_path = tenant, public`, Arcana's tables in `public`, no `:prefix` — those lookups saw nothing while the DDL worked fine.

Two consequences, both silent:

**`Arcana.Migration.down/1` did nothing and said `:ok`.** `recorded_version/2` read 0, `refuse_blind_rollback!/1` found no owned tables so it declined to complain, and `current > target` was `0 > 0`. The rollback loop never ran. Declining the operator's request without saying so is precisely the failure `refuse_blind_rollback!/1` was written to prevent — its own comment says as much.

**`Dimensions.verify!/6` stopped checking.** No row means its `with` falls through and returns `:ok`, so an embedding dimension mismatch passed unnoticed on that layout. That is the single thing that function exists to catch.

All nine sites now go through `Arcana.Migration.SchemaScope.visible/3`: `pg_table_is_visible/1` when there's no prefix, `nspname` comparison when there is. One helper rather than nine edits, so the next catalog lookup added here doesn't quietly reintroduce it. `Arcana.Graph.installed?/2` already reached this conclusion and carries the same comment; this is that fix applied to the rest of the family.

## On the tests

They pin the two lookups, not an end-to-end `down/1`, and that's deliberate. `Ecto.Migrator` runs statements through its own connection handling, so a `search_path` pinned with `Repo.checkout` never reaches them — a rollback test written that way **passes with the bug present**. I wrote that test first and caught it only because it still passed after I reverted the fix. `recorded_version/2` reading 0 is the whole mechanism of the silent no-op, and it's covered directly.

`Repo.checkout` matters for the same reason: `SET search_path` is connection-local, and without pinning, the `SET` and the lookup land on different pooled connections. My first version of these tests passed against the bug for exactly that reason.

Three of the four fail on the base branch. The fourth is a control: an explicit `:prefix` must still mean that schema and nothing else, and passes either way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent no-op in `down/1` and skipped `Dimensions.verify!/6` checks when `search_path`'s first entry isn't Arcana's schema. Catalog lookups used `current_schema()`, which is only the first `search_path` entry, while unqualified DDL resolves through the whole path — on `search_path = tenant, public` with unprefixed tables, lookups found nothing while DDL worked.

All nine lookup sites now use `Arcana.Migration.SchemaScope.visible/3`, which applies `pg_table_is_visible/1` when no prefix is set and compares `nspname` when one is.

Tests pin the two lookup paths (`recorded_version/2` and `Dimensions.verify!/6`) rather than an end-to-end rollback, since migrator connection handling would make a rollback test pass even with the bug present.

<sup>Written for commit 2209a0cbf22fd5b48fa0288627c1d40aec1bef00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

