### PR TITLE
refactor!: Make publication lifecycle explicit

### DIFF
--- a/guides/dashboard.md
+++ b/guides/dashboard.md
@@ -75,7 +75,7 @@ arcana_dashboard "/arcana",
   on_mount: [MyAppWeb.Auth],                   # Add authentication
   live_socket_path: "/live",                   # Custom LiveView socket path
   live_session_name: :arcana_dashboard,        # Unique per mount in one router
-  collections: {MyAppWeb.Access, :collections} # Scope to a collection subset
+  collection: {MyAppWeb.Access, :collection_scope} # Scope to a collection subset
 ```
 
 ### Authentication
@@ -90,14 +90,14 @@ arcana_dashboard "/arcana",
 ### Collection scoping
 
 By default the dashboard sees (and can mutate) every collection, so it's
-superuser territory. The `collections:` option lets you expose it below
+superuser territory. The `collection:` option lets you expose it below
 that level: a `{module, function}` pair that gets the `%Plug.Conn{}` of
-the page request and returns either `:all` or the list of collection
-names that user may touch.
+the page request and returns `:all`, one collection name, a list of names,
+or `[]` when the user may touch none.
 
 ```elixir
 arcana_dashboard "/arcana",
-  collections: {MyAppWeb.ArcanaAccess, :allowed_collections}
+  collection: {MyAppWeb.ArcanaAccess, :allowed_collections}
 ```
 
 ```elixir
@@ -156,7 +156,7 @@ long a stale scope can survive without that broadcast.
 It's a plain `{module, function}` tuple rather than a function capture
 so the router metadata stays serializable. The option composes with
 `on_mount:` auth hooks: use `on_mount` to decide who gets in, and
-`collections:` to decide what they see once inside. It scopes the
+`collection:` to decide what they see once inside. It scopes the
 dashboard only, not `Arcana.search/2` or other API calls your app makes.
 
 To mount two dashboards in one router (say a superuser one plus a scoped

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -393,11 +393,9 @@ chunk's stored `metadata`.
 
 ### Strict Collection Scoping
 
-By default, searching a collection name that doesn't exist silently searches
-across all collections, and ingesting into one creates it on the fly. In
-multi-tenant apps that's dangerous: a typo'd tenant collection becomes a
-cross-tenant search. Turn on strict mode to make unknown collection names an
-error instead:
+By default, searching a collection name that doesn't exist returns no results,
+while ingesting into one creates it on the fly. Turn on strict mode when an
+unknown collection should return an explicit error instead:
 
 ```elixir
 config :arcana, strict_collections: true
@@ -416,9 +414,8 @@ Three things to know:
 - Ingest without a `:collection` uses the implicit `"default"` collection,
   which strict mode also requires to exist. Create it once at setup:
   `Arcana.Collection.get_or_create("default", MyApp.Repo)`.
-- Without strict mode, an unknown name still searches unscoped on the
-  vector/keyword path (legacy behavior), but graph-enhanced context is
-  scoped to nothing rather than leaking across collections.
+- Without strict mode, an unknown name matches nothing on vector, keyword, and
+  graph paths.
 - Strict validation needs the repo-backed collection registry. The
   `:memory` vector store has no registry: it always fails closed for
   unknown collections (empty results) instead of returning the error.

--- a/guides/graphrag.md
+++ b/guides/graphrag.md
@@ -286,7 +286,7 @@ defmodule MyApp.Neo4jGraphStore do
   end
 
   @impl true
-  def persist_relationships(relationships, entity_id_map, opts) do
+  def persist_relationships(chunk_id, relationships, entity_id_map, opts) do
     # Store relationships between entities
     :ok
   end

--- a/guides/loop.md
+++ b/guides/loop.md
@@ -93,8 +93,8 @@ Arcana.Loop.new(question, opts) |> Arcana.Loop.run(opts)
 | Option | Default | Description |
 |---|---|---|
 | `:repo` | `Arcana.Config.get(opts, :repo)` | Ecto repo for retrieval tools |
-| `:collection` | `nil` | Lock the loop to a single collection. The controller physically cannot search anything else: the tool schema won't even expose a collection parameter. See "Collections: lock vs pick" below. |
-| `:collections` | `[nil]` | Allowed set of collection names the controller may pick from per search call. When 2 or more, the search tool gains an optional `collection` parameter the controller uses to narrow the search. Overrides `:collection`. |
+| `:collection` | `:all` | `:all`, one collection name, or a list of names. A single name locks the loop to it. |
+| `:collections` | `:all` | Alias for `:collection`. When 2 or more names are present, the search tool gains an optional `collection` parameter the controller uses to narrow the search. The two options are mutually exclusive. An empty list searches nothing. |
 
 `run/2` options:
 
@@ -164,9 +164,16 @@ list), the search tool returns a friendly error as the tool result
 The loop doesn't crash; the controller sees the error on its next
 turn and can correct.
 
-**Unrestricted.** Pass neither option. The search tool has no
-`collection` parameter. `Arcana.search/2` is called without a
-collection filter, hitting whatever default behavior is configured.
+**Unrestricted.** Pass neither option, or pass `:all` explicitly. The
+search tool has no `collection` parameter. `Arcana.search/2` receives
+`collection: :all` and searches the full corpus.
+
+```elixir
+Arcana.Loop.new(question, repo: Repo, collection: :all)
+```
+
+Pass `[]` when the caller is authorized for no collections. The loop keeps
+that match-nothing scope through every tool call.
 
 ```elixir
 Arcana.Loop.new(question, repo: Repo)

--- a/guides/loop.md
+++ b/guides/loop.md
@@ -94,7 +94,6 @@ Arcana.Loop.new(question, opts) |> Arcana.Loop.run(opts)
 |---|---|---|
 | `:repo` | `Arcana.Config.get(opts, :repo)` | Ecto repo for retrieval tools |
 | `:collection` | `:all` | `:all`, one collection name, or a list of names. A single name locks the loop to it. |
-| `:collections` | `:all` | Alias for `:collection`. When 2 or more names are present, the search tool gains an optional `collection` parameter the controller uses to narrow the search. The two options are mutually exclusive. An empty list searches nothing. |
 
 `run/2` options:
 
@@ -125,14 +124,14 @@ Per-call options override globals.
 
 ## Collections: lock vs pick
 
-The `:collection` / `:collections` options on `Arcana.Loop.new/2` don't
-just filter searches. They shape the **tool schema** the controller
+The `:collection` option on `Arcana.Loop.new/2` doesn't
+just filter searches. It shapes the **tool schema** the controller
 sees, which determines what the controller can and can't express.
 
 Three cases, three behaviors:
 
-**Lock to a single collection.** Pass `:collection` or a one-element
-`:collections` list. The `search` tool is built without a `collection`
+**Lock to a single collection.** Pass a collection name or a one-element
+list. The `search` tool is built without a `collection`
 parameter, so the controller literally has no way to express a
 different collection. This is the strongest possible guarantee: no
 prompt-engineering workaround, no "ignore previous instructions".
@@ -144,14 +143,14 @@ Arcana.Loop.new(question, repo: Repo, collection: "docs")
 ```
 
 **Allow a set; let the controller pick per call.** Pass a
-multi-element `:collections` list. The `search` tool gains an optional
+multi-element `:collection` list. The `search` tool gains an optional
 `collection` parameter whose documentation lists the allowed values.
 The controller picks one per call, or omits it to search across all
 listed collections. The system prompt also gains a "Collections"
 section telling the controller when to narrow vs broaden.
 
 ```elixir
-Arcana.Loop.new(question, repo: Repo, collections: ["docs", "wiki", "changelog"])
+Arcana.Loop.new(question, repo: Repo, collection: ["docs", "wiki", "changelog"])
 # tool schema: search(query, collection, limit)
 # controller decides each call:
 #   search(query: "...", collection: "docs")   -- narrow
@@ -164,7 +163,7 @@ list), the search tool returns a friendly error as the tool result
 The loop doesn't crash; the controller sees the error on its next
 turn and can correct.
 
-**Unrestricted.** Pass neither option, or pass `:all` explicitly. The
+**Unrestricted.** Omit the option, or pass `:all` explicitly. The
 search tool has no `collection` parameter. `Arcana.search/2` receives
 `collection: :all` and searches the full corpus.
 
@@ -176,9 +175,9 @@ Pass `[]` when the caller is authorized for no collections. The loop keeps
 that match-nothing scope through every tool call.
 
 ```elixir
-Arcana.Loop.new(question, repo: Repo)
+Arcana.Loop.new(question, repo: Repo, collection: [])
 # tool schema: search(query, limit)
-# searches across whatever the default is
+# every search matches nothing
 ```
 
 ### When to use which

--- a/guides/pipeline.md
+++ b/guides/pipeline.md
@@ -169,7 +169,7 @@ ctx.results
 
 #### Explicit Collection Selection
 
-Pass `:collection` or `:collections` to search specific collections without using `select/2`:
+Pass `:collection` to search specific collections without using `select/2`:
 
 ```elixir
 # Search a single collection
@@ -179,19 +179,19 @@ ctx
 
 # Search multiple collections
 ctx
-|> Pipeline.search(collections: ["docs", "faq"])
+|> Pipeline.search(collection: ["docs", "faq"])
 |> Pipeline.answer()
 
 # Search every collection, or deliberately search none
 Pipeline.search(ctx, collection: :all)
-Pipeline.search(ctx, collections: [])
+Pipeline.search(ctx, collection: [])
 ```
 
-`:collection` and `:collections` accept the same scope shapes and are mutually
-exclusive. A single string and a one-element list mean the same thing.
+`:collection` accepts `:all`, a collection name, or a list of names. A single
+string and a one-element list mean the same thing.
 
 Collection selection priority:
-1. `:collection`/`:collections` option passed to `search/2`
+1. `:collection` option passed to `search/2`
 2. `ctx.collections` (set by `select/2`)
 3. Falls back to `"default"` collection
 

--- a/guides/pipeline.md
+++ b/guides/pipeline.md
@@ -181,7 +181,14 @@ ctx
 ctx
 |> Pipeline.search(collections: ["docs", "faq"])
 |> Pipeline.answer()
+
+# Search every collection, or deliberately search none
+Pipeline.search(ctx, collection: :all)
+Pipeline.search(ctx, collections: [])
 ```
+
+`:collection` and `:collections` accept the same scope shapes and are mutually
+exclusive. A single string and a one-element list mean the same thing.
 
 Collection selection priority:
 1. `:collection`/`:collections` option passed to `search/2`

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -119,6 +119,12 @@ defmodule Arcana do
   defdelegate get_document(id, opts), to: Arcana.Documents
 
   @doc """
+  Fetches sparse metadata for published documents in one explicitly scoped read.
+  See `Arcana.Documents.get_document_metadata/2`.
+  """
+  defdelegate get_document_metadata(ids, opts), to: Arcana.Documents
+
+  @doc """
   Deletes a document and all its chunks.
 
   When the graph is enabled, also sweeps the document's collection for

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -32,6 +32,8 @@ defmodule Arcana do
   alias Arcana.Document
   alias Arcana.Graph.GraphStore
 
+  import Ecto.Query, only: [from: 2]
+
   # === Configuration ===
 
   @doc """
@@ -231,19 +233,27 @@ defmodule Arcana do
   # tuple that reads like a recoverable refusal. Their transaction already
   # provides the atomicity, and the error is theirs to act on.
   defp delete_document(document, repo, opts) do
-    if repo.in_transaction?() do
-      locked_delete(document, repo, opts)
-    else
-      repo.transaction(fn ->
-        case locked_delete(document, repo, opts) do
-          :ok -> :ok
-          {:error, reason} -> repo.rollback(reason)
+    cond do
+      repo.in_transaction?() and external_graph_cleanup?(document, opts) ->
+        {:error, :external_graph_store_requires_post_commit_delete}
+
+      repo.in_transaction?() ->
+        locked_delete(document, repo, opts)
+
+      external_graph_cleanup?(document, opts) ->
+        delete_before_external_cleanup(document, repo, opts)
+
+      true ->
+        repo.transaction(fn ->
+          case locked_delete(document, repo, opts) do
+            :ok -> :ok
+            {:error, reason} -> repo.rollback(reason)
+          end
+        end)
+        |> case do
+          {:ok, :ok} -> :ok
+          {:error, reason} -> {:error, reason}
         end
-      end)
-      |> case do
-        {:ok, :ok} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
     end
   rescue
     # The row went away between the get and the delete. A concurrent deleter
@@ -268,6 +278,34 @@ defmodule Arcana do
     # connection or a pool timeout is a different struct and still raises.
     error in Postgrex.Error ->
       {:error, error}
+  end
+
+  defp external_graph_cleanup?(document, opts) do
+    sweeping?(document, opts) and not ecto_graph_store?(opts)
+  end
+
+  defp delete_before_external_cleanup(document, repo, opts) do
+    repo.transaction(fn ->
+      chunk_ids =
+        repo.all(from(c in Arcana.Chunk, where: c.document_id == ^document.id, select: c.id))
+
+      case repo.delete(document) do
+        {:ok, _deleted} -> chunk_ids
+        {:error, reason} -> repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, chunk_ids} ->
+        with :ok <- GraphStore.delete_by_chunks(chunk_ids, Keyword.put(opts, :repo, repo)),
+             :ok <- sweep(document, repo, opts) do
+          :ok
+        else
+          {:error, reason} -> {:error, {:post_commit_graph_cleanup_failed, reason}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   # The advisory lock goes first, before any row locks, because that is the
@@ -315,14 +353,25 @@ defmodule Arcana do
   end
 
   defp delete_and_sweep(document, repo, opts) do
-    case repo.delete(document) do
-      {:ok, _deleted} ->
-        sweep(document, repo, opts)
+    chunk_ids =
+      repo.all(from(c in Arcana.Chunk, where: c.document_id == ^document.id, select: c.id))
 
-      {:error, changeset} ->
-        {:error, changeset}
+    with :ok <- cleanup_graph_before_delete(chunk_ids, document, repo, opts),
+         {:ok, _deleted} <- repo.delete(document),
+         :ok <- cleanup_graph_after_delete(chunk_ids, document, repo, opts) do
+      sweep(document, repo, opts)
     end
   end
+
+  defp cleanup_graph_before_delete(chunk_ids, document, repo, opts) do
+    if sweeping?(document, opts) and ecto_graph_store?(opts) do
+      GraphStore.delete_by_chunks(chunk_ids, Keyword.put(opts, :repo, repo))
+    else
+      :ok
+    end
+  end
+
+  defp cleanup_graph_after_delete(_chunk_ids, _document, _repo, _opts), do: :ok
 
   # :sweep_failed is for a store that *returns* an error. One that raises is
   # deliberately not folded into it: the exception happens inside the write

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -438,7 +438,12 @@ defmodule Arcana do
 
   defp cleanup_graph_before_delete(chunk_ids, document, repo, opts) do
     if sweeping?(document, opts) and ecto_graph_store?(opts) do
-      GraphStore.delete_by_chunks(chunk_ids, Keyword.put(opts, :repo, repo))
+      graph_opts =
+        opts
+        |> Keyword.put(:repo, repo)
+        |> Keyword.put(:collection_id, document.collection_id)
+
+      GraphStore.delete_by_chunks(chunk_ids, graph_opts)
     else
       :ok
     end

--- a/lib/arcana.ex
+++ b/lib/arcana.ex
@@ -137,9 +137,12 @@ defmodule Arcana do
   skips changeset constraint mapping, so a host row referencing an entity the
   sweep wants to remove arrives that way.
 
-  Any other exception from a graph store propagates. A custom store raising
-  `RuntimeError` is a bug in that store, not a failure mode with a return
-  value, and swallowing it into `{:error, _}` would hide it.
+  When an external graph store is cleaned after the database delete commits,
+  a returned error or exception is wrapped as
+  `{:error, {:post_commit_graph_cleanup_failed, context}}`. The context carries
+  `:reason`, `:chunk_ids`, `:published_chunk_ids`, and `:collection_id`, so the
+  graph deletion and sweep can be retried even though the document row is
+  already gone.
 
   A concurrent delete reports `{:error, :not_found}`, the same as losing that
   race by a moment more would have.
@@ -285,28 +288,93 @@ defmodule Arcana do
   end
 
   defp delete_before_external_cleanup(document, repo, opts) do
-    repo.transaction(fn ->
-      chunk_ids =
-        repo.all(from(c in Arcana.Chunk, where: c.document_id == ^document.id, select: c.id))
+    GraphStore.with_write_lock(
+      document.collection_id,
+      Keyword.put(opts, :repo, repo),
+      fn -> delete_and_cleanup_external_graph(document, repo, opts) end
+    )
+    |> case do
+      {:ok, {chunk_ids, locked_document}} ->
+        sweep_external_graph(chunk_ids, locked_document, repo, opts)
 
-      case repo.delete(document) do
-        {:ok, _deleted} -> chunk_ids
-        {:error, reason} -> repo.rollback(reason)
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp delete_and_cleanup_external_graph(document, repo, opts) do
+    repo.transaction(fn ->
+      locked_document =
+        repo.one(from(d in Document, where: d.id == ^document.id, lock: "FOR UPDATE"))
+
+      if locked_document do
+        chunk_ids =
+          repo.all(
+            from(c in Arcana.Chunk, where: c.document_id == ^locked_document.id, select: c.id)
+          )
+
+        case repo.delete(locked_document) do
+          {:ok, deleted} -> {chunk_ids, deleted}
+          {:error, reason} -> repo.rollback(reason)
+        end
+      else
+        repo.rollback(:not_found)
       end
     end)
     |> case do
-      {:ok, chunk_ids} ->
-        with :ok <- GraphStore.delete_by_chunks(chunk_ids, Keyword.put(opts, :repo, repo)),
-             :ok <- sweep(document, repo, opts) do
-          :ok
-        else
-          {:error, reason} -> {:error, {:post_commit_graph_cleanup_failed, reason}}
+      {:ok, {chunk_ids, locked_document}} ->
+        case delete_external_graph_chunks(chunk_ids, locked_document, repo, opts) do
+          :ok -> {:ok, {chunk_ids, locked_document}}
+          {:error, _reason} = error -> error
         end
 
       {:error, reason} ->
         {:error, reason}
     end
   end
+
+  defp delete_external_graph_chunks(chunk_ids, document, repo, opts) do
+    graph_opts =
+      opts
+      |> Keyword.put(:repo, repo)
+      |> Keyword.put(:published_chunk_ids, published_chunk_ids(document, chunk_ids))
+
+    case GraphStore.delete_by_chunks(chunk_ids, graph_opts) do
+      :ok -> :ok
+      {:error, reason} -> post_commit_graph_cleanup_error(reason, document, chunk_ids)
+    end
+  rescue
+    exception -> post_commit_graph_cleanup_error(exception, document, chunk_ids)
+  catch
+    :exit, reason -> post_commit_graph_cleanup_error(reason, document, chunk_ids)
+    kind, reason -> post_commit_graph_cleanup_error({kind, reason}, document, chunk_ids)
+  end
+
+  defp sweep_external_graph(chunk_ids, document, repo, opts) do
+    case sweep(document, repo, opts) do
+      :ok -> :ok
+      {:error, reason} -> post_commit_graph_cleanup_error(reason, document, chunk_ids)
+    end
+  rescue
+    exception -> post_commit_graph_cleanup_error(exception, document, chunk_ids)
+  catch
+    :exit, reason -> post_commit_graph_cleanup_error(reason, document, chunk_ids)
+    kind, reason -> post_commit_graph_cleanup_error({kind, reason}, document, chunk_ids)
+  end
+
+  defp post_commit_graph_cleanup_error(reason, document, chunk_ids) do
+    {:error,
+     {:post_commit_graph_cleanup_failed,
+      %{
+        reason: reason,
+        chunk_ids: chunk_ids,
+        published_chunk_ids: published_chunk_ids(document, chunk_ids),
+        collection_id: document.collection_id
+      }}}
+  end
+
+  defp published_chunk_ids(%Document{status: :completed}, chunk_ids), do: chunk_ids
+  defp published_chunk_ids(_document, _chunk_ids), do: []
 
   # The advisory lock goes first, before any row locks, because that is the
   # order the build side takes them (Arcana.Graph.persist_chunk_graph/6 holds
@@ -335,15 +403,9 @@ defmodule Arcana do
     !is_nil(document.collection_id) and Arcana.Config.graph_enabled?(opts)
   end
 
-  # Only the :ecto store. The lock is hoisted here to fix an ordering hazard
-  # between *that* store's advisory lock and the row locks the FK cascade
-  # takes, and pg_advisory_xact_lock is re-entrant within a transaction, so
-  # sweep_orphans/2 taking it again is free.
-  #
-  # A custom store's lock has no such hazard to fix - it does not contend with
-  # arcana_chunks row locks - and nothing says its with_write_lock/3 has to be
-  # re-entrant. Hoisting it there would buy nothing and could deadlock every
-  # graph-enabled delete against the sweep's own acquisition.
+  # Only the :ecto store reaches this in-transaction lock path. External stores
+  # lock around the transaction before calling locked_delete/3, then sweep
+  # after releasing that non-reentrant lock.
   defp ecto_graph_store?(opts) do
     case Keyword.get(opts, :graph_store, GraphStore.backend()) do
       :ecto -> true
@@ -359,6 +421,17 @@ defmodule Arcana do
     with :ok <- cleanup_graph_before_delete(chunk_ids, document, repo, opts),
          {:ok, _deleted} <- repo.delete(document),
          :ok <- cleanup_graph_after_delete(chunk_ids, document, repo, opts) do
+      maybe_sweep_after_delete(document, repo, opts)
+    end
+  end
+
+  defp maybe_sweep_after_delete(document, repo, opts) do
+    # Ecto's delete_by_chunks/2 already sweeps the affected collections in
+    # the transaction that removes their mentions. External stores keep the
+    # explicit pass because their delete callback does not own that contract.
+    if sweeping?(document, opts) and ecto_graph_store?(opts) do
+      :ok
+    else
       sweep(document, repo, opts)
     end
   end

--- a/lib/arcana/ask.ex
+++ b/lib/arcana/ask.ex
@@ -16,6 +16,7 @@ defmodule Arcana.Ask do
 
   """
 
+  alias Arcana.{Collection, CollectionScope}
   alias Arcana.Graph.GraphStore
   alias Arcana.LLM
 
@@ -37,8 +38,10 @@ defmodule Arcana.Ask do
     * `:threshold` - Minimum similarity score for context (default: 0.0)
     * `:mode` - Search mode: `:vector` (default), `:keyword`, or `:hybrid`.
       `:semantic` and `:fulltext` are deprecated aliases and log a warning.
-    * `:collection` - Filter to a specific collection
-    * `:collections` - Filter to multiple collections
+    * `:collection` - Collection scope as `:all`, a collection name, or a list
+      of collection names
+    * `:collections` - Alias for `:collection`. The two options are mutually
+      exclusive.
     * `:prompt` - Custom prompt function. Supports arity 2 `(question, context)` or
       arity 3 `(question, context, graph_context)`
     * `:reranker` - Reranker module/function (passed through to search)
@@ -203,13 +206,16 @@ defmodule Arcana.Ask do
     repo = Arcana.Config.get(opts, :repo)
 
     if Arcana.Config.graph_enabled?(opts) and repo do
-      fetch_graph_context(question, repo, opts)
+      case resolve_collection_ids(opts, repo) do
+        [] -> %{}
+        collection_ids -> fetch_graph_context(question, repo, opts, collection_ids)
+      end
     else
       %{}
     end
   end
 
-  defp fetch_graph_context(question, repo, opts) do
+  defp fetch_graph_context(question, repo, opts, collection_ids) do
     import Ecto.Query
     alias Arcana.Graph.Community
 
@@ -220,7 +226,6 @@ defmodule Arcana.Ask do
     summary_limit = graph_config[:community_summary_limit] || 5
     threshold = graph_config[:entity_embedding_threshold] || 0.3
 
-    collection_ids = resolve_collection_ids(opts, repo)
     embedder = Arcana.Config.embedder()
 
     matched_entities =
@@ -413,14 +418,14 @@ defmodule Arcana.Ask do
     end)
   end
 
-  # `nil` means unscoped; `[]` means the named collections resolved to
-  # nothing and downstream graph queries must match nothing. Strict
-  # validation already happened in Arcana.Search.search/2.
   defp resolve_collection_ids(opts, repo) do
-    {:ok, ids} =
-      Arcana.Collection.names_from_opts(opts)
-      |> Arcana.Collection.resolve_ids(repo)
+    case CollectionScope.from_opts!(opts, :all) do
+      :all ->
+        nil
 
-    ids
+      {:only, names} ->
+        {:ok, ids} = Collection.resolve_ids(names, repo)
+        ids
+    end
   end
 end

--- a/lib/arcana/ask.ex
+++ b/lib/arcana/ask.ex
@@ -38,10 +38,8 @@ defmodule Arcana.Ask do
     * `:threshold` - Minimum similarity score for context (default: 0.0)
     * `:mode` - Search mode: `:vector` (default), `:keyword`, or `:hybrid`.
       `:semantic` and `:fulltext` are deprecated aliases and log a warning.
-    * `:collection` - Collection scope as `:all`, a collection name, or a list
-      of collection names
-    * `:collections` - Alias for `:collection`. The two options are mutually
-      exclusive.
+    * `:collection` - Collection scope as `:all`, a collection name, a list of
+      collection names, or `[]` to match nothing
     * `:prompt` - Custom prompt function. Supports arity 2 `(question, context)` or
       arity 3 `(question, context, graph_context)`
     * `:reranker` - Reranker module/function (passed through to search)

--- a/lib/arcana/ask.ex
+++ b/lib/arcana/ask.ex
@@ -16,6 +16,7 @@ defmodule Arcana.Ask do
 
   """
 
+  alias Arcana.Graph.GraphStore
   alias Arcana.LLM
 
   @doc """
@@ -210,7 +211,7 @@ defmodule Arcana.Ask do
 
   defp fetch_graph_context(question, repo, opts) do
     import Ecto.Query
-    alias Arcana.Graph.{Community, GraphStore}
+    alias Arcana.Graph.Community
 
     graph_config = Arcana.Graph.config()
     entity_limit = graph_config[:context_entity_limit] || 10
@@ -242,7 +243,7 @@ defmodule Arcana.Ask do
     # its summary can describe entities from other sources in the same
     # collection. Collections, not sources, are the isolation boundary.
     source_id = Keyword.get(opts, :source_id)
-    matched_entities = scope_entities_by_source(matched_entities, source_id, repo)
+    matched_entities = scope_entities_by_evidence(matched_entities, source_id, repo, opts)
 
     if matched_entities == [] do
       %{}
@@ -252,12 +253,16 @@ defmodule Arcana.Ask do
 
       expanded_ids =
         entity_ids
-        |> Arcana.Graph.expand_entity_ids(graph_depth, collection_ids, repo: repo)
+        |> Arcana.Graph.expand_entity_ids(graph_depth, collection_ids,
+          repo: repo,
+          source_id: source_id
+        )
         |> Map.values()
         |> List.flatten()
-        |> entity_ids_in_source(source_id, repo)
+        |> entity_ids_with_evidence(source_id, repo, opts)
 
-      relationships = fetch_relationships(expanded_ids, entity_ids, graph_depth, rel_limit, repo)
+      relationships =
+        fetch_relationships(expanded_ids, entity_ids, graph_depth, rel_limit, source_id, repo)
 
       level_filter =
         case summary_levels do
@@ -280,7 +285,7 @@ defmodule Arcana.Ask do
           from(c in Community,
             where:
               fragment("? && ?", c.entity_ids, ^matched_binary) and
-                not is_nil(c.summary) and c.summary != "",
+                not c.dirty and not is_nil(c.summary) and c.summary != "",
             where: ^level_filter,
             order_by: [
               desc:
@@ -309,12 +314,13 @@ defmodule Arcana.Ask do
   # source AND target both matched the query. With graph_depth > 0 the edge
   # closure runs over the expanded entity set, ordered so edges touching a
   # directly matched entity win the limit over neighbor-to-neighbor edges.
-  defp fetch_relationships(expanded_ids, _matched_ids, 0, rel_limit, repo) do
+  defp fetch_relationships(expanded_ids, _matched_ids, 0, rel_limit, source_id, repo) do
     import Ecto.Query
-    alias Arcana.Graph.{Entity, Relationship}
+    alias Arcana.Graph.Entity
+    alias Arcana.RetrievalScope
 
-    repo.all(
-      from(r in Relationship,
+    query =
+      from([relationship: r] in RetrievalScope.relationships(source_id),
         join: src in Entity,
         on: r.source_id == src.id,
         join: tgt in Entity,
@@ -323,15 +329,17 @@ defmodule Arcana.Ask do
         select: %{source: src.name, target: tgt.name, type: r.type},
         limit: ^rel_limit
       )
-    )
+
+    repo.all(query)
   end
 
-  defp fetch_relationships(expanded_ids, matched_ids, _depth, rel_limit, repo) do
+  defp fetch_relationships(expanded_ids, matched_ids, _depth, rel_limit, source_id, repo) do
     import Ecto.Query
-    alias Arcana.Graph.{Entity, Relationship}
+    alias Arcana.Graph.Entity
+    alias Arcana.RetrievalScope
 
-    repo.all(
-      from(r in Relationship,
+    query =
+      from([relationship: r] in RetrievalScope.relationships(source_id),
         join: src in Entity,
         on: r.source_id == src.id,
         join: tgt in Entity,
@@ -341,43 +349,61 @@ defmodule Arcana.Ask do
         select: %{source: src.name, target: tgt.name, type: r.type},
         limit: ^rel_limit
       )
-    )
+
+    repo.all(query)
   end
 
-  defp scope_entities_by_source(entities, nil, _repo), do: entities
-  defp scope_entities_by_source([], _source_id, _repo), do: []
+  defp scope_entities_by_evidence([], _source_id, _repo, _opts), do: []
 
-  defp scope_entities_by_source(entities, source_id, repo) do
+  defp scope_entities_by_evidence(entities, source_id, repo, opts) do
     in_source =
       entities
       |> Enum.map(& &1.id)
-      |> entity_ids_in_source(source_id, repo)
+      |> entity_ids_with_evidence(source_id, repo, opts)
       |> MapSet.new()
 
     Enum.filter(entities, &MapSet.member?(in_source, &1.id))
   end
 
-  # An entity belongs to a source when at least one of its mentions sits
-  # on a chunk of a document with that source_id.
-  defp entity_ids_in_source(ids, nil, _repo), do: ids
-  defp entity_ids_in_source([], _source_id, _repo), do: []
+  # An entity is visible when at least one mention belongs to a completed
+  # document. A source filter narrows that evidence further.
+  defp entity_ids_with_evidence([], _source_id, _repo, _opts), do: []
 
-  defp entity_ids_in_source(ids, source_id, repo) do
+  defp entity_ids_with_evidence(ids, nil, repo, opts) do
+    if ecto_graph_store?(opts), do: published_entity_ids(ids, nil, repo), else: ids
+  end
+
+  defp entity_ids_with_evidence(ids, source_id, repo, _opts) do
+    published_entity_ids(ids, source_id, repo)
+  end
+
+  defp published_entity_ids(ids, source_id, repo) do
     import Ecto.Query
-    alias Arcana.{Chunk, Document}
-    alias Arcana.Graph.EntityMention
+    alias Arcana.RetrievalScope
 
-    repo.all(
-      from(m in EntityMention,
-        join: c in Chunk,
-        on: c.id == m.chunk_id,
-        join: d in Document,
-        on: d.id == c.document_id,
-        where: m.entity_id in ^ids and d.source_id == ^source_id,
+    query =
+      from([mention: m] in RetrievalScope.mentions(),
+        where: m.entity_id in ^ids,
         select: m.entity_id,
         distinct: true
       )
-    )
+
+    query =
+      if source_id do
+        from([document: d] in query, where: d.source_id == ^source_id)
+      else
+        query
+      end
+
+    repo.all(query)
+  end
+
+  defp ecto_graph_store?(opts) do
+    case Keyword.get(opts, :graph_store, GraphStore.backend()) do
+      :ecto -> true
+      {:ecto, _opts} -> true
+      _other -> false
+    end
   end
 
   defp entity_ids_to_binary(entity_ids) do

--- a/lib/arcana/collection.ex
+++ b/lib/arcana/collection.ex
@@ -140,18 +140,4 @@ defmodule Arcana.Collection do
       collection -> {:ok, collection.id}
     end
   end
-
-  @doc """
-  Extracts collection names from search/ask opts.
-
-  Looks for `:collections` (list) or `:collection` (single name).
-  Returns `[nil]` if neither is set.
-  """
-  def names_from_opts(opts) do
-    cond do
-      Keyword.has_key?(opts, :collections) -> Keyword.get(opts, :collections)
-      Keyword.has_key?(opts, :collection) -> [Keyword.get(opts, :collection)]
-      true -> [nil]
-    end
-  end
 end

--- a/lib/arcana/collection.ex
+++ b/lib/arcana/collection.ex
@@ -93,21 +93,32 @@ defmodule Arcana.Collection do
 
   def resolve_ids([nil], _repo, _opts), do: {:ok, nil}
 
+  def resolve_ids([], _repo, _opts), do: {:ok, []}
+
   def resolve_ids(names, repo, opts) when is_list(names) do
     strict? = Keyword.get(opts, :strict, false)
 
-    names
-    |> Enum.reject(&is_nil/1)
-    |> Enum.reduce_while({:ok, []}, fn name, {:ok, acc} ->
-      case resolve_id(name, repo, strict?) do
-        {:ok, nil} -> {:cont, {:ok, acc}}
-        {:ok, id} -> {:cont, {:ok, [id | acc]}}
-        {:error, _} = error -> {:halt, error}
-      end
-    end)
-    |> case do
-      {:ok, ids} -> {:ok, Enum.reverse(ids)}
-      error -> error
+    names = Enum.reject(names, &is_nil/1)
+
+    resolve_collection_ids(names, repo, strict?)
+  end
+
+  defp resolve_collection_ids([], _repo, _strict?), do: {:ok, []}
+
+  defp resolve_collection_ids(names, repo, strict?) do
+    import Ecto.Query
+
+    ids_by_name =
+      from(c in __MODULE__, where: c.name in ^names, select: {c.name, c.id})
+      |> repo.all()
+      |> Map.new()
+
+    case strict? && Enum.find(names, &(not Map.has_key?(ids_by_name, &1))) do
+      missing when is_binary(missing) ->
+        {:error, {:unknown_collection, missing}}
+
+      _ ->
+        {:ok, names |> Enum.map(&Map.get(ids_by_name, &1)) |> Enum.reject(&is_nil/1)}
     end
   end
 

--- a/lib/arcana/collection_scope.ex
+++ b/lib/arcana/collection_scope.ex
@@ -1,0 +1,115 @@
+defmodule Arcana.CollectionScope do
+  @moduledoc """
+  Represents the collections included in a read.
+
+  Public inputs are normalized before they reach query code:
+
+    * `:all` includes every collection
+    * a collection name includes only that collection
+    * a list of names includes those collections
+    * an empty list matches no collections
+
+  Collection names must be non-empty binaries. Normalization preserves their
+  order while removing duplicates.
+  """
+
+  @type name :: String.t()
+  @type input :: :all | name() | [name()]
+  @type t :: :all | {:only, [name()]}
+  @type error_reason ::
+          {:invalid_collection_scope, term()} | :conflicting_collection_options
+
+  @doc """
+  Normalizes a public collection scope.
+
+  Returns `{:error, {:invalid_collection_scope, input}}` when a name is blank
+  or an input has an unsupported shape.
+  """
+  @spec normalize(term()) :: {:ok, t()} | {:error, error_reason()}
+  def normalize(:all), do: {:ok, :all}
+
+  def normalize(name) when is_binary(name) do
+    if valid_name?(name) do
+      {:ok, {:only, [name]}}
+    else
+      invalid_scope(name)
+    end
+  end
+
+  def normalize(names) when is_list(names) do
+    if Enum.all?(names, &valid_name?/1) do
+      {:ok, {:only, Enum.uniq(names)}}
+    else
+      invalid_scope(names)
+    end
+  end
+
+  def normalize(input), do: invalid_scope(input)
+
+  @doc """
+  Normalizes a collection scope or raises `ArgumentError`.
+  """
+  @spec normalize!(term()) :: t()
+  def normalize!(input) do
+    case normalize(input) do
+      {:ok, scope} -> scope
+      {:error, reason} -> raise ArgumentError, error_message(reason)
+    end
+  end
+
+  @doc """
+  Reads a collection scope from keyword options.
+
+  The `:collection` and `:collections` options are mutually exclusive. When
+  neither is present, `default` is normalized instead.
+  """
+  @spec from_opts(keyword(), input()) :: {:ok, t()} | {:error, error_reason()}
+  def from_opts(opts, default) when is_list(opts) do
+    collection? = Keyword.has_key?(opts, :collection)
+    collections? = Keyword.has_key?(opts, :collections)
+
+    case {collection?, collections?} do
+      {true, true} -> {:error, :conflicting_collection_options}
+      {true, false} -> normalize(Keyword.fetch!(opts, :collection))
+      {false, true} -> normalize(Keyword.fetch!(opts, :collections))
+      {false, false} -> normalize(default)
+    end
+  end
+
+  @doc """
+  Reads and normalizes a collection scope from options or raises `ArgumentError`.
+  """
+  @spec from_opts!(keyword(), input()) :: t()
+  def from_opts!(opts, default) do
+    case from_opts(opts, default) do
+      {:ok, scope} -> scope
+      {:error, reason} -> raise ArgumentError, error_message(reason)
+    end
+  end
+
+  @doc """
+  Returns the intersection of two normalized collection scopes.
+
+  When both scopes list names, their order follows the first scope.
+  """
+  @spec intersect(t(), t()) :: t()
+  def intersect(:all, scope), do: scope
+  def intersect(scope, :all), do: scope
+
+  def intersect({:only, first}, {:only, second}) do
+    included = MapSet.new(second)
+    {:only, Enum.filter(first, &MapSet.member?(included, &1))}
+  end
+
+  defp valid_name?(name), do: is_binary(name) and String.trim(name) != ""
+
+  defp invalid_scope(input), do: {:error, {:invalid_collection_scope, input}}
+
+  defp error_message(:conflicting_collection_options) do
+    ":collection and :collections cannot be used together"
+  end
+
+  defp error_message({:invalid_collection_scope, input}) do
+    "collection scope must be :all, a non-empty name, or a list of non-empty names, got: #{inspect(input)}"
+  end
+end

--- a/lib/arcana/collection_scope.ex
+++ b/lib/arcana/collection_scope.ex
@@ -17,7 +17,7 @@ defmodule Arcana.CollectionScope do
   @type input :: :all | name() | [name()]
   @type t :: :all | {:only, [name()]}
   @type error_reason ::
-          {:invalid_collection_scope, term()} | :conflicting_collection_options
+          {:invalid_collection_scope, term()} | {:unsupported_collection_option, atom()}
 
   @doc """
   Normalizes a public collection scope.
@@ -60,19 +60,21 @@ defmodule Arcana.CollectionScope do
   @doc """
   Reads a collection scope from keyword options.
 
-  The `:collection` and `:collections` options are mutually exclusive. When
-  neither is present, `default` is normalized instead.
+  The `:collection` option accepts every public scope shape. When it is absent,
+  `default` is normalized instead. The removed `:collections` alias is rejected
+  so an outdated scoped caller cannot silently widen to the default.
   """
   @spec from_opts(keyword(), input()) :: {:ok, t()} | {:error, error_reason()}
   def from_opts(opts, default) when is_list(opts) do
-    collection? = Keyword.has_key?(opts, :collection)
-    collections? = Keyword.has_key?(opts, :collections)
+    cond do
+      Keyword.has_key?(opts, :collections) ->
+        {:error, {:unsupported_collection_option, :collections}}
 
-    case {collection?, collections?} do
-      {true, true} -> {:error, :conflicting_collection_options}
-      {true, false} -> normalize(Keyword.fetch!(opts, :collection))
-      {false, true} -> normalize(Keyword.fetch!(opts, :collections))
-      {false, false} -> normalize(default)
+      Keyword.has_key?(opts, :collection) ->
+        normalize(Keyword.fetch!(opts, :collection))
+
+      true ->
+        normalize(default)
     end
   end
 
@@ -101,12 +103,27 @@ defmodule Arcana.CollectionScope do
     {:only, Enum.filter(first, &MapSet.member?(included, &1))}
   end
 
+  @doc """
+  Returns whether every collection in `scope` is included in `allowed`.
+
+  This is useful at authorization boundaries where silently intersecting an
+  explicit request would accept only part of a forged scope.
+  """
+  @spec subset?(t(), t()) :: boolean()
+  def subset?(_scope, :all), do: true
+  def subset?(:all, {:only, _allowed}), do: false
+
+  def subset?({:only, names}, {:only, allowed}) do
+    allowed = MapSet.new(allowed)
+    Enum.all?(names, &MapSet.member?(allowed, &1))
+  end
+
   defp valid_name?(name), do: is_binary(name) and String.trim(name) != ""
 
   defp invalid_scope(input), do: {:error, {:invalid_collection_scope, input}}
 
-  defp error_message(:conflicting_collection_options) do
-    ":collection and :collections cannot be used together"
+  defp error_message({:unsupported_collection_option, :collections}) do
+    ":collections is not supported, pass the scope through :collection"
   end
 
   defp error_message({:invalid_collection_scope, input}) do

--- a/lib/arcana/document_metadata.ex
+++ b/lib/arcana/document_metadata.ex
@@ -1,0 +1,28 @@
+defmodule Arcana.DocumentMetadata do
+  @moduledoc """
+  Sparse document attribution returned by `Arcana.get_document_metadata/2`.
+
+  This shape deliberately leaves out document content, ingestion state, and
+  associations. Use `to_map/1` when passing it to an encoder or another API.
+  """
+
+  defstruct [:id, :source_id, metadata: %{}]
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          source_id: String.t() | nil,
+          metadata: map()
+        }
+
+  @doc """
+  Returns the documented plain-map representation of the metadata projection.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = document) do
+    %{
+      id: document.id,
+      source_id: document.source_id,
+      metadata: document.metadata
+    }
+  end
+end

--- a/lib/arcana/documents.ex
+++ b/lib/arcana/documents.ex
@@ -13,7 +13,7 @@ defmodule Arcana.Documents do
 
   import Ecto.Query
 
-  alias Arcana.Document
+  alias Arcana.{CollectionScope, Document, DocumentMetadata, RetrievalScope}
 
   @doc """
   Lists documents, newest first.
@@ -21,8 +21,9 @@ defmodule Arcana.Documents do
   ## Options
 
     * `:repo` - The Ecto repo to use (required unless configured globally)
-    * `:collection` - Filter by collection name. A name that doesn't
-      exist matches nothing.
+    * `:collection` - Filter by one collection name, or use `:all`
+    * `:collections` - Filter by several collection names, or use `:all`.
+      An empty list matches nothing and unknown names never widen the query.
     * `:status` - Filter by status (`:pending`, `:processing`,
       `:completed`, `:failed`)
     * `:source_id` - Filter by source id
@@ -76,18 +77,28 @@ defmodule Arcana.Documents do
   ## Options
 
     * `:repo` - The Ecto repo to use (required unless configured globally)
+    * `:collection` - Limit the lookup to one collection name, or use `:all`
+    * `:collections` - Limit the lookup to several collection names, or use
+      `:all`. An empty list matches nothing.
 
   ## Examples
 
       {:ok, document} = Arcana.get_document(id, repo: MyApp.Repo)
+      {:ok, document} =
+        Arcana.get_document(id, repo: MyApp.Repo, collections: ["support", "api"])
 
   """
   def get_document(id, opts) do
     repo = require_repo!(opts)
+    collection_scope = CollectionScope.from_opts!(opts, :all)
 
     with {:ok, uuid} <- Ecto.UUID.cast(id),
          %Document{} = document <-
-           repo.one(from(d in Document, where: d.id == ^uuid, preload: [:collection])) do
+           Document
+           |> apply_collection_scope(collection_scope)
+           |> where([d], d.id == ^uuid)
+           |> preload([:collection])
+           |> repo.one() do
       {:ok, document}
     else
       # Malformed ids can't match anything, same outcome as a missing row
@@ -95,19 +106,58 @@ defmodule Arcana.Documents do
     end
   end
 
+  @doc """
+  Fetches sparse metadata for several published documents in one query.
+
+  A collection scope is required. Pass `collection: "support"`,
+  `collections: ["support", "api"]`, or an explicit `collection: :all`.
+  Missing IDs, documents outside the scope, and documents that have not
+  completed ingestion are omitted from the returned ID-keyed map. Duplicate
+  IDs are queried once.
+
+  Returns `{:error, {:invalid_document_id, id}}` without querying when any ID
+  is not a valid UUID.
+
+  ## Options
+
+    * `:repo` - The Ecto repo to use (required unless configured globally)
+    * `:collection` - One collection name, or `:all`
+    * `:collections` - Several collection names, or `:all`
+
+  """
+  @spec get_document_metadata([Ecto.UUID.t()], keyword()) ::
+          {:ok, %{optional(Ecto.UUID.t()) => DocumentMetadata.t()}}
+          | {:error, {:invalid_document_id, term()}}
+  def get_document_metadata(ids, opts) when is_list(ids) do
+    repo = require_repo!(opts)
+    require_collection_scope!(opts)
+    collection_scope = CollectionScope.from_opts!(opts, :all)
+
+    with {:ok, ids} <- cast_document_ids(ids) do
+      fetch_document_metadata(ids, collection_scope, repo)
+    end
+  end
+
+  def get_document_metadata(ids, _opts) do
+    raise ArgumentError, ":document_ids must be a list, got: #{inspect(ids)}"
+  end
+
   defp base_query(opts) do
+    collection_scope = CollectionScope.from_opts!(opts, :all)
+
     Document
-    |> filter_collection(Keyword.get(opts, :collection))
+    |> apply_collection_scope(collection_scope)
     |> filter_status(Keyword.get(opts, :status))
     |> filter_source_id(Keyword.get(opts, :source_id))
   end
 
-  defp filter_collection(query, nil), do: query
+  defp apply_collection_scope(query, :all), do: query
+  defp apply_collection_scope(query, {:only, []}), do: from(d in query, where: false)
 
-  defp filter_collection(query, collection_name) do
+  defp apply_collection_scope(query, {:only, collection_names}) do
     from(d in query,
       join: c in assoc(d, :collection),
-      where: c.name == ^collection_name
+      where: c.name in ^collection_names
     )
   end
 
@@ -118,6 +168,44 @@ defmodule Arcana.Documents do
   defp filter_source_id(query, source_id), do: from(d in query, where: d.source_id == ^source_id)
 
   defp require_repo!(opts), do: Arcana.Config.require_repo!(opts)
+
+  defp fetch_document_metadata([], _collection_scope, _repo), do: {:ok, %{}}
+
+  defp fetch_document_metadata(ids, collection_scope, repo) do
+    metadata =
+      RetrievalScope.documents()
+      |> apply_collection_scope(collection_scope)
+      |> where([document: d], d.id in ^ids)
+      |> select([document: d], %{id: d.id, source_id: d.source_id, metadata: d.metadata})
+      |> repo.all()
+      |> Map.new(fn attributes ->
+        document = struct!(DocumentMetadata, attributes)
+        {document.id, document}
+      end)
+
+    {:ok, metadata}
+  end
+
+  defp require_collection_scope!(opts) do
+    unless Keyword.has_key?(opts, :collection) or Keyword.has_key?(opts, :collections) do
+      raise ArgumentError,
+            "get_document_metadata/2 requires an explicit :collection or :collections scope"
+    end
+  end
+
+  defp cast_document_ids(ids) do
+    ids
+    |> Enum.reduce_while({:ok, []}, fn id, {:ok, cast_ids} ->
+      case Ecto.UUID.cast(id) do
+        {:ok, uuid} -> {:cont, {:ok, [uuid | cast_ids]}}
+        :error -> {:halt, {:error, {:invalid_document_id, id}}}
+      end
+    end)
+    |> case do
+      {:ok, cast_ids} -> {:ok, cast_ids |> Enum.reverse() |> Enum.uniq()}
+      {:error, _reason} = error -> error
+    end
+  end
 
   defp validate_non_neg_integer!(opts, key, default) do
     case Keyword.get(opts, key, default) do

--- a/lib/arcana/documents.ex
+++ b/lib/arcana/documents.ex
@@ -21,9 +21,8 @@ defmodule Arcana.Documents do
   ## Options
 
     * `:repo` - The Ecto repo to use (required unless configured globally)
-    * `:collection` - Filter by one collection name, or use `:all`
-    * `:collections` - Filter by several collection names, or use `:all`.
-      An empty list matches nothing and unknown names never widen the query.
+    * `:collection` - Filter by `:all`, one collection name, a list of names,
+      or `[]` to match nothing. Unknown names never widen the query.
     * `:status` - Filter by status (`:pending`, `:processing`,
       `:completed`, `:failed`)
     * `:source_id` - Filter by source id
@@ -77,15 +76,14 @@ defmodule Arcana.Documents do
   ## Options
 
     * `:repo` - The Ecto repo to use (required unless configured globally)
-    * `:collection` - Limit the lookup to one collection name, or use `:all`
-    * `:collections` - Limit the lookup to several collection names, or use
-      `:all`. An empty list matches nothing.
+    * `:collection` - Limit the lookup to `:all`, one collection name, a list
+      of names, or `[]` to match nothing
 
   ## Examples
 
       {:ok, document} = Arcana.get_document(id, repo: MyApp.Repo)
       {:ok, document} =
-        Arcana.get_document(id, repo: MyApp.Repo, collections: ["support", "api"])
+        Arcana.get_document(id, repo: MyApp.Repo, collection: ["support", "api"])
 
   """
   def get_document(id, opts) do
@@ -110,7 +108,7 @@ defmodule Arcana.Documents do
   Fetches sparse metadata for several published documents in one query.
 
   A collection scope is required. Pass `collection: "support"`,
-  `collections: ["support", "api"]`, or an explicit `collection: :all`.
+  `collection: ["support", "api"]`, or an explicit `collection: :all`.
   Missing IDs, documents outside the scope, and documents that have not
   completed ingestion are omitted from the returned ID-keyed map. Duplicate
   IDs are queried once.
@@ -121,8 +119,7 @@ defmodule Arcana.Documents do
   ## Options
 
     * `:repo` - The Ecto repo to use (required unless configured globally)
-    * `:collection` - One collection name, or `:all`
-    * `:collections` - Several collection names, or `:all`
+    * `:collection` - `:all`, one collection name, a list of names, or `[]`
 
   """
   @spec get_document_metadata([Ecto.UUID.t()], keyword()) ::
@@ -130,8 +127,8 @@ defmodule Arcana.Documents do
           | {:error, {:invalid_document_id, term()}}
   def get_document_metadata(ids, opts) when is_list(ids) do
     repo = require_repo!(opts)
-    require_collection_scope!(opts)
     collection_scope = CollectionScope.from_opts!(opts, :all)
+    require_collection_scope!(opts)
 
     with {:ok, ids} <- cast_document_ids(ids) do
       fetch_document_metadata(ids, collection_scope, repo)
@@ -187,9 +184,9 @@ defmodule Arcana.Documents do
   end
 
   defp require_collection_scope!(opts) do
-    unless Keyword.has_key?(opts, :collection) or Keyword.has_key?(opts, :collections) do
+    unless Keyword.has_key?(opts, :collection) do
       raise ArgumentError,
-            "get_document_metadata/2 requires an explicit :collection or :collections scope"
+            "get_document_metadata/2 requires an explicit :collection scope"
     end
   end
 

--- a/lib/arcana/evaluation.ex
+++ b/lib/arcana/evaluation.ex
@@ -68,12 +68,11 @@ defmodule Arcana.Evaluation do
       question being evaluated, and handlers are global, so a listener that
       wants only its own run's questions has to filter on something; this
       is it.
-    * `:collection` / `:collections` - `:all`, one collection name, or a list
-      of collection names to confine the run to. The options are mutually
-      exclusive. An empty list runs no test cases. The scope controls which
-      test cases run (see `list_test_cases/1`), is forwarded to
-      the retriever so retrieval can't reach outside those collections, and
-      is recorded on the run so scoped listings can find it again.
+    * `:collection` - `:all`, one collection name, or a list of collection
+      names to confine the run to. An empty list runs no test cases. The scope
+      controls which test cases run (see `list_test_cases/1`), is forwarded to
+      the retriever so retrieval can't reach outside those collections, and is
+      recorded on the run so scoped listings can find it again.
       Retrieval then runs with `strict_collections: true` unless
       `:strict_collections` says otherwise, so a collection name with no
       row fails the search instead of widening it to the whole corpus.
@@ -85,7 +84,7 @@ defmodule Arcana.Evaluation do
     source_id = Keyword.get(opts, :source_id)
     evaluate_answers = Keyword.get(opts, :evaluate_answers, false)
     llm = Keyword.get(opts, :llm)
-    collection_scope = CollectionScope.from_opts!(opts, :all)
+    collection_scope = normalize_collection_scope!(opts)
     run_ref = Keyword.get(opts, :run_ref)
     retriever = Keyword.get(opts, :retriever, &default_retriever/2)
 
@@ -209,15 +208,15 @@ defmodule Arcana.Evaluation do
     end
   end
 
-  # Retrieval scope for the run. Passing `:collections` without strict
+  # Retrieval scope for the run. Passing collection names without strict
   # resolution would let a collection name with no row resolve to "no
   # filter", which is the whole corpus — the opposite of what a scoped run
   # asked for.
-  defp retrieval_scope_opts(_opts, :all), do: []
+  defp retrieval_scope_opts(_opts, :all), do: [collection: :all]
 
   defp retrieval_scope_opts(opts, {:only, collections}) do
     [
-      collections: collections,
+      collection: collections,
       strict_collections: Keyword.get(opts, :strict_collections, true)
     ]
   end
@@ -369,15 +368,14 @@ defmodule Arcana.Evaluation do
 
     * `:repo` - Ecto repo (required)
     * `:source_id` - Filter by source (optional)
-    * `:collection` / `:collections` - `:all`, one collection name, or a list
-      of collection names to scope the listing to. The options are mutually
-      exclusive. See "Collection scoping" below.
+    * `:collection` - `:all`, one collection name, or a list of collection
+      names to scope the listing to. See "Collection scoping" below.
 
   ## Collection scoping
 
   A test case has no collection of its own: it reaches one through its
   chunks (the relevant chunks it is scored against, and the source chunk it
-  was generated from). When `:collections` is given, only test cases whose
+  was generated from). When a collection scope is given, only test cases whose
   every linked chunk resolves to one of those collections are returned, and
   at least one link has to resolve. Anything else — a test case straddling
   two collections, one whose chunks were deleted, one with no links at all
@@ -406,18 +404,19 @@ defmodule Arcana.Evaluation do
       end
 
     query
-    |> scope_test_cases(CollectionScope.from_opts!(opts, :all))
+    |> scope_test_cases(normalize_collection_scope!(opts))
     |> repo.all()
   end
 
   @doc """
   Gets a single test case by ID.
 
-  Accepts the same `:collections` scoping option as `list_test_cases/1`;
+  Accepts the same `:collection` scoping option as `list_test_cases/1`;
   a test case outside the scope reads as missing.
   """
   def get_test_case(id, opts) do
     repo = Keyword.fetch!(opts, :repo)
+    collection_scope = normalize_collection_scope!(opts)
 
     case Ecto.UUID.cast(id) do
       :error ->
@@ -428,7 +427,7 @@ defmodule Arcana.Evaluation do
           where: tc.id == ^uuid,
           preload: [:relevant_chunks, :source_chunk]
         )
-        |> scope_test_cases(CollectionScope.from_opts!(opts, :all))
+        |> scope_test_cases(collection_scope)
         |> repo.one()
     end
   end
@@ -564,17 +563,18 @@ defmodule Arcana.Evaluation do
   @doc """
   Deletes a test case.
 
-  With `:collections`, the scope predicate rides inside the DELETE, so a
+  With `:collection`, the scope predicate rides inside the DELETE, so a
   test case outside the allowed collections is rejected with
   `{:error, :not_found}` and nothing can change between the check and the
   delete. A malformed id is rejected the same way.
   """
   def delete_test_case(id, opts) do
     repo = Keyword.fetch!(opts, :repo)
+    collection_scope = normalize_collection_scope!(opts)
 
     with {:ok, uuid} <- cast_id(id) do
       from(tc in TestCase, where: tc.id == ^uuid, select: tc)
-      |> scope_test_cases(CollectionScope.from_opts!(opts, :all))
+      |> scope_test_cases(collection_scope)
       |> delete_one(repo)
     end
   end
@@ -586,7 +586,7 @@ defmodule Arcana.Evaluation do
 
     * `:repo` - Ecto repo (required)
     * `:limit` - Maximum runs to return (default: 20)
-    * `:collections` - Only list runs recorded as having run under a
+    * `:collection` - Only list runs recorded as having run under a
       non-empty subset of these collection names
 
   """
@@ -598,22 +598,23 @@ defmodule Arcana.Evaluation do
       order_by: [desc: r.inserted_at, desc: r.id],
       limit: ^limit
     )
-    |> scope_runs(CollectionScope.from_opts!(opts, :all))
+    |> scope_runs(normalize_collection_scope!(opts))
     |> repo.all()
   end
 
   @doc """
   Gets a single evaluation run by ID.
 
-  Accepts the same `:collections` scoping option as `list_runs/1`.
+  Accepts the same `:collection` scoping option as `list_runs/1`.
   """
   def get_run(id, opts) do
     repo = Keyword.fetch!(opts, :repo)
+    collection_scope = normalize_collection_scope!(opts)
 
     case cast_id(id) do
       {:ok, uuid} ->
         from(r in Run, where: r.id == ^uuid)
-        |> scope_runs(CollectionScope.from_opts!(opts, :all))
+        |> scope_runs(collection_scope)
         |> repo.one()
 
       {:error, :not_found} ->
@@ -628,10 +629,11 @@ defmodule Arcana.Evaluation do
   """
   def delete_run(id, opts) do
     repo = Keyword.fetch!(opts, :repo)
+    collection_scope = normalize_collection_scope!(opts)
 
     with {:ok, uuid} <- cast_id(id) do
       from(r in Run, where: r.id == ^uuid, select: r)
-      |> scope_runs(CollectionScope.from_opts!(opts, :all))
+      |> scope_runs(collection_scope)
       |> delete_one(repo)
     end
   end
@@ -639,13 +641,13 @@ defmodule Arcana.Evaluation do
   @doc """
   Returns count of test cases.
 
-  Accepts the same `:collections` scoping option as `list_test_cases/1`.
+  Accepts the same `:collection` scoping option as `list_test_cases/1`.
   """
   def count_test_cases(opts) do
     repo = Keyword.fetch!(opts, :repo)
 
     from(tc in TestCase, select: count(tc.id))
-    |> scope_test_cases(CollectionScope.from_opts!(opts, :all))
+    |> scope_test_cases(normalize_collection_scope!(opts))
     |> repo.one() || 0
   end
 
@@ -656,6 +658,10 @@ defmodule Arcana.Evaluation do
       {:ok, uuid} -> {:ok, uuid}
       :error -> {:error, :not_found}
     end
+  end
+
+  defp normalize_collection_scope!(opts) do
+    CollectionScope.from_opts!(opts, :all)
   end
 
   defp delete_one(query, repo) do

--- a/lib/arcana/evaluation.ex
+++ b/lib/arcana/evaluation.ex
@@ -25,7 +25,7 @@ defmodule Arcana.Evaluation do
 
   import Ecto.Query
 
-  alias Arcana.{Collection, Document}
+  alias Arcana.{Collection, CollectionScope, Document}
   alias Arcana.Evaluation.{Generator, Metrics, Run, TestCase}
 
   @doc """
@@ -68,8 +68,10 @@ defmodule Arcana.Evaluation do
       question being evaluated, and handlers are global, so a listener that
       wants only its own run's questions has to filter on something; this
       is it.
-    * `:collections` - List of collection names to confine the run to. It
-      scopes which test cases run (see `list_test_cases/1`), is forwarded to
+    * `:collection` / `:collections` - `:all`, one collection name, or a list
+      of collection names to confine the run to. The options are mutually
+      exclusive. An empty list runs no test cases. The scope controls which
+      test cases run (see `list_test_cases/1`), is forwarded to
       the retriever so retrieval can't reach outside those collections, and
       is recorded on the run so scoped listings can find it again.
       Retrieval then runs with `strict_collections: true` unless
@@ -83,12 +85,12 @@ defmodule Arcana.Evaluation do
     source_id = Keyword.get(opts, :source_id)
     evaluate_answers = Keyword.get(opts, :evaluate_answers, false)
     llm = Keyword.get(opts, :llm)
-    collections = Keyword.get(opts, :collections)
+    collection_scope = CollectionScope.from_opts!(opts, :all)
     run_ref = Keyword.get(opts, :run_ref)
     retriever = Keyword.get(opts, :retriever, &default_retriever/2)
 
     retriever_opts =
-      [repo: repo, mode: mode, limit: 10] ++ retrieval_scope_opts(opts, collections)
+      [repo: repo, mode: mode, limit: 10] ++ retrieval_scope_opts(opts, collection_scope)
 
     # Validate llm is provided when evaluate_answers is true
     if evaluate_answers and is_nil(llm) do
@@ -108,7 +110,7 @@ defmodule Arcana.Evaluation do
         |> Map.put(:mode, mode)
         |> Map.put(:source_id, source_id)
         |> Map.put(:evaluate_answers, evaluate_answers)
-        |> put_run_collections(collections)
+        |> put_run_collections(collection_scope)
 
       # Create a run record
       {:ok, run} =
@@ -211,17 +213,20 @@ defmodule Arcana.Evaluation do
   # resolution would let a collection name with no row resolve to "no
   # filter", which is the whole corpus — the opposite of what a scoped run
   # asked for.
-  defp retrieval_scope_opts(_opts, nil), do: []
+  defp retrieval_scope_opts(_opts, :all), do: []
 
-  defp retrieval_scope_opts(opts, collections) when is_list(collections) do
+  defp retrieval_scope_opts(opts, {:only, collections}) do
     [
       collections: collections,
       strict_collections: Keyword.get(opts, :strict_collections, true)
     ]
   end
 
-  defp put_run_collections(config, nil), do: config
-  defp put_run_collections(config, collections), do: Map.put(config, :collections, collections)
+  defp put_run_collections(config, :all), do: config
+
+  defp put_run_collections(config, {:only, collections}) do
+    Map.put(config, :collections, collections)
+  end
 
   defp evaluate_test_case(test_case, retriever_opts, evaluate_answers, llm, retriever) do
     {search_results, pre_generated_answer} =
@@ -364,8 +369,9 @@ defmodule Arcana.Evaluation do
 
     * `:repo` - Ecto repo (required)
     * `:source_id` - Filter by source (optional)
-    * `:collections` - List of collection names to scope the listing to.
-      See "Collection scoping" below.
+    * `:collection` / `:collections` - `:all`, one collection name, or a list
+      of collection names to scope the listing to. The options are mutually
+      exclusive. See "Collection scoping" below.
 
   ## Collection scoping
 
@@ -400,7 +406,7 @@ defmodule Arcana.Evaluation do
       end
 
     query
-    |> scope_test_cases(Keyword.get(opts, :collections))
+    |> scope_test_cases(CollectionScope.from_opts!(opts, :all))
     |> repo.all()
   end
 
@@ -422,14 +428,14 @@ defmodule Arcana.Evaluation do
           where: tc.id == ^uuid,
           preload: [:relevant_chunks, :source_chunk]
         )
-        |> scope_test_cases(Keyword.get(opts, :collections))
+        |> scope_test_cases(CollectionScope.from_opts!(opts, :all))
         |> repo.one()
     end
   end
 
-  defp scope_test_cases(query, nil), do: query
+  defp scope_test_cases(query, :all), do: query
 
-  defp scope_test_cases(query, collections) when is_list(collections) do
+  defp scope_test_cases(query, {:only, collections}) do
     from(tc in query, where: tc.id in subquery(scoped_test_case_ids(collections)))
   end
 
@@ -504,9 +510,9 @@ defmodule Arcana.Evaluation do
   # config. A scoped listing only sees runs whose recorded scope is a
   # non-empty subset of what the caller may read: unscoped runs (an
   # unrestricted dashboard's, or any run predating this) stay hidden.
-  defp scope_runs(query, nil), do: query
+  defp scope_runs(query, :all), do: query
 
-  defp scope_runs(query, collections) when is_list(collections) do
+  defp scope_runs(query, {:only, collections}) do
     from(r in query,
       where: fragment("jsonb_typeof(?->'collections') = 'array'", r.config),
       where: fragment("?->'collections' <> '[]'::jsonb", r.config),
@@ -568,7 +574,7 @@ defmodule Arcana.Evaluation do
 
     with {:ok, uuid} <- cast_id(id) do
       from(tc in TestCase, where: tc.id == ^uuid, select: tc)
-      |> scope_test_cases(Keyword.get(opts, :collections))
+      |> scope_test_cases(CollectionScope.from_opts!(opts, :all))
       |> delete_one(repo)
     end
   end
@@ -592,7 +598,7 @@ defmodule Arcana.Evaluation do
       order_by: [desc: r.inserted_at, desc: r.id],
       limit: ^limit
     )
-    |> scope_runs(Keyword.get(opts, :collections))
+    |> scope_runs(CollectionScope.from_opts!(opts, :all))
     |> repo.all()
   end
 
@@ -607,7 +613,7 @@ defmodule Arcana.Evaluation do
     case cast_id(id) do
       {:ok, uuid} ->
         from(r in Run, where: r.id == ^uuid)
-        |> scope_runs(Keyword.get(opts, :collections))
+        |> scope_runs(CollectionScope.from_opts!(opts, :all))
         |> repo.one()
 
       {:error, :not_found} ->
@@ -625,7 +631,7 @@ defmodule Arcana.Evaluation do
 
     with {:ok, uuid} <- cast_id(id) do
       from(r in Run, where: r.id == ^uuid, select: r)
-      |> scope_runs(Keyword.get(opts, :collections))
+      |> scope_runs(CollectionScope.from_opts!(opts, :all))
       |> delete_one(repo)
     end
   end
@@ -639,7 +645,7 @@ defmodule Arcana.Evaluation do
     repo = Keyword.fetch!(opts, :repo)
 
     from(tc in TestCase, select: count(tc.id))
-    |> scope_test_cases(Keyword.get(opts, :collections))
+    |> scope_test_cases(CollectionScope.from_opts!(opts, :all))
     |> repo.one() || 0
   end
 

--- a/lib/arcana/evaluation/generator.ex
+++ b/lib/arcana/evaluation/generator.ex
@@ -8,8 +8,8 @@ defmodule Arcana.Evaluation.Generator do
 
   import Ecto.Query
 
-  alias Arcana.{Chunk, LLM}
   alias Arcana.Evaluation.TestCase
+  alias Arcana.{LLM, RetrievalScope}
 
   @default_prompt """
   Given this text chunk from a document, generate a natural question that can ONLY be answered using information in this chunk.
@@ -69,22 +69,21 @@ defmodule Arcana.Evaluation.Generator do
 
   defp sample_chunks(repo, sample_size, source_id, collection) do
     query =
-      from(c in Chunk,
-        join: d in assoc(c, :document),
+      from([chunk: c] in RetrievalScope.chunks(),
         order_by: fragment("RANDOM()"),
         limit: ^sample_size
       )
 
     query =
       if source_id do
-        from([c, d] in query, where: d.source_id == ^source_id)
+        from([document: d] in query, where: d.source_id == ^source_id)
       else
         query
       end
 
     query =
       if collection do
-        from([c, d] in query,
+        from([document: d] in query,
           join: col in assoc(d, :collection),
           where: col.name == ^collection
         )

--- a/lib/arcana/evaluation/generator.ex
+++ b/lib/arcana/evaluation/generator.ex
@@ -32,9 +32,8 @@ defmodule Arcana.Evaluation.Generator do
     * `:llm` - LLM implementing Arcana.LLM protocol (required)
     * `:sample_size` - Number of chunks to sample (default: 50)
     * `:source_id` - Limit to chunks from specific source
-    * `:collection` / `:collections` - `:all`, one collection name, or a list
-      of collection names. The options are mutually exclusive. An empty list
-      samples no chunks.
+    * `:collection` - `:all`, one collection name, or a list of collection
+      names. An empty list samples no chunks.
     * `:prompt` - Custom prompt template (must include {chunk_text})
 
   """
@@ -43,7 +42,9 @@ defmodule Arcana.Evaluation.Generator do
     llm = Keyword.fetch!(opts, :llm)
     sample_size = Keyword.get(opts, :sample_size, 50)
     source_id = Keyword.get(opts, :source_id)
+
     collection_scope = CollectionScope.from_opts!(opts, :all)
+
     prompt_template = Keyword.get(opts, :prompt, @default_prompt)
 
     chunks = sample_chunks(repo, sample_size, source_id, collection_scope)

--- a/lib/arcana/evaluation/generator.ex
+++ b/lib/arcana/evaluation/generator.ex
@@ -8,8 +8,8 @@ defmodule Arcana.Evaluation.Generator do
 
   import Ecto.Query
 
+  alias Arcana.{CollectionScope, LLM, RetrievalScope}
   alias Arcana.Evaluation.TestCase
-  alias Arcana.{LLM, RetrievalScope}
 
   @default_prompt """
   Given this text chunk from a document, generate a natural question that can ONLY be answered using information in this chunk.
@@ -32,7 +32,9 @@ defmodule Arcana.Evaluation.Generator do
     * `:llm` - LLM implementing Arcana.LLM protocol (required)
     * `:sample_size` - Number of chunks to sample (default: 50)
     * `:source_id` - Limit to chunks from specific source
-    * `:collection` - Limit to chunks from specific collection
+    * `:collection` / `:collections` - `:all`, one collection name, or a list
+      of collection names. The options are mutually exclusive. An empty list
+      samples no chunks.
     * `:prompt` - Custom prompt template (must include {chunk_text})
 
   """
@@ -41,10 +43,10 @@ defmodule Arcana.Evaluation.Generator do
     llm = Keyword.fetch!(opts, :llm)
     sample_size = Keyword.get(opts, :sample_size, 50)
     source_id = Keyword.get(opts, :source_id)
-    collection = Keyword.get(opts, :collection)
+    collection_scope = CollectionScope.from_opts!(opts, :all)
     prompt_template = Keyword.get(opts, :prompt, @default_prompt)
 
-    chunks = sample_chunks(repo, sample_size, source_id, collection)
+    chunks = sample_chunks(repo, sample_size, source_id, collection_scope)
 
     test_cases =
       chunks
@@ -67,7 +69,7 @@ defmodule Arcana.Evaluation.Generator do
   """
   def default_prompt, do: @default_prompt
 
-  defp sample_chunks(repo, sample_size, source_id, collection) do
+  defp sample_chunks(repo, sample_size, source_id, collection_scope) do
     query =
       from([chunk: c] in RetrievalScope.chunks(),
         order_by: fragment("RANDOM()"),
@@ -81,17 +83,18 @@ defmodule Arcana.Evaluation.Generator do
         query
       end
 
-    query =
-      if collection do
-        from([document: d] in query,
-          join: col in assoc(d, :collection),
-          where: col.name == ^collection
-        )
-      else
-        query
-      end
+    query = scope_chunks(query, collection_scope)
 
     repo.all(query)
+  end
+
+  defp scope_chunks(query, :all), do: query
+
+  defp scope_chunks(query, {:only, collection_names}) do
+    from([document: d] in query,
+      join: col in assoc(d, :collection),
+      where: col.name in ^collection_names
+    )
   end
 
   defp generate_question(llm, chunk, prompt_template) do

--- a/lib/arcana/graph.ex
+++ b/lib/arcana/graph.ex
@@ -692,7 +692,7 @@ defmodule Arcana.Graph do
         # for DB writes only.
         entities = maybe_embed_entities(entities)
 
-        merged_entity_id_map =
+        {merged_entity_id_map, persisted_relationship_count} =
           persist_chunk_graph(
             collection_id,
             chunk_id,
@@ -706,7 +706,7 @@ defmodule Arcana.Graph do
         # Report progress
         progress_fn.(index, total_chunks)
 
-        {merged_entity_id_map, rel_count + length(relationships)}
+        {merged_entity_id_map, rel_count + persisted_relationship_count}
     end)
   end
 
@@ -717,12 +717,9 @@ defmodule Arcana.Graph do
   #
   # Atomicity here is store-dependent (see GraphStore.with_write_lock/3).
   # The :ecto backend holds the lock inside a transaction, so a failure
-  # anywhere in the trio rolls the whole chunk back. The :memory backend
-  # and custom stores that skip the optional callback just run the trio,
-  # so a failure mid-trio leaves that chunk's graph data half-persisted;
-  # the raise then aborts the build. Nothing downstream cleans that up,
-  # and no caller of build_and_persist/4 treats a failed build as having
-  # left the graph untouched.
+  # anywhere in the trio rolls the whole chunk back. Other backends provide
+  # the same serialization, but may leave partial graph data if their lock
+  # does not also provide transactional rollback.
   defp persist_chunk_graph(
          collection_id,
          chunk_id,
@@ -733,21 +730,27 @@ defmodule Arcana.Graph do
          store_opts
        ) do
     GraphStore.with_write_lock(collection_id, store_opts, fn ->
-      {:ok, new_entity_ids} = GraphStore.persist_entities(collection_id, entities, store_opts)
+      repo = Keyword.fetch!(store_opts, :repo)
 
-      merged_entity_id_map = Map.merge(entity_id_map, new_entity_ids)
+      if repo.get(Arcana.Chunk, chunk_id) do
+        {:ok, new_entity_ids} = GraphStore.persist_entities(collection_id, entities, store_opts)
 
-      :ok = GraphStore.persist_mentions(mentions, merged_entity_id_map, store_opts)
+        merged_entity_id_map = Map.merge(entity_id_map, new_entity_ids)
 
-      :ok =
-        GraphStore.persist_relationships(
-          chunk_id,
-          relationships,
-          merged_entity_id_map,
-          store_opts
-        )
+        :ok = GraphStore.persist_mentions(mentions, merged_entity_id_map, store_opts)
 
-      merged_entity_id_map
+        :ok =
+          GraphStore.persist_relationships(
+            chunk_id,
+            relationships,
+            merged_entity_id_map,
+            store_opts
+          )
+
+        {merged_entity_id_map, length(relationships)}
+      else
+        {entity_id_map, 0}
+      end
     end)
   end
 

--- a/lib/arcana/graph.ex
+++ b/lib/arcana/graph.ex
@@ -340,21 +340,31 @@ defmodule Arcana.Graph do
   def expand_entity_ids(entity_ids, depth, collection_ids, opts)
       when is_integer(depth) and depth > 0 do
     repo = Keyword.fetch!(opts, :repo)
+    source_id = Keyword.get(opts, :source_id)
     frontier = Enum.uniq(entity_ids)
 
-    do_expand(frontier, MapSet.new(frontier), %{0 => frontier}, 1, depth, collection_ids, repo)
+    do_expand(
+      frontier,
+      MapSet.new(frontier),
+      %{0 => frontier},
+      1,
+      depth,
+      collection_ids,
+      repo,
+      source_id
+    )
   end
 
-  defp do_expand(frontier, visited, acc, hop, depth, collection_ids, repo)
+  defp do_expand(frontier, visited, acc, hop, depth, collection_ids, repo, source_id)
 
-  defp do_expand(_frontier, _visited, acc, hop, depth, _collection_ids, _repo)
+  defp do_expand(_frontier, _visited, acc, hop, depth, _collection_ids, _repo, _source_id)
        when hop > depth,
        do: acc
 
-  defp do_expand(frontier, visited, acc, hop, depth, collection_ids, repo) do
+  defp do_expand(frontier, visited, acc, hop, depth, collection_ids, repo, source_id) do
     neighbors =
       frontier
-      |> neighbor_entity_ids(collection_ids, repo)
+      |> neighbor_entity_ids(collection_ids, repo, source_id)
       |> Enum.reject(&MapSet.member?(visited, &1))
 
     case neighbors do
@@ -363,25 +373,45 @@ defmodule Arcana.Graph do
 
       ids ->
         visited = MapSet.union(visited, MapSet.new(ids))
-        do_expand(ids, visited, Map.put(acc, hop, ids), hop + 1, depth, collection_ids, repo)
+
+        do_expand(
+          ids,
+          visited,
+          Map.put(acc, hop, ids),
+          hop + 1,
+          depth,
+          collection_ids,
+          repo,
+          source_id
+        )
     end
   end
 
   # One query per hop: joining both endpoints carries each neighbor's
   # collection along, so scoping needs no second round trip.
-  defp neighbor_entity_ids(frontier, collection_ids, repo) do
+  defp neighbor_entity_ids(frontier, collection_ids, repo, source_id) do
     import Ecto.Query
 
-    repo.all(
-      from(r in Arcana.Graph.Relationship,
+    published_entity_ids =
+      from([mention: m] in Arcana.RetrievalScope.mentions(),
+        select: m.entity_id,
+        distinct: true
+      )
+
+    relationship_query =
+      from([relationship: r] in Arcana.RetrievalScope.relationships(source_id),
         join: s in Arcana.Graph.Entity,
         on: s.id == r.source_id,
         join: t in Arcana.Graph.Entity,
         on: t.id == r.target_id,
-        where: r.source_id in ^frontier or r.target_id in ^frontier,
+        where:
+          (r.source_id in ^frontier or r.target_id in ^frontier) and
+            r.source_id in subquery(published_entity_ids) and
+            r.target_id in subquery(published_entity_ids),
         select: {r.source_id, s.collection_id, r.target_id, t.collection_id}
       )
-    )
+
+    repo.all(relationship_query)
     |> Enum.flat_map(fn {source, source_collection, target, target_collection} ->
       [{source, source_collection}, {target, target_collection}]
     end)
@@ -640,7 +670,7 @@ defmodule Arcana.Graph do
         # here; nothing short of an unlinked task covers that.
         try do
           {entities, mentions, relationships} = extract_fn.(chunk)
-          {:extracted, index, entities, mentions, relationships}
+          {:extracted, index, chunk.id, entities, mentions, relationships}
         catch
           kind, reason -> {:extract_failed, kind, reason, __STACKTRACE__}
         end
@@ -655,7 +685,8 @@ defmodule Arcana.Graph do
         # leaves no half-written chunk behind.
         :erlang.raise(kind, reason, stacktrace)
 
-      {:ok, {:extracted, index, entities, mentions, relationships}}, {entity_id_map, rel_count} ->
+      {:ok, {:extracted, index, chunk_id, entities, mentions, relationships}},
+      {entity_id_map, rel_count} ->
         # Embed entity descriptions for GraphRAG-style entity search.
         # Stays outside the write lock: it can hit a model, and the lock is
         # for DB writes only.
@@ -664,6 +695,7 @@ defmodule Arcana.Graph do
         merged_entity_id_map =
           persist_chunk_graph(
             collection_id,
+            chunk_id,
             entities,
             mentions,
             relationships,
@@ -693,6 +725,7 @@ defmodule Arcana.Graph do
   # left the graph untouched.
   defp persist_chunk_graph(
          collection_id,
+         chunk_id,
          entities,
          mentions,
          relationships,
@@ -705,7 +738,14 @@ defmodule Arcana.Graph do
       merged_entity_id_map = Map.merge(entity_id_map, new_entity_ids)
 
       :ok = GraphStore.persist_mentions(mentions, merged_entity_id_map, store_opts)
-      :ok = GraphStore.persist_relationships(relationships, merged_entity_id_map, store_opts)
+
+      :ok =
+        GraphStore.persist_relationships(
+          chunk_id,
+          relationships,
+          merged_entity_id_map,
+          store_opts
+        )
 
       merged_entity_id_map
     end)

--- a/lib/arcana/graph/entity_matcher/ner.ex
+++ b/lib/arcana/graph/entity_matcher/ner.ex
@@ -22,6 +22,7 @@ defmodule Arcana.Graph.EntityMatcher.NER do
   import Ecto.Query
 
   alias Arcana.Graph.{Entity, EntityExtractor}
+  alias Arcana.RetrievalScope
 
   @impl Arcana.Graph.EntityMatcher
   def match(query, collection_ids, opts) do
@@ -39,7 +40,14 @@ defmodule Arcana.Graph.EntityMatcher.NER do
   end
 
   defp lookup_ids_by_name(entity_names, collection_ids, repo) do
-    query = from(e in Entity, where: e.name in ^entity_names, select: e.id)
+    published_entity_ids =
+      from([mention: m] in RetrievalScope.mentions(), select: m.entity_id, distinct: true)
+
+    query =
+      from(e in Entity,
+        where: e.name in ^entity_names and e.id in subquery(published_entity_ids),
+        select: e.id
+      )
 
     # nil means unscoped; a list scopes the query, and an empty list must
     # match nothing (`in []` compiles to false) — never fall back to global.

--- a/lib/arcana/graph/graph_store.ex
+++ b/lib/arcana/graph/graph_store.ex
@@ -124,6 +124,9 @@ defmodule Arcana.Graph.GraphStore do
 
   The memory backend has no such window, since the whole operation is one
   `GenServer` call.
+
+  Implementations must be idempotent. Post-commit recovery can replay the
+  same chunk IDs after a backend applied only part of an earlier attempt.
   """
   @callback delete_by_chunks(chunk_ids :: [binary()], opts :: keyword()) ::
               :ok | {:error, term()}
@@ -161,10 +164,8 @@ defmodule Arcana.Graph.GraphStore do
 
   The `:ecto` backend serializes both sides through `with_write_lock/3`
   (a transaction-scoped Postgres advisory lock keyed on the collection).
-  The `:memory` backend serializes individual calls through its GenServer
-  but leaves the window between the entity and mention calls open, which
-  is fine for a test backend. Custom backends get the full guarantee only
-  if they implement `with_write_lock/3`.
+  The `:memory` backend uses a per-server, per-collection lock around the
+  full write sequence. Custom backends must provide the same exclusion.
   """
   @callback sweep_orphans(binary(), opts :: keyword()) ::
               :ok | {:error, term()}
@@ -174,9 +175,9 @@ defmodule Arcana.Graph.GraphStore do
   @doc """
   Runs `fun` while holding the collection's graph write lock.
 
-  Optional. Backends that can serialize concurrent graph writes implement
-  this so `sweep_orphans/2` and the entity/mention persist path cannot
-  interleave. Backends that don't implement it simply run `fun`.
+  Required for every backend. It serializes graph persistence with document
+  deletion and replacement, so a chunk cannot gain graph evidence after its
+  database row has been retired.
 
   The lock is meant to cover DB writes only, never extraction, so callers
   keep the wrapped work short.
@@ -187,10 +188,9 @@ defmodule Arcana.Graph.GraphStore do
   Atomicity is best-effort and store-dependent: callers must not assume
   that a failure inside `fun` rolls back the writes it already made.
 
-  The `:ecto` backend does give both, because it takes the advisory lock
-  inside a transaction. The `:memory` backend implements neither (it
-  falls through to running `fun`), so a mid-`fun` failure leaves partial
-  graph data behind, which is fine for a test backend.
+  The `:ecto` backend gives both because it takes the advisory lock inside a
+  transaction. The `:memory` backend provides mutual exclusion but cannot
+  roll back writes already applied inside the function.
 
   A custom store that wants the full guarantee has to do what the `:ecto`
   backend does: hold a per-collection exclusive lock *and* run `fun`
@@ -201,7 +201,7 @@ defmodule Arcana.Graph.GraphStore do
   @callback with_write_lock(binary(), opts :: keyword(), (-> result)) :: result
             when result: term()
 
-  @optional_callbacks with_write_lock: 3, sweep_orphans: 2
+  @optional_callbacks sweep_orphans: 2
 
   # === Detail Query Callbacks ===
 
@@ -436,6 +436,11 @@ defmodule Arcana.Graph.GraphStore do
 
   `Arcana.delete/2` is usually what you want: it removes the document, its
   chunks and their graph data together.
+
+  `:published_chunk_ids` may be passed when replaying cleanup after the
+  database rows have already committed away. It records which deleted chunks
+  were published before deletion so backends can preserve publication-aware
+  invalidation even though the repo can no longer answer that question.
   """
   def delete_by_chunks(chunk_ids, opts \\ []) do
     {backend, backend_opts, opts} = extract_backend(opts)
@@ -501,9 +506,8 @@ defmodule Arcana.Graph.GraphStore do
   @doc """
   Runs `fun` holding the collection's graph write lock on the configured backend.
 
-  Backends that don't implement `c:with_write_lock/3` just run `fun`, with
-  no locking and no rollback. See `c:with_write_lock/3` for what each
-  backend actually guarantees.
+  Every backend must implement `c:with_write_lock/3`. See that callback for
+  the required serialization and backend-specific rollback guarantees.
   """
   def with_write_lock(collection_id, opts, fun) when is_function(fun, 0) do
     {backend, backend_opts, opts} = extract_backend(opts)
@@ -513,14 +517,16 @@ defmodule Arcana.Graph.GraphStore do
   defp lock(:ecto, collection_id, opts, fun),
     do: __MODULE__.Ecto.with_write_lock(collection_id, opts, fun)
 
-  defp lock(:memory, _collection_id, _opts, fun), do: fun.()
+  defp lock(:memory, collection_id, opts, fun),
+    do: __MODULE__.Memory.with_write_lock(collection_id, opts, fun)
 
   defp lock(module, collection_id, opts, fun) do
-    if Code.ensure_loaded?(module) and function_exported?(module, :with_write_lock, 3) do
-      module.with_write_lock(collection_id, opts, fun)
-    else
-      fun.()
+    unless Code.ensure_loaded?(module) and function_exported?(module, :with_write_lock, 3) do
+      raise ArgumentError,
+            "custom graph store #{inspect(module)} must implement with_write_lock/3"
     end
+
+    module.with_write_lock(collection_id, opts, fun)
   end
 
   @doc """
@@ -895,9 +901,8 @@ defmodule Arcana.Graph.GraphStore do
     module.delete_by_collection(collection_id, opts)
   end
 
-  # sweep_orphans/2 is optional, like with_write_lock/3: a store written
-  # against the behaviour before the callback existed keeps working, and
-  # skipping the sweep is what those callers already did.
+  # sweep_orphans/2 remains optional: a store written before that callback
+  # keeps working, and skipping the sweep is what those callers already did.
   defp dispatch(:sweep_orphans, module, [collection_id], backend_opts, opts) do
     if Code.ensure_loaded?(module) and function_exported?(module, :sweep_orphans, 2) do
       module.sweep_orphans(collection_id, Keyword.merge(backend_opts, opts))

--- a/lib/arcana/graph/graph_store.ex
+++ b/lib/arcana/graph/graph_store.ex
@@ -34,9 +34,9 @@ defmodule Arcana.Graph.GraphStore do
               {:ok, map()} | {:error, term()}
 
   @doc """
-  Persists relationships between entities.
+  Persists relationships between entities with the chunk that supports them.
   """
-  @callback persist_relationships([map()], map(), opts :: keyword()) ::
+  @callback persist_relationships(binary(), [map()], map(), opts :: keyword()) ::
               :ok | {:error, term()}
 
   @doc """
@@ -315,18 +315,19 @@ defmodule Arcana.Graph.GraphStore do
   @doc """
   Persists relationships using the configured backend.
   """
-  def persist_relationships(relationships, entity_id_map, opts \\ []) do
+  def persist_relationships(chunk_id, relationships, entity_id_map, opts \\ [])
+      when is_binary(chunk_id) do
     {backend, backend_opts, opts} = extract_backend(opts)
 
     :telemetry.span(
       [:arcana, :graph_store, :persist_relationships],
-      %{relationship_count: length(relationships)},
+      %{chunk_id: chunk_id, relationship_count: length(relationships)},
       fn ->
         result =
           dispatch(
             :persist_relationships,
             backend,
-            [relationships, entity_id_map],
+            [chunk_id, relationships, entity_id_map],
             backend_opts,
             opts
           )
@@ -606,9 +607,15 @@ defmodule Arcana.Graph.GraphStore do
     __MODULE__.Ecto.persist_entities(collection_id, entities, opts)
   end
 
-  defp dispatch(:persist_relationships, :ecto, [relationships, entity_id_map], backend_opts, opts) do
+  defp dispatch(
+         :persist_relationships,
+         :ecto,
+         [chunk_id, relationships, entity_id_map],
+         backend_opts,
+         opts
+       ) do
     opts = Keyword.merge(backend_opts, opts)
-    __MODULE__.Ecto.persist_relationships(relationships, entity_id_map, opts)
+    __MODULE__.Ecto.persist_relationships(chunk_id, relationships, entity_id_map, opts)
   end
 
   defp dispatch(:persist_mentions, :ecto, [mentions, entity_id_map], backend_opts, opts) do
@@ -716,12 +723,12 @@ defmodule Arcana.Graph.GraphStore do
   defp dispatch(
          :persist_relationships,
          :memory,
-         [relationships, entity_id_map],
+         [chunk_id, relationships, entity_id_map],
          backend_opts,
          opts
        ) do
     opts = Keyword.merge(backend_opts, opts)
-    __MODULE__.Memory.persist_relationships(relationships, entity_id_map, opts)
+    __MODULE__.Memory.persist_relationships(chunk_id, relationships, entity_id_map, opts)
   end
 
   defp dispatch(:persist_mentions, :memory, [mentions, entity_id_map], backend_opts, opts) do
@@ -829,12 +836,12 @@ defmodule Arcana.Graph.GraphStore do
   defp dispatch(
          :persist_relationships,
          module,
-         [relationships, entity_id_map],
+         [chunk_id, relationships, entity_id_map],
          backend_opts,
          opts
        ) do
     opts = Keyword.merge(backend_opts, opts)
-    module.persist_relationships(relationships, entity_id_map, opts)
+    module.persist_relationships(chunk_id, relationships, entity_id_map, opts)
   end
 
   defp dispatch(:persist_mentions, module, [mentions, entity_id_map], backend_opts, opts) do

--- a/lib/arcana/graph/graph_store.ex
+++ b/lib/arcana/graph/graph_store.ex
@@ -104,7 +104,9 @@ defmodule Arcana.Graph.GraphStore do
 
   Prefer `Arcana.delete/2`, which removes the document and its chunks and
   sweeps in one step. Reach for this only when you are deleting chunks
-  yourself.
+  yourself. If the collection is already known, pass its ID as
+  `:collection_id` so the Ecto backend can still sweep when none of the
+  chunks have graph mentions.
 
   ## The call is not atomic
 

--- a/lib/arcana/graph/graph_store/ecto.ex
+++ b/lib/arcana/graph/graph_store/ecto.ex
@@ -121,11 +121,10 @@ defmodule Arcana.Graph.GraphStore.Ecto do
           metadata: rel[:metadata] || %{}
         }
 
-        fingerprint = Relationship.fingerprint(attrs)
+        changeset = Relationship.changeset(%Relationship{}, attrs)
+        fingerprint = Ecto.Changeset.get_field(changeset, :fingerprint)
 
-        %Relationship{}
-        |> Relationship.changeset(Map.put(attrs, :fingerprint, fingerprint))
-        |> repo.insert!(on_conflict: :nothing, conflict_target: :fingerprint)
+        repo.insert!(changeset, on_conflict: :nothing, conflict_target: :fingerprint)
 
         relationship = repo.get_by!(Relationship, fingerprint: fingerprint)
 

--- a/lib/arcana/graph/graph_store/ecto.ex
+++ b/lib/arcana/graph/graph_store/ecto.ex
@@ -270,7 +270,12 @@ defmodule Arcana.Graph.GraphStore.Ecto do
   # === Deletion Callbacks ===
 
   @impl true
-  def delete_by_chunks([], _opts), do: :ok
+  def delete_by_chunks([], opts) do
+    case Keyword.get(opts, :collection_id) do
+      nil -> :ok
+      collection_id -> sweep_orphans(collection_id, opts)
+    end
+  end
 
   def delete_by_chunks(chunk_ids, opts) when is_list(chunk_ids) do
     repo = Keyword.fetch!(opts, :repo)
@@ -326,15 +331,26 @@ defmodule Arcana.Graph.GraphStore.Ecto do
         from(m in EntityMention, where: m.chunk_id in ^chunk_ids, select: m.entity_id)
       )
 
-    # Only the collections these chunks touched: a delete in one tenant must
-    # not sweep another tenant's entities.
-    collection_ids = collections_for_entities(entity_ids, repo)
+    # Sweep collections discovered from the deleted mentions plus the
+    # caller-known document collection. The latter matters when the chunks
+    # never produced a mention, while keeping the sweep tenant-scoped.
+    collection_ids =
+      entity_ids
+      |> collections_for_entities(repo)
+      |> include_known_collection(opts)
 
     Enum.each(collection_ids, &sweep_orphans(&1, opts))
     sweep_uncollected(entity_ids, repo)
     dirty_relationship_communities(unpublished_endpoints, repo)
 
     :ok
+  end
+
+  defp include_known_collection(collection_ids, opts) do
+    case Keyword.get(opts, :collection_id) do
+      nil -> collection_ids
+      collection_id -> Enum.uniq([collection_id | collection_ids])
+    end
   end
 
   defp dirty_relationship_communities([], _repo), do: :ok

--- a/lib/arcana/graph/graph_store/ecto.ex
+++ b/lib/arcana/graph/graph_store/ecto.ex
@@ -8,7 +8,18 @@ defmodule Arcana.Graph.GraphStore.Ecto do
 
   @behaviour Arcana.Graph.GraphStore
 
-  alias Arcana.Graph.{Community, Entity, EntityMention, EntityName, Relationship}
+  alias Arcana.{Chunk, Document}
+
+  alias Arcana.Graph.{
+    Community,
+    Entity,
+    EntityMention,
+    EntityName,
+    Relationship,
+    RelationshipEvidence
+  }
+
+  alias Arcana.RetrievalScope
   import Ecto.Query
 
   # Postgres-side spelling of EntityName.normalize/1, so upserts and
@@ -92,7 +103,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
   end
 
   @impl true
-  def persist_relationships(relationships, entity_id_map, opts) do
+  def persist_relationships(chunk_id, relationships, entity_id_map, opts) do
     repo = Keyword.fetch!(opts, :repo)
 
     relationships
@@ -101,16 +112,29 @@ defmodule Arcana.Graph.GraphStore.Ecto do
       target_id = lookup_entity_id(entity_id_map, rel.target)
 
       if source_id && target_id && rel.type && rel.type != "" do
-        %Relationship{}
-        |> Relationship.changeset(%{
+        attrs = %{
           source_id: source_id,
           target_id: target_id,
           type: rel.type,
           description: rel[:description],
           strength: rel[:strength],
-          metadata: rel[:metadata]
+          metadata: rel[:metadata] || %{}
+        }
+
+        fingerprint = Relationship.fingerprint(attrs)
+
+        %Relationship{}
+        |> Relationship.changeset(Map.put(attrs, :fingerprint, fingerprint))
+        |> repo.insert!(on_conflict: :nothing, conflict_target: :fingerprint)
+
+        relationship = repo.get_by!(Relationship, fingerprint: fingerprint)
+
+        %RelationshipEvidence{}
+        |> RelationshipEvidence.changeset(%{
+          relationship_id: relationship.id,
+          chunk_id: chunk_id
         })
-        |> repo.insert!()
+        |> repo.insert!(on_conflict: :nothing)
       end
     end)
 
@@ -156,9 +180,12 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     limit = Keyword.get(opts, :limit, 10)
     threshold = Keyword.get(opts, :threshold, 0.3)
 
+    published_entity_ids =
+      from([mention: m] in RetrievalScope.mentions(), select: m.entity_id, distinct: true)
+
     base =
       from(e in Entity,
-        where: not is_nil(e.embedding),
+        where: not is_nil(e.embedding) and e.id in subquery(published_entity_ids),
         select: %{
           id: e.id,
           name: e.name,
@@ -197,7 +224,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     repo = Keyword.fetch!(opts, :repo)
 
     repo.all(
-      from(e in Entity,
+      from([entity: e] in RetrievalScope.entities(),
         where: e.collection_id == ^collection_id,
         select: %{id: e.id, name: e.name, type: e.type, description: e.description}
       )
@@ -235,7 +262,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
 
     repo.all(
       from(c in Community,
-        where: c.collection_id == ^collection_id,
+        where: c.collection_id == ^collection_id and not c.dirty,
         select: %{id: c.id, level: c.level, summary: c.summary, entity_ids: c.entity_ids}
       )
     )
@@ -248,6 +275,45 @@ defmodule Arcana.Graph.GraphStore.Ecto do
 
   def delete_by_chunks(chunk_ids, opts) when is_list(chunk_ids) do
     repo = Keyword.fetch!(opts, :repo)
+
+    remaining_published_evidence =
+      from(e in RelationshipEvidence,
+        join: c in Chunk,
+        on: c.id == e.chunk_id,
+        join: d in Document,
+        on: d.id == c.document_id,
+        where:
+          e.relationship_id == parent_as(:relationship).id and
+            e.chunk_id not in ^chunk_ids and d.status == :completed
+      )
+
+    unpublished_endpoints =
+      repo.all(
+        from([relationship: r] in RetrievalScope.relationships(),
+          where: not exists(subquery(remaining_published_evidence)),
+          select: {r.source_id, r.target_id}
+        )
+      )
+
+    {_count, relationship_ids} =
+      repo.delete_all(
+        from(e in RelationshipEvidence,
+          where: e.chunk_id in ^chunk_ids,
+          select: e.relationship_id
+        )
+      )
+
+    remaining_evidence = from(e in RelationshipEvidence, select: e.relationship_id)
+
+    {_count, _removed_endpoints} =
+      repo.delete_all(
+        from(r in Relationship,
+          where:
+            r.id in ^Enum.uniq(relationship_ids) and
+              r.id not in subquery(remaining_evidence),
+          select: {r.source_id, r.target_id}
+        )
+      )
 
     # The entities come back from the delete itself rather than from a read
     # before it. Reading first leaves a window: a concurrent build can add a
@@ -267,6 +333,20 @@ defmodule Arcana.Graph.GraphStore.Ecto do
 
     Enum.each(collection_ids, &sweep_orphans(&1, opts))
     sweep_uncollected(entity_ids, repo)
+    dirty_relationship_communities(unpublished_endpoints, repo)
+
+    :ok
+  end
+
+  defp dirty_relationship_communities([], _repo), do: :ok
+
+  defp dirty_relationship_communities(endpoints, repo) do
+    entity_ids =
+      endpoints |> Enum.flat_map(fn {source, target} -> [source, target] end) |> Enum.uniq()
+
+    entity_ids
+    |> collections_for_entities(repo)
+    |> Enum.each(&mark_relationship_communities_dirty(&1, entity_ids, repo))
 
     :ok
   end
@@ -426,6 +506,21 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     mark_communities_dirty(dynamic([c], c.collection_id == ^collection_id), entity_ids, repo)
   end
 
+  defp mark_relationship_communities_dirty(collection_id, entity_ids, repo) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    repo.update_all(
+      from(c in Community,
+        where: c.collection_id == ^collection_id,
+        where: fragment("? && ?", c.entity_ids, type(^entity_ids, {:array, Ecto.UUID})),
+        update: [set: [dirty: true, updated_at: ^now]]
+      ),
+      []
+    )
+
+    :ok
+  end
+
   defp mark_communities_dirty(_scope, [], _repo), do: :ok
 
   defp mark_communities_dirty(scope, entity_ids, repo) do
@@ -458,7 +553,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
   def get_entity(entity_id, opts) do
     repo = Keyword.fetch!(opts, :repo)
 
-    case repo.one(from(e in Entity, where: e.id == ^entity_id)) do
+    case repo.one(from([entity: e] in RetrievalScope.entities(), where: e.id == ^entity_id)) do
       nil ->
         {:error, :not_found}
 
@@ -480,7 +575,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     repo = Keyword.fetch!(opts, :repo)
 
     repo.all(
-      from(r in Relationship,
+      from([relationship: r] in RetrievalScope.relationships(),
         join: source in Entity,
         on: source.id == r.source_id,
         join: target in Entity,
@@ -507,7 +602,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     repo = Keyword.fetch!(opts, :repo)
 
     case repo.one(
-           from(r in Relationship,
+           from([relationship: r] in RetrievalScope.relationships(),
              join: source in Entity,
              on: source.id == r.source_id,
              join: target in Entity,
@@ -538,9 +633,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     limit = Keyword.get(opts, :limit, 5)
 
     repo.all(
-      from(m in EntityMention,
-        join: c in Arcana.Chunk,
-        on: c.id == m.chunk_id,
+      from([mention: m, chunk: c] in RetrievalScope.mentions(),
         where: m.entity_id == ^entity_id,
         limit: ^limit,
         select: %{
@@ -589,26 +682,26 @@ defmodule Arcana.Graph.GraphStore.Ecto do
 
     # Subquery for mention counts
     mention_counts =
-      from(m in EntityMention,
+      from([mention: m] in RetrievalScope.mentions(),
         group_by: m.entity_id,
         select: %{entity_id: m.entity_id, count: count(m.id)}
       )
 
     # Subquery for relationship counts (source + target)
     source_counts =
-      from(r in Relationship,
+      from([relationship: r] in RetrievalScope.relationships(),
         group_by: r.source_id,
-        select: %{entity_id: r.source_id, count: count(r.id)}
+        select: %{entity_id: r.source_id, count: count(r.id, :distinct)}
       )
 
     target_counts =
-      from(r in Relationship,
+      from([relationship: r] in RetrievalScope.relationships(),
         group_by: r.target_id,
-        select: %{entity_id: r.target_id, count: count(r.id)}
+        select: %{entity_id: r.target_id, count: count(r.id, :distinct)}
       )
 
     query =
-      from(e in Entity,
+      from([entity: e] in RetrievalScope.entities(),
         join: c in Arcana.Collection,
         on: c.id == e.collection_id,
         left_join: mc in subquery(mention_counts),
@@ -661,7 +754,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     limit = Keyword.get(opts, :limit, 50)
     offset = Keyword.get(opts, :offset, 0)
 
-    from(r in Relationship,
+    from([relationship: r] in RetrievalScope.relationships(),
       join: source in Entity,
       on: source.id == r.source_id,
       join: target in Entity,
@@ -812,7 +905,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     # limited warranty" a query-time extractor emits. Both sides normalize
     # through the same SQL for the reasons in @normalize_template.
     query =
-      from(e in Entity,
+      from([entity: e] in RetrievalScope.entities(),
         where:
           fragment(
             @normalized_names_match_sql,
@@ -835,7 +928,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
   defp fetch_and_score_chunks(entity_ids, repo) do
     chunk_ids =
       repo.all(
-        from(m in EntityMention,
+        from([mention: m] in RetrievalScope.mentions(),
           where: m.entity_id in ^entity_ids,
           select: m.chunk_id,
           distinct: true
@@ -856,7 +949,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
   defp score_chunk(chunk_id, entity_ids, repo) do
     mention_count =
       repo.one(
-        from(m in EntityMention,
+        from([mention: m] in RetrievalScope.mentions(),
           where: m.chunk_id == ^chunk_id and m.entity_id in ^entity_ids,
           select: count()
         )
@@ -876,7 +969,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
     # Find all entities connected to current_ids
     related_ids =
       repo.all(
-        from(r in Relationship,
+        from([relationship: r] in RetrievalScope.relationships(),
           where: r.source_id in ^current_ids or r.target_id in ^current_ids,
           select: {r.source_id, r.target_id}
         )
@@ -897,7 +990,7 @@ defmodule Arcana.Graph.GraphStore.Ecto do
       []
     else
       repo.all(
-        from(e in Entity,
+        from([entity: e] in RetrievalScope.entities(),
           where: e.id in ^ids,
           select: %{id: e.id, name: e.name, type: e.type, description: e.description}
         )

--- a/lib/arcana/graph/graph_store/memory.ex
+++ b/lib/arcana/graph/graph_store/memory.ex
@@ -112,7 +112,12 @@ defmodule Arcana.Graph.GraphStore.Memory do
   @impl Arcana.Graph.GraphStore
   def delete_by_chunks(chunk_ids, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:delete_by_chunks, chunk_ids, visible_chunk_ids(server, opts)})
+
+    GenServer.call(
+      server,
+      {:delete_by_chunks, chunk_ids, visible_chunk_ids(server, opts),
+       MapSet.new(Keyword.get(opts, :published_chunk_ids, []))}
+    )
   end
 
   @impl Arcana.Graph.GraphStore
@@ -123,8 +128,18 @@ defmodule Arcana.Graph.GraphStore.Memory do
 
   @impl Arcana.Graph.GraphStore
   def sweep_orphans(collection_id, opts) do
+    with_write_lock(collection_id, opts, fn ->
+      server = get_server(opts)
+      GenServer.call(server, {:sweep_orphans, collection_id})
+    end)
+  end
+
+  @impl Arcana.Graph.GraphStore
+  def with_write_lock(collection_id, opts, fun) when is_function(fun, 0) do
     server = get_server(opts)
-    GenServer.call(server, {:sweep_orphans, collection_id})
+    server_pid = server_pid!(server)
+    resource = {__MODULE__, server_pid, collection_id}
+    :global.trans({resource, self()}, fun, [node(server_pid)])
   end
 
   @impl Arcana.Graph.GraphStore
@@ -402,13 +417,19 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:delete_by_chunks, chunk_ids, visible_chunks}, _from, state) do
+  def handle_call(
+        {:delete_by_chunks, chunk_ids, visible_chunks, published_chunk_ids},
+        _from,
+        state
+      ) do
     chunk_id_set = MapSet.new(chunk_ids)
+    visible_before_delete = include_published_snapshot(visible_chunks, published_chunk_ids)
 
     unpublished_endpoints =
       state.relationships
       |> Enum.filter(fn relationship ->
-        not MapSet.disjoint?(relationship.evidence, chunk_id_set) and
+        Enum.any?(relationship.evidence, &visible_chunk?(&1, visible_before_delete)) and
+          not MapSet.disjoint?(relationship.evidence, chunk_id_set) and
           relationship.evidence
           |> MapSet.difference(chunk_id_set)
           |> Enum.all?(&(not visible_chunk?(&1, visible_chunks)))
@@ -775,6 +796,13 @@ defmodule Arcana.Graph.GraphStore.Memory do
     end
   end
 
+  defp server_pid!(server) do
+    case GenServer.whereis(server) do
+      pid when is_pid(pid) -> pid
+      nil -> raise ArgumentError, "memory graph store #{inspect(server)} is not running"
+    end
+  end
+
   defp visible_chunk_ids(server, opts) do
     case Keyword.fetch(opts, :repo) do
       {:ok, repo} ->
@@ -799,6 +827,12 @@ defmodule Arcana.Graph.GraphStore.Memory do
 
   defp visible_chunk?(_chunk_id, :all), do: true
   defp visible_chunk?(chunk_id, visible_chunks), do: MapSet.member?(visible_chunks, chunk_id)
+
+  defp include_published_snapshot(:all, _published_chunk_ids), do: :all
+
+  defp include_published_snapshot(visible_chunks, published_chunk_ids) do
+    MapSet.union(visible_chunks, published_chunk_ids)
+  end
 
   defp visible_entity?(entity_id, mentions, visible_chunks) do
     if visible_chunks == :all do

--- a/lib/arcana/graph/graph_store/memory.ex
+++ b/lib/arcana/graph/graph_store/memory.ex
@@ -21,9 +21,12 @@ defmodule Arcana.Graph.GraphStore.Memory do
 
   use GenServer
 
+  import Ecto.Query
+
   @behaviour Arcana.Graph.GraphStore
 
-  alias Arcana.Graph.EntityName
+  alias Arcana.Graph.{EntityName, Relationship}
+  alias Arcana.RetrievalScope
 
   # === Client API ===
 
@@ -54,9 +57,9 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl Arcana.Graph.GraphStore
-  def persist_relationships(relationships, entity_id_map, opts) do
+  def persist_relationships(chunk_id, relationships, entity_id_map, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:persist_relationships, relationships, entity_id_map})
+    GenServer.call(server, {:persist_relationships, chunk_id, relationships, entity_id_map})
   end
 
   @impl Arcana.Graph.GraphStore
@@ -68,7 +71,11 @@ defmodule Arcana.Graph.GraphStore.Memory do
   @impl Arcana.Graph.GraphStore
   def search(entity_names, collection_ids, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:search, entity_names, collection_ids})
+
+    GenServer.call(
+      server,
+      {:search, entity_names, collection_ids, visible_chunk_ids(server, opts)}
+    )
   end
 
   @impl Arcana.Graph.GraphStore
@@ -77,13 +84,17 @@ defmodule Arcana.Graph.GraphStore.Memory do
   @impl Arcana.Graph.GraphStore
   def find_entities(collection_id, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:find_entities, collection_id})
+    GenServer.call(server, {:find_entities, collection_id, visible_chunk_ids(server, opts)})
   end
 
   @impl Arcana.Graph.GraphStore
   def find_related_entities(entity_id, depth, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:find_related_entities, entity_id, depth})
+
+    GenServer.call(
+      server,
+      {:find_related_entities, entity_id, depth, visible_chunk_ids(server, opts)}
+    )
   end
 
   @impl Arcana.Graph.GraphStore
@@ -101,7 +112,7 @@ defmodule Arcana.Graph.GraphStore.Memory do
   @impl Arcana.Graph.GraphStore
   def delete_by_chunks(chunk_ids, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:delete_by_chunks, chunk_ids})
+    GenServer.call(server, {:delete_by_chunks, chunk_ids, visible_chunk_ids(server, opts)})
   end
 
   @impl Arcana.Graph.GraphStore
@@ -119,25 +130,25 @@ defmodule Arcana.Graph.GraphStore.Memory do
   @impl Arcana.Graph.GraphStore
   def get_entity(entity_id, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:get_entity, entity_id})
+    GenServer.call(server, {:get_entity, entity_id, visible_chunk_ids(server, opts)})
   end
 
   @impl Arcana.Graph.GraphStore
   def get_relationships(entity_id, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:get_relationships, entity_id})
+    GenServer.call(server, {:get_relationships, entity_id, visible_chunk_ids(server, opts)})
   end
 
   @impl Arcana.Graph.GraphStore
   def get_relationship(relationship_id, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:get_relationship, relationship_id})
+    GenServer.call(server, {:get_relationship, relationship_id, visible_chunk_ids(server, opts)})
   end
 
   @impl Arcana.Graph.GraphStore
   def get_mentions(entity_id, opts) do
     server = get_server(opts)
-    GenServer.call(server, {:get_mentions, entity_id})
+    GenServer.call(server, {:get_mentions, entity_id, visible_chunk_ids(server, opts)})
   end
 
   @impl Arcana.Graph.GraphStore
@@ -149,13 +160,13 @@ defmodule Arcana.Graph.GraphStore.Memory do
   @impl Arcana.Graph.GraphStore
   def list_entities(opts) do
     server = get_server(opts)
-    GenServer.call(server, {:list_entities, opts})
+    GenServer.call(server, {:list_entities, opts, visible_chunk_ids(server, opts)})
   end
 
   @impl Arcana.Graph.GraphStore
   def list_relationships(opts) do
     server = get_server(opts)
-    GenServer.call(server, {:list_relationships, opts})
+    GenServer.call(server, {:list_relationships, opts, visible_chunk_ids(server, opts)})
   end
 
   @impl Arcana.Graph.GraphStore
@@ -217,7 +228,11 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:persist_relationships, relationships, entity_id_map}, _from, state) do
+  def handle_call(
+        {:persist_relationships, chunk_id, relationships, entity_id_map},
+        _from,
+        state
+      ) do
     valid_relationships =
       relationships
       |> Enum.map(fn rel ->
@@ -227,18 +242,53 @@ defmodule Arcana.Graph.GraphStore.Memory do
         Map.has_key?(entity_id_map, source_key) and Map.has_key?(entity_id_map, target_key)
       end)
       |> Enum.map(fn {source_key, target_key, rel} ->
-        %{
-          id: Ecto.UUID.generate(),
+        attrs = %{
           source_id: entity_id_map[source_key],
           target_id: entity_id_map[target_key],
           type: rel.type,
           description: rel[:description],
-          strength: rel[:strength]
+          strength: rel[:strength],
+          metadata: Relationship.normalized_metadata(rel[:metadata])
         }
+
+        Map.put(attrs, :fingerprint, Relationship.fingerprint(attrs))
       end)
 
-    new_state = %{state | relationships: state.relationships ++ valid_relationships}
+    new_relationships =
+      Enum.reduce(valid_relationships, state.relationships, fn relationship, stored ->
+        case Enum.find_index(stored, &(&1.fingerprint == relationship.fingerprint)) do
+          nil ->
+            [
+              relationship
+              |> Map.put(:id, Ecto.UUID.generate())
+              |> Map.put(:evidence, MapSet.new([chunk_id]))
+              | stored
+            ]
+
+          index ->
+            List.update_at(stored, index, fn existing ->
+              %{existing | evidence: MapSet.put(existing.evidence, chunk_id)}
+            end)
+        end
+      end)
+
+    new_state = %{state | relationships: new_relationships}
     {:reply, :ok, new_state}
+  end
+
+  @impl GenServer
+  def handle_call(:publication_candidates, _from, state) do
+    chunk_ids =
+      state.mentions
+      |> Enum.map(& &1.chunk_id)
+      |> Enum.concat(
+        Enum.flat_map(state.relationships, fn relationship ->
+          MapSet.to_list(relationship.evidence)
+        end)
+      )
+      |> Enum.uniq()
+
+    {:reply, chunk_ids, state}
   end
 
   @impl GenServer
@@ -266,7 +316,7 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:search, entity_names, collection_ids}, _from, state) do
+  def handle_call({:search, entity_names, collection_ids, visible_chunks}, _from, state) do
     # Match on the normalized name: persistence collapses variants onto
     # one entity keeping its first-seen display name, so matching raw
     # names here would miss a stored "Two_Year_Limited_Warranty" for a
@@ -287,7 +337,9 @@ defmodule Arcana.Graph.GraphStore.Memory do
       # Find chunks with mentions of these entities
       chunk_scores =
         state.mentions
-        |> Enum.filter(fn m -> MapSet.member?(entity_ids, m.entity_id) end)
+        |> Enum.filter(fn m ->
+          MapSet.member?(entity_ids, m.entity_id) and visible_chunk?(m.chunk_id, visible_chunks)
+        end)
         |> Enum.group_by(& &1.chunk_id)
         |> Enum.map(fn {chunk_id, mentions} ->
           %{chunk_id: chunk_id, score: length(mentions) * 0.1}
@@ -299,10 +351,11 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:find_entities, collection_id}, _from, state) do
+  def handle_call({:find_entities, collection_id, visible_chunks}, _from, state) do
     entities =
       state.entities
       |> Map.get(collection_id, [])
+      |> Enum.filter(&visible_entity?(&1.id, state.mentions, visible_chunks))
       |> Enum.map(fn e ->
         %{id: e.id, name: e.name, type: e.type, description: e[:description]}
       end)
@@ -311,14 +364,17 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:find_related_entities, entity_id, depth}, _from, state) do
+  def handle_call({:find_related_entities, entity_id, depth, visible_chunks}, _from, state) do
     # BFS traversal
-    visited = find_related_bfs([entity_id], MapSet.new([entity_id]), depth, state.relationships)
+    relationships = Enum.filter(state.relationships, &visible_relationship?(&1, visible_chunks))
+    visited = find_related_bfs([entity_id], MapSet.new([entity_id]), depth, relationships)
 
     entities =
       state.entities
       |> Enum.flat_map(fn {_cid, ents} -> ents end)
-      |> Enum.filter(fn e -> MapSet.member?(visited, e.id) end)
+      |> Enum.filter(fn e ->
+        MapSet.member?(visited, e.id) and visible_entity?(e.id, state.mentions, visible_chunks)
+      end)
       |> Enum.map(fn e ->
         %{id: e.id, name: e.name, type: e.type, description: e[:description]}
       end)
@@ -337,6 +393,7 @@ defmodule Arcana.Graph.GraphStore.Memory do
     communities =
       state.communities
       |> Map.get(collection_id, [])
+      |> Enum.reject(& &1[:dirty])
       |> Enum.map(fn c ->
         %{id: c.id, level: c.level, summary: c.summary, entity_ids: c.entity_ids}
       end)
@@ -345,8 +402,25 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:delete_by_chunks, chunk_ids}, _from, state) do
+  def handle_call({:delete_by_chunks, chunk_ids, visible_chunks}, _from, state) do
     chunk_id_set = MapSet.new(chunk_ids)
+
+    unpublished_endpoints =
+      state.relationships
+      |> Enum.filter(fn relationship ->
+        not MapSet.disjoint?(relationship.evidence, chunk_id_set) and
+          relationship.evidence
+          |> MapSet.difference(chunk_id_set)
+          |> Enum.all?(&(not visible_chunk?(&1, visible_chunks)))
+      end)
+      |> Enum.flat_map(&[&1.source_id, &1.target_id])
+      |> MapSet.new()
+
+    new_relationships =
+      Enum.flat_map(state.relationships, fn relationship ->
+        evidence = MapSet.difference(relationship.evidence, chunk_id_set)
+        if MapSet.size(evidence) == 0, do: [], else: [%{relationship | evidence: evidence}]
+      end)
 
     # Remove mentions for these chunks
     new_mentions =
@@ -359,6 +433,7 @@ defmodule Arcana.Graph.GraphStore.Memory do
       |> Enum.filter(&MapSet.member?(chunk_id_set, &1.chunk_id))
       |> Enum.map(& &1.entity_id)
       |> MapSet.new()
+      |> MapSet.union(unpublished_endpoints)
 
     affected_collections =
       state.entities
@@ -375,9 +450,10 @@ defmodule Arcana.Graph.GraphStore.Memory do
     new_state =
       Enum.reduce(
         affected_collections,
-        %{state | mentions: new_mentions},
+        %{state | mentions: new_mentions, relationships: new_relationships},
         &sweep_collection(&2, &1)
       )
+      |> mark_relationship_communities_dirty(unpublished_endpoints)
 
     {:reply, :ok, new_state}
   end
@@ -425,11 +501,13 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:get_entity, entity_id}, _from, state) do
+  def handle_call({:get_entity, entity_id, visible_chunks}, _from, state) do
     entity =
       state.entities
       |> Enum.flat_map(fn {_cid, ents} -> ents end)
-      |> Enum.find(fn e -> e.id == entity_id end)
+      |> Enum.find(fn e ->
+        e.id == entity_id and visible_entity?(e.id, state.mentions, visible_chunks)
+      end)
 
     result =
       case entity do
@@ -441,7 +519,7 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:get_relationships, entity_id}, _from, state) do
+  def handle_call({:get_relationships, entity_id, visible_chunks}, _from, state) do
     # Build entity lookup for names
     entity_by_id =
       state.entities
@@ -450,7 +528,10 @@ defmodule Arcana.Graph.GraphStore.Memory do
 
     relationships =
       state.relationships
-      |> Enum.filter(fn r -> r.source_id == entity_id or r.target_id == entity_id end)
+      |> Enum.filter(fn relationship ->
+        visible_relationship?(relationship, visible_chunks) and
+          (relationship.source_id == entity_id or relationship.target_id == entity_id)
+      end)
       |> Enum.map(fn r ->
         source = Map.get(entity_by_id, r.source_id)
         target = Map.get(entity_by_id, r.target_id)
@@ -471,14 +552,17 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:get_relationship, relationship_id}, _from, state) do
+  def handle_call({:get_relationship, relationship_id, visible_chunks}, _from, state) do
     # Build entity lookup for names
     entity_by_id =
       state.entities
       |> Enum.flat_map(fn {_cid, ents} -> ents end)
       |> Map.new(fn e -> {e.id, e} end)
 
-    relationship = Enum.find(state.relationships, fn r -> r.id == relationship_id end)
+    relationship =
+      Enum.find(state.relationships, fn r ->
+        r.id == relationship_id and visible_relationship?(r, visible_chunks)
+      end)
 
     result =
       case relationship do
@@ -506,11 +590,13 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:get_mentions, entity_id}, _from, state) do
+  def handle_call({:get_mentions, entity_id, visible_chunks}, _from, state) do
     # Note: In memory backend, we don't have chunk text - just return mention structure
     mentions =
       state.mentions
-      |> Enum.filter(fn m -> m.entity_id == entity_id end)
+      |> Enum.filter(fn mention ->
+        mention.entity_id == entity_id and visible_chunk?(mention.chunk_id, visible_chunks)
+      end)
       |> Enum.map(fn m ->
         %{
           id: m.id,
@@ -542,7 +628,7 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:list_entities, opts}, _from, state) do
+  def handle_call({:list_entities, opts, visible_chunks}, _from, state) do
     collection_id = Keyword.get(opts, :collection_id)
     type_filter = Keyword.get(opts, :type)
     search_filter = Keyword.get(opts, :search)
@@ -556,16 +642,19 @@ defmodule Arcana.Graph.GraphStore.Memory do
       else
         Enum.flat_map(state.entities, fn {_cid, ents} -> ents end)
       end
+      |> Enum.filter(&visible_entity?(&1.id, state.mentions, visible_chunks))
 
     # Count mentions per entity
     mention_counts =
       state.mentions
+      |> Enum.filter(&visible_chunk?(&1.chunk_id, visible_chunks))
       |> Enum.group_by(& &1.entity_id)
       |> Map.new(fn {eid, mentions} -> {eid, length(mentions)} end)
 
     # Count relationships per entity
     relationship_counts =
       state.relationships
+      |> Enum.filter(&visible_relationship?(&1, visible_chunks))
       |> Enum.flat_map(fn r -> [r.source_id, r.target_id] end)
       |> Enum.frequencies()
 
@@ -589,7 +678,7 @@ defmodule Arcana.Graph.GraphStore.Memory do
   end
 
   @impl GenServer
-  def handle_call({:list_relationships, opts}, _from, state) do
+  def handle_call({:list_relationships, opts, visible_chunks}, _from, state) do
     collection_id = Keyword.get(opts, :collection_id)
     type_filter = Keyword.get(opts, :type)
     search_filter = Keyword.get(opts, :search)
@@ -616,6 +705,7 @@ defmodule Arcana.Graph.GraphStore.Memory do
 
     relationships =
       state.relationships
+      |> Enum.filter(&visible_relationship?(&1, visible_chunks))
       |> maybe_filter_rels_by_collection(collection_entity_ids)
       |> maybe_filter_rels_by_type(type_filter)
       |> maybe_filter_rels_by_strength(strength_filter)
@@ -685,6 +775,45 @@ defmodule Arcana.Graph.GraphStore.Memory do
     end
   end
 
+  defp visible_chunk_ids(server, opts) do
+    case Keyword.fetch(opts, :repo) do
+      {:ok, repo} ->
+        candidates = GenServer.call(server, :publication_candidates)
+
+        if candidates == [] do
+          MapSet.new()
+        else
+          repo.all(
+            from([chunk: c] in RetrievalScope.chunks(),
+              where: c.id in ^candidates,
+              select: c.id
+            )
+          )
+          |> MapSet.new()
+        end
+
+      :error ->
+        :all
+    end
+  end
+
+  defp visible_chunk?(_chunk_id, :all), do: true
+  defp visible_chunk?(chunk_id, visible_chunks), do: MapSet.member?(visible_chunks, chunk_id)
+
+  defp visible_entity?(entity_id, mentions, visible_chunks) do
+    if visible_chunks == :all do
+      true
+    else
+      Enum.any?(mentions, fn mention ->
+        mention.entity_id == entity_id and visible_chunk?(mention.chunk_id, visible_chunks)
+      end)
+    end
+  end
+
+  defp visible_relationship?(relationship, visible_chunks) do
+    Enum.any?(relationship.evidence, &visible_chunk?(&1, visible_chunks))
+  end
+
   # nil means unscoped; [] means the caller named collections that resolved
   # to nothing and must match nothing, never fall back to everything.
   defp filter_by_collections(entities_map, nil), do: entities_map
@@ -731,6 +860,34 @@ defmodule Arcana.Graph.GraphStore.Memory do
         community
       end
     end)
+  end
+
+  defp mark_relationship_communities_dirty(state, endpoint_ids) do
+    if MapSet.size(endpoint_ids) == 0 do
+      state
+    else
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+      communities =
+        Map.new(state.communities, fn {collection_id, communities} ->
+          updated =
+            Enum.map(communities, &maybe_dirty_relationship_community(&1, endpoint_ids, now))
+
+          {collection_id, updated}
+        end)
+
+      %{state | communities: communities}
+    end
+  end
+
+  defp maybe_dirty_relationship_community(community, endpoint_ids, now) do
+    if Enum.any?(community.entity_ids || [], &MapSet.member?(endpoint_ids, &1)) do
+      community
+      |> Map.put(:dirty, true)
+      |> Map.put(:updated_at, now)
+    else
+      community
+    end
   end
 
   # Drops entities in the collection that no mention points at any more,

--- a/lib/arcana/graph/migration.ex
+++ b/lib/arcana/graph/migration.ex
@@ -12,7 +12,9 @@ defmodule Arcana.Graph.Migration do
         def down, do: Arcana.Graph.Migration.down()
       end
 
-  Upgrading needs no new DDL, only another migration calling `up/1`.
+  Upgrade by adding another host migration that calls `up/1`. Version 2 adds
+  relationship provenance DDL and clears legacy relationship facts that have
+  no source chunk.
 
   ## Options
 
@@ -70,17 +72,30 @@ defmodule Arcana.Graph.Migration do
     * 1 - entities, relationships, mentions and communities, including the
       entity-mention unique index and `communities.summary_fingerprint` that
       earlier releases shipped as separate upgrade migrations
+    * 2 - canonical relationship facts with per-chunk evidence. Existing
+      relationships are cleared because their source chunks cannot be inferred;
+      rebuild the graph after upgrading
+
+  ## Uninstall ownership
+
+  Target version 0 removes only Arcana's graph tables and table-contained
+  objects. It leaves the core tables, Postgres schema, and `vector` extension in
+  place. Foreign keys, views, and materialized views owned by the host
+  application block uninstall with their schema-qualified identities. Arcana
+  never uses `DROP ... CASCADE`, because that would delete host-owned objects.
 
   """
 
   use Ecto.Migration
 
+  alias Arcana.Migration.Dependencies
   alias Arcana.Migration.Dimensions
+  alias Arcana.Migration.Registry
+  alias Arcana.Migration.SchemaScope
   alias Arcana.Migration.UniqueIndex
 
-  @current_version 1
-
-  @version_table "arcana_graph_entities"
+  @current_version Registry.current_version(:graph)
+  @version_table Registry.version_table(:graph)
 
   @doc """
   Migrates up to `:version`, or to the latest version.
@@ -89,7 +104,8 @@ defmodule Arcana.Graph.Migration do
     target = Keyword.get(opts, :version, @current_version)
     validate_target!(target)
 
-    prefix = Keyword.get(opts, :prefix)
+    prefix = SchemaScope.resolve(repo(), :graph, Keyword.get(opts, :prefix))
+    opts = Keyword.put(opts, :prefix, prefix)
     current = recorded_version(repo(), prefix: prefix)
     validate_recorded!(current)
 
@@ -105,7 +121,6 @@ defmodule Arcana.Graph.Migration do
     if current < target do
       maybe_create_schema(prefix, opts)
       for version <- (current + 1)..target//1, do: change(version, :up, opts)
-      record_version(target, prefix)
     end
 
     # Mentions are the one exception, so this sits after the steps: converge_v1
@@ -115,21 +130,43 @@ defmodule Arcana.Graph.Migration do
     # target gets repaired too.
     converge_mentions_index!(prefix)
 
+    if target >= 2 do
+      converge_v2_indexes!(prefix)
+      verify_v2_schema!(prefix)
+    end
+
+    if current < target, do: record_version(target, prefix)
+
     :ok
   end
 
   @doc """
-  Migrates down to `:version`, or removes the graph tables entirely.
+  Migrates down to `:version`, or removes the graph tables entirely after
+  checking for host-owned dependents.
   """
   def down(opts \\ []) do
     target = Keyword.get(opts, :version, 0)
     validate_rollback_target!(target)
 
-    prefix = Keyword.get(opts, :prefix)
+    prefix = SchemaScope.resolve(repo(), :graph, Keyword.get(opts, :prefix))
+    opts = Keyword.put(opts, :prefix, prefix)
     current = recorded_version(repo(), prefix: prefix)
     validate_recorded!(current)
 
     if current == 0, do: refuse_blind_rollback!(prefix)
+
+    if current >= 2 and target == 1 do
+      raise """
+      Arcana graph migration v2 cannot be rolled back to v1 safely.
+
+      Version 2 stores relationship provenance in arcana_graph_relationship_evidence.
+      Dropping that table loses the information needed to reconstruct v2 on a later
+      upgrade. Roll back to version 0 to uninstall all graph tables, or restore a
+      pre-v2 database backup.
+      """
+    end
+
+    if current > target and target == 0, do: preflight_uninstall!(prefix)
 
     if current > target do
       for version <- current..(target + 1)//-1, do: change(version, :down, opts)
@@ -204,25 +241,27 @@ defmodule Arcana.Graph.Migration do
   #
   # relkind is constrained to ordinary and partitioned tables, so a view or
   # sequence that happens to share a name is not mistaken for an install.
-  defp owned_tables_present(prefix) do
-    %{rows: rows} =
-      repo().query!(
-        "SELECT c.relname FROM pg_class c " <>
-          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
-          "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
-        [
-          ~w(
-                   arcana_graph_entities
-                   arcana_graph_entity_mentions
-                   arcana_graph_relationships
-                   arcana_graph_communities
-          ),
-          prefix
-        ]
-      )
+  defp owned_tables_present(prefix), do: Registry.present(repo(), :graph, prefix)
 
-    List.flatten(rows)
+  defp preflight_uninstall!(prefix) do
+    execute(fn ->
+      case Dependencies.external(repo(), :graph, prefix) do
+        [] ->
+          :ok
+
+        dependents ->
+          listed = Enum.map_join(dependents, "\n", &"    #{&1}")
+          retry_scope = if prefix, do: "with prefix: #{inspect(prefix)}", else: "without a prefix"
+
+          raise """
+          Arcana.Graph.Migration.down/1 can't remove the graph schema because objects Arcana does not own depend on it:
+
+          #{listed}
+
+          Drop or repoint these objects, then retry #{retry_scope}. Nothing was changed. Arcana will not use DROP ... CASCADE because that would delete host-owned objects.
+          """
+      end
+    end)
   end
 
   @doc """
@@ -250,7 +289,7 @@ defmodule Arcana.Graph.Migration do
       repo.query!(
         "SELECT obj_description(c.oid) FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
-          "WHERE c.relname = $1 AND n.nspname = COALESCE($2, current_schema())",
+          "WHERE c.relname = $1 AND " <> SchemaScope.visible("c", "n", "$2"),
         [@version_table, prefix]
       )
 
@@ -268,24 +307,19 @@ defmodule Arcana.Graph.Migration do
       0
   end
 
-  defp parse_version(nil), do: 0
-
   # Anchored, so only a comment that is exactly the marker counts. An
   # unanchored match read a version out of any prose that happened to
   # contain "arcana_graph:2", and a bare integer (what Oban stores) would read a
   # host's own "1" as version 1. Anything we don't recognise reads as 0,
   # which is the same answer as "never installed" - see the moduledoc.
-  defp parse_version(comment) do
-    case Regex.run(~r/\Aarcana_graph:(\d+)\z/, String.trim(comment)) do
-      [_, version] -> String.to_integer(version)
-      _ -> 0
-    end
-  end
+  defp parse_version(comment), do: Registry.parse_marker(:graph, comment)
 
   defp record_version(0, _prefix), do: :ok
 
   defp record_version(version, prefix) do
-    execute("COMMENT ON TABLE #{qualify(@version_table, prefix)} IS 'arcana_graph:#{version}'")
+    execute(
+      "COMMENT ON TABLE #{qualify(@version_table, prefix)} IS '#{Registry.marker(:graph, version)}'"
+    )
   end
 
   # Raw SQL gets none of Ecto's prefix handling, so anything that doesn't go
@@ -348,6 +382,27 @@ defmodule Arcana.Graph.Migration do
         ["entity_id", "chunk_id"],
         prefix,
         &qualify(&1, prefix)
+      )
+    end)
+  end
+
+  defp converge_v2_indexes!(prefix) do
+    execute(fn ->
+      UniqueIndex.converge!(
+        repo(),
+        "arcana_graph_relationships",
+        ["fingerprint"],
+        prefix,
+        &qualify(&1, prefix)
+      )
+
+      UniqueIndex.converge!(
+        repo(),
+        "arcana_graph_relationship_evidence",
+        ["relationship_id", "chunk_id"],
+        prefix,
+        &qualify(&1, prefix),
+        name: "arcana_graph_relationship_evidence_rel_chunk_index"
       )
     end)
   end
@@ -529,10 +584,265 @@ defmodule Arcana.Graph.Migration do
   defp change(1, :down, opts) do
     prefix = Keyword.get(opts, :prefix)
 
-    drop_if_exists(table(:arcana_graph_communities, prefix: prefix))
-    drop_if_exists(table(:arcana_graph_entity_mentions, prefix: prefix))
-    drop_if_exists(table(:arcana_graph_relationships, prefix: prefix))
-    drop_if_exists(table(:arcana_graph_entities, prefix: prefix))
+    for table_name <- Registry.tables_added_in(:graph, 1) |> Enum.reverse() do
+      drop_if_exists(table(String.to_atom(table_name), prefix: prefix))
+    end
+  end
+
+  # === Version 2 ===
+
+  defp change(2, :up, opts) do
+    prefix = Keyword.get(opts, :prefix)
+
+    # Legacy rows carry no chunk provenance. Guessing would let failed or
+    # replaced documents keep influencing retrieval, so v2 deliberately
+    # discards them and requires a graph rebuild.
+    execute(fn ->
+      case v2_install_state(prefix) do
+        :legacy ->
+          repo().query!("DELETE FROM #{qualify("arcana_graph_relationships", prefix)}", [])
+
+          repo().query!(
+            "UPDATE #{qualify("arcana_graph_communities", prefix)} " <>
+              "SET dirty = true, summary = NULL, summary_fingerprint = NULL",
+            []
+          )
+
+        :v2 ->
+          verify_v2_data!(prefix)
+
+        :partial ->
+          raise """
+          Arcana found a partial graph migration v2 install.
+
+          The fingerprint column and arcana_graph_relationship_evidence table must
+          either both be absent (v1) or both be present with valid provenance (v2).
+          Nothing was changed. Restore the schema to one of those states and rerun.
+          """
+      end
+    end)
+
+    execute(
+      "ALTER TABLE #{qualify("arcana_graph_relationships", prefix)} " <>
+        "ADD COLUMN IF NOT EXISTS fingerprint varchar(64)"
+    )
+
+    execute(
+      "ALTER TABLE #{qualify("arcana_graph_relationships", prefix)} " <>
+        "ALTER COLUMN fingerprint SET NOT NULL"
+    )
+
+    create_if_not_exists(
+      unique_index(:arcana_graph_relationships, [:fingerprint], prefix: prefix)
+    )
+
+    create_if_not_exists table(:arcana_graph_relationship_evidence,
+                           primary_key: false,
+                           prefix: prefix
+                         ) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(
+        :relationship_id,
+        references(:arcana_graph_relationships,
+          type: :binary_id,
+          on_delete: :delete_all,
+          prefix: prefix
+        ),
+        null: false
+      )
+
+      add(
+        :chunk_id,
+        references(:arcana_chunks, type: :binary_id, on_delete: :delete_all, prefix: prefix),
+        null: false
+      )
+
+      timestamps(updated_at: false)
+    end
+
+    create_if_not_exists(
+      unique_index(:arcana_graph_relationship_evidence, [:relationship_id, :chunk_id],
+        prefix: prefix,
+        name: :arcana_graph_relationship_evidence_rel_chunk_index
+      )
+    )
+
+    create_if_not_exists(index(:arcana_graph_relationship_evidence, [:chunk_id], prefix: prefix))
+  end
+
+  defp change(2, :down, opts) do
+    prefix = Keyword.get(opts, :prefix)
+
+    for table_name <- Registry.tables_added_in(:graph, 2) |> Enum.reverse() do
+      drop_if_exists(table(String.to_atom(table_name), prefix: prefix))
+    end
+
+    drop_if_exists(index(:arcana_graph_relationships, [:fingerprint], prefix: prefix))
+
+    execute(
+      "ALTER TABLE #{qualify("arcana_graph_relationships", prefix)} " <>
+        "DROP COLUMN IF EXISTS fingerprint"
+    )
+  end
+
+  defp v2_install_state(prefix) do
+    fingerprint? = column_exists?("arcana_graph_relationships", "fingerprint", prefix)
+    evidence? = table_exists?("arcana_graph_relationship_evidence", prefix)
+
+    evidence_columns? =
+      evidence? and
+        column_exists?("arcana_graph_relationship_evidence", "relationship_id", prefix) and
+        column_exists?("arcana_graph_relationship_evidence", "chunk_id", prefix)
+
+    case {fingerprint?, evidence?, evidence_columns?} do
+      {false, false, false} -> :legacy
+      {true, true, true} -> :v2
+      _mixed -> :partial
+    end
+  end
+
+  defp verify_v2_data!(prefix) do
+    %{rows: [[null_fingerprints, missing_evidence]]} =
+      repo().query!(
+        "SELECT " <>
+          "count(*) FILTER (WHERE r.fingerprint IS NULL), " <>
+          "count(*) FILTER (WHERE NOT EXISTS (" <>
+          "SELECT 1 FROM #{qualify("arcana_graph_relationship_evidence", prefix)} e " <>
+          "WHERE e.relationship_id = r.id)) " <>
+          "FROM #{qualify("arcana_graph_relationships", prefix)} r",
+        []
+      )
+
+    if null_fingerprints > 0 or missing_evidence > 0 do
+      raise """
+      Arcana found relationship rows that are not valid graph migration v2 data.
+
+      NULL fingerprints: #{null_fingerprints}
+      Relationships without chunk evidence: #{missing_evidence}
+
+      Nothing was changed. Repair or remove those rows and rerun the migration.
+      """
+    end
+  end
+
+  defp verify_v2_schema!(prefix) do
+    execute(fn ->
+      verify_fingerprint_column!(prefix)
+      verify_evidence_columns!(prefix)
+      verify_evidence_foreign_keys!(prefix)
+    end)
+  end
+
+  defp verify_fingerprint_column!(prefix) do
+    %{rows: rows} =
+      repo().query!(
+        "SELECT format_type(a.atttypid, a.atttypmod), a.attnotnull " <>
+          "FROM pg_attribute a " <>
+          "JOIN pg_class c ON c.oid = a.attrelid " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "WHERE c.relname = 'arcana_graph_relationships' " <>
+          "AND a.attname = 'fingerprint' AND NOT a.attisdropped " <>
+          "AND " <> SchemaScope.visible("c", "n", "$1"),
+        [prefix]
+      )
+
+    unless rows == [["character varying(64)", true]] do
+      raise "Arcana graph v2 requires fingerprint varchar(64) NOT NULL, got: #{inspect(rows)}"
+    end
+  end
+
+  defp verify_evidence_columns!(prefix) do
+    %{rows: rows} =
+      repo().query!(
+        "SELECT a.attname, format_type(a.atttypid, a.atttypmod), a.attnotnull " <>
+          "FROM pg_attribute a " <>
+          "JOIN pg_class c ON c.oid = a.attrelid " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "WHERE c.relname = 'arcana_graph_relationship_evidence' " <>
+          "AND a.attname IN ('relationship_id', 'chunk_id') AND NOT a.attisdropped " <>
+          "AND " <> SchemaScope.visible("c", "n", "$1") <> " ORDER BY a.attname",
+        [prefix]
+      )
+
+    expected = [["chunk_id", "uuid", true], ["relationship_id", "uuid", true]]
+
+    unless rows == expected do
+      raise "Arcana graph v2 evidence columns have the wrong shape: #{inspect(rows)}"
+    end
+  end
+
+  defp verify_evidence_foreign_keys!(prefix) do
+    %{rows: rows} =
+      repo().query!(
+        "SELECT source_attr.attname, target.relname, target_ns.nspname, " <>
+          "source_ns.nspname, con.confdeltype " <>
+          "FROM pg_constraint con " <>
+          "JOIN pg_class source ON source.oid = con.conrelid " <>
+          "JOIN pg_namespace source_ns ON source_ns.oid = source.relnamespace " <>
+          "JOIN pg_class target ON target.oid = con.confrelid " <>
+          "JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace " <>
+          "JOIN LATERAL unnest(con.conkey) WITH ORDINALITY sk(attnum, ord) ON true " <>
+          "JOIN pg_attribute source_attr ON source_attr.attrelid = source.oid " <>
+          "AND source_attr.attnum = sk.attnum " <>
+          "WHERE con.contype = 'f' AND source.relname = 'arcana_graph_relationship_evidence' " <>
+          "AND " <>
+          SchemaScope.visible("source", "source_ns", "$1") <>
+          " " <>
+          "ORDER BY source_attr.attname",
+        [prefix]
+      )
+
+    valid? =
+      case rows do
+        [
+          ["chunk_id", "arcana_chunks", chunk_schema, source_schema, "c"],
+          [
+            "relationship_id",
+            "arcana_graph_relationships",
+            relationship_schema,
+            source_schema,
+            "c"
+          ]
+        ] ->
+          chunk_schema == source_schema and relationship_schema == source_schema
+
+        _ ->
+          false
+      end
+
+    unless valid? do
+      raise "Arcana graph v2 evidence foreign keys have the wrong shape: #{inspect(rows)}"
+    end
+  end
+
+  defp table_exists?(table, prefix) do
+    %{rows: [[exists?]]} =
+      repo().query!(
+        "SELECT EXISTS (" <>
+          "SELECT 1 FROM pg_class c " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "WHERE c.relname = $1 AND c.relkind IN ('r', 'p') " <>
+          "AND " <> SchemaScope.visible("c", "n", "$2") <> ")",
+        [table, prefix]
+      )
+
+    exists?
+  end
+
+  defp column_exists?(table, column, prefix) do
+    %{rows: [[exists?]]} =
+      repo().query!(
+        "SELECT EXISTS (" <>
+          "SELECT 1 FROM pg_attribute a " <>
+          "JOIN pg_class c ON c.oid = a.attrelid " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "WHERE c.relname = $1 AND a.attname = $2 AND NOT a.attisdropped " <>
+          "AND " <> SchemaScope.visible("c", "n", "$3") <> ")",
+        [table, column, prefix]
+      )
+
+    exists?
   end
 
   # Everything a release added after the tables first shipped. An install

--- a/lib/arcana/graph/migration.ex
+++ b/lib/arcana/graph/migration.ex
@@ -116,26 +116,26 @@ defmodule Arcana.Graph.Migration do
     # Nothing purges duplicate entity names, so this preflight has to beat
     # change(1, :up, _)'s create_if_not_exists to explain them rather than let
     # Postgres raise a bare unique violation.
-    converge_entities_index!(prefix)
+    if target < 2 or current >= 2, do: converge_entities_index!(prefix)
 
     if current < target do
       maybe_create_schema(prefix, opts)
       for version <- (current + 1)..target//1, do: change(version, :up, opts)
     end
 
-    # Mentions are the one exception, so this sits after the steps: converge_v1
-    # purges the duplicate pairs a unique index cannot coexist with, and
-    # checking first refused the migration over duplicates it was about to
-    # clean. Still outside the version comparison, so an install already at the
-    # target gets repaired too.
-    converge_mentions_index!(prefix)
+    # A v2 upgrade converges and verifies all graph indexes inside its own
+    # transaction before discarding legacy facts. Existing installs still run
+    # these repairs when up/1 is called again.
+    if target < 2 or current >= 2, do: converge_mentions_index!(prefix)
 
-    if target >= 2 do
+    if target >= 2 and current >= 2 do
       converge_v2_indexes!(prefix)
       verify_v2_schema!(prefix)
     end
 
-    if current < target, do: record_version(target, prefix)
+    # change(2, :up, _) records v2 in the same transaction that discards
+    # legacy facts. Version 1 still uses the normal queued marker command.
+    if current < target and target < 2, do: record_version(target, prefix)
 
     :ok
   end
@@ -363,48 +363,60 @@ defmodule Arcana.Graph.Migration do
   # adopted v1 while still carrying a wrong-shaped legacy index would never
   # have been repaired.
   defp converge_entities_index!(prefix) do
-    execute(fn ->
-      UniqueIndex.converge!(
-        repo(),
-        "arcana_graph_entities",
-        ["name", "collection_id"],
-        prefix,
-        &qualify(&1, prefix)
-      )
-    end)
+    execute(fn -> converge_entities_index_now!(prefix) end)
   end
 
   defp converge_mentions_index!(prefix) do
-    execute(fn ->
-      UniqueIndex.converge!(
-        repo(),
-        "arcana_graph_entity_mentions",
-        ["entity_id", "chunk_id"],
-        prefix,
-        &qualify(&1, prefix)
-      )
-    end)
+    execute(fn -> converge_mentions_index_now!(prefix) end)
   end
 
   defp converge_v2_indexes!(prefix) do
-    execute(fn ->
-      UniqueIndex.converge!(
-        repo(),
-        "arcana_graph_relationships",
-        ["fingerprint"],
-        prefix,
-        &qualify(&1, prefix)
-      )
+    execute(fn -> converge_v2_indexes_now!(prefix) end)
+  end
 
-      UniqueIndex.converge!(
-        repo(),
-        "arcana_graph_relationship_evidence",
-        ["relationship_id", "chunk_id"],
-        prefix,
-        &qualify(&1, prefix),
-        name: "arcana_graph_relationship_evidence_rel_chunk_index"
-      )
-    end)
+  defp converge_mentions_index_now!(prefix) do
+    UniqueIndex.converge!(
+      repo(),
+      "arcana_graph_entity_mentions",
+      ["entity_id", "chunk_id"],
+      prefix,
+      &qualify(&1, prefix)
+    )
+  end
+
+  defp converge_entities_index_now!(prefix) do
+    UniqueIndex.converge!(
+      repo(),
+      "arcana_graph_entities",
+      ["name", "collection_id"],
+      prefix,
+      &qualify(&1, prefix)
+    )
+  end
+
+  defp converge_v2_indexes_now!(prefix) do
+    UniqueIndex.converge!(
+      repo(),
+      "arcana_graph_relationships",
+      ["fingerprint"],
+      prefix,
+      &qualify(&1, prefix)
+    )
+
+    UniqueIndex.converge!(
+      repo(),
+      "arcana_graph_relationship_evidence",
+      ["relationship_id", "chunk_id"],
+      prefix,
+      &qualify(&1, prefix),
+      name: "arcana_graph_relationship_evidence_rel_chunk_index"
+    )
+
+    repo().query!(
+      "CREATE INDEX IF NOT EXISTS arcana_graph_relationship_evidence_chunk_id_index " <>
+        "ON #{qualify("arcana_graph_relationship_evidence", prefix)} (chunk_id)",
+      []
+    )
   end
 
   defp require_dimensions!(opts) do
@@ -594,81 +606,7 @@ defmodule Arcana.Graph.Migration do
   defp change(2, :up, opts) do
     prefix = Keyword.get(opts, :prefix)
 
-    # Legacy rows carry no chunk provenance. Guessing would let failed or
-    # replaced documents keep influencing retrieval, so v2 deliberately
-    # discards them and requires a graph rebuild.
-    execute(fn ->
-      case v2_install_state(prefix) do
-        :legacy ->
-          repo().query!("DELETE FROM #{qualify("arcana_graph_relationships", prefix)}", [])
-
-          repo().query!(
-            "UPDATE #{qualify("arcana_graph_communities", prefix)} " <>
-              "SET dirty = true, summary = NULL, summary_fingerprint = NULL",
-            []
-          )
-
-        :v2 ->
-          verify_v2_data!(prefix)
-
-        :partial ->
-          raise """
-          Arcana found a partial graph migration v2 install.
-
-          The fingerprint column and arcana_graph_relationship_evidence table must
-          either both be absent (v1) or both be present with valid provenance (v2).
-          Nothing was changed. Restore the schema to one of those states and rerun.
-          """
-      end
-    end)
-
-    execute(
-      "ALTER TABLE #{qualify("arcana_graph_relationships", prefix)} " <>
-        "ADD COLUMN IF NOT EXISTS fingerprint varchar(64)"
-    )
-
-    execute(
-      "ALTER TABLE #{qualify("arcana_graph_relationships", prefix)} " <>
-        "ALTER COLUMN fingerprint SET NOT NULL"
-    )
-
-    create_if_not_exists(
-      unique_index(:arcana_graph_relationships, [:fingerprint], prefix: prefix)
-    )
-
-    create_if_not_exists table(:arcana_graph_relationship_evidence,
-                           primary_key: false,
-                           prefix: prefix
-                         ) do
-      add(:id, :binary_id, primary_key: true)
-
-      add(
-        :relationship_id,
-        references(:arcana_graph_relationships,
-          type: :binary_id,
-          on_delete: :delete_all,
-          prefix: prefix
-        ),
-        null: false
-      )
-
-      add(
-        :chunk_id,
-        references(:arcana_chunks, type: :binary_id, on_delete: :delete_all, prefix: prefix),
-        null: false
-      )
-
-      timestamps(updated_at: false)
-    end
-
-    create_if_not_exists(
-      unique_index(:arcana_graph_relationship_evidence, [:relationship_id, :chunk_id],
-        prefix: prefix,
-        name: :arcana_graph_relationship_evidence_rel_chunk_index
-      )
-    )
-
-    create_if_not_exists(index(:arcana_graph_relationship_evidence, [:chunk_id], prefix: prefix))
+    execute(fn -> transact_v2_upgrade!(prefix) end)
   end
 
   defp change(2, :down, opts) do
@@ -684,6 +622,94 @@ defmodule Arcana.Graph.Migration do
       "ALTER TABLE #{qualify("arcana_graph_relationships", prefix)} " <>
         "DROP COLUMN IF EXISTS fingerprint"
     )
+  end
+
+  defp transact_v2_upgrade!(prefix) do
+    run = fn -> upgrade_v2!(prefix) end
+
+    if repo().in_transaction?() do
+      run.()
+    else
+      {:ok, :ok} = repo().transaction(run)
+    end
+  end
+
+  defp upgrade_v2!(prefix) do
+    state = v2_install_state(prefix)
+
+    case state do
+      :legacy -> install_v2_schema!(prefix)
+      :v2 -> verify_v2_data!(prefix)
+      :partial -> refuse_partial_v2!()
+    end
+
+    converge_entities_index_now!(prefix)
+    converge_mentions_index_now!(prefix)
+    converge_v2_indexes_now!(prefix)
+    verify_v2_schema_now!(prefix)
+
+    if state == :legacy, do: discard_legacy_relationships!(prefix)
+
+    repo().query!(
+      "COMMENT ON TABLE #{qualify(@version_table, prefix)} " <>
+        "IS '#{Registry.marker(:graph, 2)}'",
+      []
+    )
+
+    :ok
+  end
+
+  defp install_v2_schema!(prefix) do
+    repo().query!(
+      "ALTER TABLE #{qualify("arcana_graph_relationships", prefix)} " <>
+        "ADD COLUMN fingerprint varchar(64)",
+      []
+    )
+
+    repo().query!(
+      "CREATE TABLE #{qualify("arcana_graph_relationship_evidence", prefix)} (" <>
+        "id uuid PRIMARY KEY, " <>
+        "relationship_id uuid NOT NULL REFERENCES " <>
+        "#{qualify("arcana_graph_relationships", prefix)}(id) ON DELETE CASCADE, " <>
+        "chunk_id uuid NOT NULL REFERENCES #{qualify("arcana_chunks", prefix)}(id) " <>
+        "ON DELETE CASCADE, inserted_at timestamp(0) without time zone NOT NULL)",
+      []
+    )
+
+    # The legacy rows are removed only after every schema convergence and
+    # verification succeeds. Their ids are unique placeholders that let the
+    # NOT NULL index shape be validated without losing the rows first.
+    repo().query!(
+      "UPDATE #{qualify("arcana_graph_relationships", prefix)} " <>
+        "SET fingerprint = id::text WHERE fingerprint IS NULL",
+      []
+    )
+
+    repo().query!(
+      "ALTER TABLE #{qualify("arcana_graph_relationships", prefix)} " <>
+        "ALTER COLUMN fingerprint SET NOT NULL",
+      []
+    )
+  end
+
+  defp discard_legacy_relationships!(prefix) do
+    repo().query!("DELETE FROM #{qualify("arcana_graph_relationships", prefix)}", [])
+
+    repo().query!(
+      "UPDATE #{qualify("arcana_graph_communities", prefix)} " <>
+        "SET dirty = true, summary = NULL, summary_fingerprint = NULL",
+      []
+    )
+  end
+
+  defp refuse_partial_v2! do
+    raise """
+    Arcana found a partial graph migration v2 install.
+
+    The fingerprint column and arcana_graph_relationship_evidence table must
+    either both be absent (v1) or both be present with valid provenance (v2).
+    Nothing was changed. Restore the schema to one of those states and rerun.
+    """
   end
 
   defp v2_install_state(prefix) do
@@ -727,11 +753,13 @@ defmodule Arcana.Graph.Migration do
   end
 
   defp verify_v2_schema!(prefix) do
-    execute(fn ->
-      verify_fingerprint_column!(prefix)
-      verify_evidence_columns!(prefix)
-      verify_evidence_foreign_keys!(prefix)
-    end)
+    execute(fn -> verify_v2_schema_now!(prefix) end)
+  end
+
+  defp verify_v2_schema_now!(prefix) do
+    verify_fingerprint_column!(prefix)
+    verify_evidence_columns!(prefix)
+    verify_evidence_foreign_keys!(prefix)
   end
 
   defp verify_fingerprint_column!(prefix) do
@@ -760,31 +788,59 @@ defmodule Arcana.Graph.Migration do
           "JOIN pg_class c ON c.oid = a.attrelid " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = 'arcana_graph_relationship_evidence' " <>
-          "AND a.attname IN ('relationship_id', 'chunk_id') AND NOT a.attisdropped " <>
+          "AND a.attname IN ('id', 'relationship_id', 'chunk_id', 'inserted_at') " <>
+          "AND NOT a.attisdropped " <>
           "AND " <> SchemaScope.visible("c", "n", "$1") <> " ORDER BY a.attname",
         [prefix]
       )
 
-    expected = [["chunk_id", "uuid", true], ["relationship_id", "uuid", true]]
+    expected = [
+      ["chunk_id", "uuid", true],
+      ["id", "uuid", true],
+      ["inserted_at", "timestamp(0) without time zone", true],
+      ["relationship_id", "uuid", true]
+    ]
 
     unless rows == expected do
       raise "Arcana graph v2 evidence columns have the wrong shape: #{inspect(rows)}"
+    end
+
+    %{rows: primary_key_rows} =
+      repo().query!(
+        "SELECT a.attname FROM pg_constraint con " <>
+          "JOIN pg_class c ON c.oid = con.conrelid " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "JOIN LATERAL unnest(con.conkey) WITH ORDINALITY key(attnum, ord) ON true " <>
+          "JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = key.attnum " <>
+          "WHERE con.contype = 'p' " <>
+          "AND c.relname = 'arcana_graph_relationship_evidence' AND " <>
+          SchemaScope.visible("c", "n", "$1") <>
+          " ORDER BY key.ord",
+        [prefix]
+      )
+
+    unless primary_key_rows == [["id"]] do
+      raise "Arcana graph v2 evidence primary key has the wrong shape: #{inspect(primary_key_rows)}"
     end
   end
 
   defp verify_evidence_foreign_keys!(prefix) do
     %{rows: rows} =
       repo().query!(
-        "SELECT source_attr.attname, target.relname, target_ns.nspname, " <>
-          "source_ns.nspname, con.confdeltype " <>
+        "SELECT source_attr.attname, target.relname, target_attr.attname, " <>
+          "target_ns.nspname, source_ns.nspname, con.confdeltype, con.convalidated " <>
           "FROM pg_constraint con " <>
           "JOIN pg_class source ON source.oid = con.conrelid " <>
           "JOIN pg_namespace source_ns ON source_ns.oid = source.relnamespace " <>
           "JOIN pg_class target ON target.oid = con.confrelid " <>
           "JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace " <>
           "JOIN LATERAL unnest(con.conkey) WITH ORDINALITY sk(attnum, ord) ON true " <>
+          "JOIN LATERAL unnest(con.confkey) WITH ORDINALITY tk(attnum, ord) " <>
+          "ON tk.ord = sk.ord " <>
           "JOIN pg_attribute source_attr ON source_attr.attrelid = source.oid " <>
           "AND source_attr.attnum = sk.attnum " <>
+          "JOIN pg_attribute target_attr ON target_attr.attrelid = target.oid " <>
+          "AND target_attr.attnum = tk.attnum " <>
           "WHERE con.contype = 'f' AND source.relname = 'arcana_graph_relationship_evidence' " <>
           "AND " <>
           SchemaScope.visible("source", "source_ns", "$1") <>
@@ -796,13 +852,15 @@ defmodule Arcana.Graph.Migration do
     valid? =
       case rows do
         [
-          ["chunk_id", "arcana_chunks", chunk_schema, source_schema, "c"],
+          ["chunk_id", "arcana_chunks", "id", chunk_schema, source_schema, "c", true],
           [
             "relationship_id",
             "arcana_graph_relationships",
+            "id",
             relationship_schema,
             source_schema,
-            "c"
+            "c",
+            true
           ]
         ] ->
           chunk_schema == source_schema and relationship_schema == source_schema

--- a/lib/arcana/graph/relationship.ex
+++ b/lib/arcana/graph/relationship.ex
@@ -84,9 +84,10 @@ defmodule Arcana.Graph.Relationship do
   def normalized_metadata(nil), do: %{}
 
   def normalized_metadata(metadata) do
-    case Jason.encode(metadata) do
-      {:ok, json} -> Jason.decode!(json)
-      {:error, _reason} -> metadata
-    end
+    metadata
+    |> JSON.encode!()
+    |> JSON.decode!()
+  rescue
+    Protocol.UndefinedError -> metadata
   end
 end

--- a/lib/arcana/graph/relationship.ex
+++ b/lib/arcana/graph/relationship.ex
@@ -88,6 +88,6 @@ defmodule Arcana.Graph.Relationship do
     |> JSON.encode!()
     |> JSON.decode!()
   rescue
-    Protocol.UndefinedError -> metadata
+    _error in [Protocol.UndefinedError, ArgumentError] -> metadata
   end
 end

--- a/lib/arcana/graph/relationship.ex
+++ b/lib/arcana/graph/relationship.ex
@@ -9,7 +9,7 @@ defmodule Arcana.Graph.Relationship do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Arcana.Graph.Entity
+  alias Arcana.Graph.{Entity, RelationshipEvidence}
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -19,22 +19,74 @@ defmodule Arcana.Graph.Relationship do
     field(:description, :string)
     field(:strength, :integer)
     field(:metadata, :map, default: %{})
+    field(:fingerprint, :string)
 
     belongs_to(:source, Entity)
     belongs_to(:target, Entity)
+    has_many(:evidence, RelationshipEvidence)
 
     timestamps()
   end
 
-  @required_fields [:type, :source_id, :target_id]
+  @required_fields [:type, :source_id, :target_id, :fingerprint]
   @optional_fields [:description, :strength, :metadata]
 
   def changeset(relationship, attrs) do
     relationship
     |> cast(attrs, @required_fields ++ @optional_fields)
+    |> normalize_metadata()
+    |> put_fingerprint()
     |> validate_required(@required_fields)
     |> validate_number(:strength, greater_than_or_equal_to: 1, less_than_or_equal_to: 10)
     |> foreign_key_constraint(:source_id)
     |> foreign_key_constraint(:target_id)
+  end
+
+  defp put_fingerprint(changeset) do
+    attrs = %{
+      source_id: get_field(changeset, :source_id),
+      target_id: get_field(changeset, :target_id),
+      type: get_field(changeset, :type),
+      description: get_field(changeset, :description),
+      strength: get_field(changeset, :strength),
+      metadata: get_field(changeset, :metadata) || %{}
+    }
+
+    if attrs.source_id && attrs.target_id && attrs.type do
+      put_change(changeset, :fingerprint, fingerprint(attrs))
+    else
+      changeset
+    end
+  end
+
+  defp normalize_metadata(changeset) do
+    put_change(changeset, :metadata, normalized_metadata(get_field(changeset, :metadata)))
+  end
+
+  @doc false
+  def fingerprint(attrs) do
+    fact = {
+      attrs.source_id,
+      attrs.target_id,
+      attrs.type,
+      attrs[:description],
+      attrs[:strength],
+      normalized_metadata(attrs[:metadata])
+    }
+
+    fact
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  @doc false
+  def normalized_metadata(nil), do: %{}
+
+  def normalized_metadata(metadata) do
+    case Jason.encode(metadata) do
+      {:ok, json} -> Jason.decode!(json)
+      {:error, _reason} -> metadata
+    end
   end
 end

--- a/lib/arcana/graph/relationship_evidence.ex
+++ b/lib/arcana/graph/relationship_evidence.ex
@@ -1,0 +1,30 @@
+defmodule Arcana.Graph.RelationshipEvidence do
+  @moduledoc false
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Arcana.Chunk
+  alias Arcana.Graph.Relationship
+
+  @unique_index :arcana_graph_relationship_evidence_rel_chunk_index
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "arcana_graph_relationship_evidence" do
+    belongs_to(:relationship, Relationship)
+    belongs_to(:chunk, Chunk)
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(evidence, attrs) do
+    evidence
+    |> cast(attrs, [:relationship_id, :chunk_id])
+    |> validate_required([:relationship_id, :chunk_id])
+    |> foreign_key_constraint(:relationship_id)
+    |> foreign_key_constraint(:chunk_id)
+    |> unique_constraint([:relationship_id, :chunk_id], name: @unique_index)
+  end
+end

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -6,8 +6,6 @@ defmodule Arcana.Ingest do
   GraphRAG entity/relationship extraction.
   """
 
-  require Logger
-
   alias Arcana.{Chunk, Chunker, Collection, Document, Embedder, Parser}
   alias Arcana.Graph.GraphStore
 
@@ -77,6 +75,13 @@ defmodule Arcana.Ingest do
 
   A replacement that fails to embed leaves the predecessor untouched: the
   swap only runs once the new document's chunks are all in hand.
+
+  A custom graph store cannot join the database transaction. If retiring the
+  predecessor's graph data fails after the swap commits, ingestion returns
+  `{:error, {:post_commit_graph_cleanup_failed, context}}`. The replacement is
+  already the published document in that case. The context contains the
+  failure reason, retired chunk IDs, their publication snapshot, and the
+  collection ID needed to retry graph cleanup without re-ingesting the source.
   """
   def ingest(text, opts) when is_binary(text) do
     repo = require_repo!(opts)
@@ -257,17 +262,95 @@ defmodule Arcana.Ingest do
     build_graph_or_fail_document(document, chunk_records, collection, repo, opts)
 
     if Keyword.get(opts, :replace, false) do
-      with {:ok, {document, replaced_chunk_ids}} <-
-             finalize_replace(document, chunk_records, repo, opts) do
-        cleanup_replaced_graph(replaced_chunk_ids, repo, opts)
-        sweep_graph_orphans(document.collection_id, repo, opts)
-        {:ok, document}
+      case finalize_replace(document, chunk_records, repo, opts) do
+        {:ok, {document, replaced_chunk_ids, published_chunk_ids, graph_cleaned?}} ->
+          finish_replaced_graph_cleanup(
+            document,
+            replaced_chunk_ids,
+            published_chunk_ids,
+            graph_cleaned?,
+            repo,
+            opts
+          )
+
+        {:error, reason} ->
+          {:error, reason}
       end
     else
       document
       |> Document.changeset(%{status: :completed, chunk_count: length(chunk_records)})
       |> repo.update()
     end
+  end
+
+  defp finish_replaced_graph_cleanup(
+         document,
+         replaced_chunk_ids,
+         published_chunk_ids,
+         graph_cleaned?,
+         repo,
+         opts
+       ) do
+    with :ok <-
+           maybe_cleanup_replaced_graph(
+             graph_cleaned?,
+             replaced_chunk_ids,
+             published_chunk_ids,
+             repo,
+             opts
+           ),
+         :ok <- sweep_graph_orphans(document.collection_id, repo, opts) do
+      {:ok, document}
+    else
+      {:error, reason} ->
+        replaced_graph_cleanup_error(
+          reason,
+          document.collection_id,
+          replaced_chunk_ids,
+          published_chunk_ids
+        )
+    end
+  rescue
+    exception ->
+      replaced_graph_cleanup_error(
+        exception,
+        document.collection_id,
+        replaced_chunk_ids,
+        published_chunk_ids
+      )
+  catch
+    :exit, reason ->
+      replaced_graph_cleanup_error(
+        reason,
+        document.collection_id,
+        replaced_chunk_ids,
+        published_chunk_ids
+      )
+
+    kind, reason ->
+      replaced_graph_cleanup_error(
+        {kind, reason},
+        document.collection_id,
+        replaced_chunk_ids,
+        published_chunk_ids
+      )
+  end
+
+  defp maybe_cleanup_replaced_graph(true, _chunk_ids, _published_chunk_ids, _repo, _opts),
+    do: :ok
+
+  defp maybe_cleanup_replaced_graph(false, chunk_ids, published_chunk_ids, repo, opts),
+    do: cleanup_replaced_graph(chunk_ids, published_chunk_ids, repo, opts)
+
+  defp replaced_graph_cleanup_error(reason, collection_id, chunk_ids, published_chunk_ids) do
+    {:error,
+     {:post_commit_graph_cleanup_failed,
+      %{
+        reason: reason,
+        chunk_ids: chunk_ids,
+        published_chunk_ids: published_chunk_ids,
+        collection_id: collection_id
+      }}}
   end
 
   # A graph build blows up on failure (extraction errors that come back as
@@ -298,21 +381,13 @@ defmodule Arcana.Ingest do
 
   # The replaced predecessors' chunks cascade away with them, which can
   # strand zero-mention entities; sweep them like Arcana.delete/2 does.
-  # Unlike delete/2 a failed sweep doesn't fail the call: the new document
-  # is already committed, and returning an error here would push the
-  # caller into redoing the whole (LLM-priced) ingest over a cleanup
-  # problem. Log it and leave the orphans for the next sweep.
   defp sweep_graph_orphans(collection_id, repo, opts) do
-    case GraphStore.maybe_sweep_orphans(collection_id, repo, opts) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning(
-          "Arcana: graph orphan sweep failed for collection #{collection_id}: #{inspect(reason)}"
-        )
-
-        :ok
+    # The Ecto delete_by_chunks/2 call in finalize_replace already swept
+    # inside the swap transaction. External stores still need this pass.
+    if Arcana.Config.graph_enabled?(opts) and ecto_graph_store?(opts) do
+      :ok
+    else
+      GraphStore.maybe_sweep_orphans(collection_id, repo, opts)
     end
   end
 
@@ -324,62 +399,153 @@ defmodule Arcana.Ingest do
   # around chunking/embedding. A run whose document was already deleted by a
   # faster concurrent replace loses cleanly.
   defp finalize_replace(document, chunk_records, repo, opts) do
-    replace = fn -> do_finalize_replace(document, chunk_records, repo, opts) end
+    cond do
+      Arcana.Config.graph_enabled?(opts) and ecto_graph_store?(opts) ->
+        repo.transaction(fn ->
+          replace = fn -> do_finalize_replace(document, chunk_records, repo, opts) end
 
-    if Arcana.Config.graph_enabled?(opts) and ecto_graph_store?(opts) do
-      GraphStore.with_write_lock(document.collection_id, Keyword.put(opts, :repo, repo), replace)
-    else
-      replace.()
+          GraphStore.with_write_lock(
+            document.collection_id,
+            Keyword.put(opts, :repo, repo),
+            replace
+          )
+        end)
+        |> mark_replaced_graph_cleaned(true)
+
+      Arcana.Config.graph_enabled?(opts) ->
+        GraphStore.with_write_lock(
+          document.collection_id,
+          Keyword.put(opts, :repo, repo),
+          fn -> finalize_external_replace(document, chunk_records, repo, opts) end
+        )
+
+      true ->
+        repo.transaction(fn -> do_finalize_replace(document, chunk_records, repo, opts) end)
+        |> mark_replaced_graph_cleaned(false)
     end
   end
 
+  defp finalize_external_replace(document, chunk_records, repo, opts) do
+    case repo.transaction(fn -> do_finalize_replace(document, chunk_records, repo, opts) end) do
+      {:ok, {document, chunk_ids, published_chunk_ids}} ->
+        cleanup_external_replaced_graph(document, chunk_ids, published_chunk_ids, repo, opts)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp cleanup_external_replaced_graph(document, chunk_ids, published_chunk_ids, repo, opts) do
+    case cleanup_replaced_graph(chunk_ids, published_chunk_ids, repo, opts) do
+      :ok ->
+        {:ok, {document, chunk_ids, published_chunk_ids, true}}
+
+      {:error, reason} ->
+        replaced_graph_cleanup_error(
+          reason,
+          document.collection_id,
+          chunk_ids,
+          published_chunk_ids
+        )
+    end
+  rescue
+    exception ->
+      replaced_graph_cleanup_error(
+        exception,
+        document.collection_id,
+        chunk_ids,
+        published_chunk_ids
+      )
+  catch
+    :exit, reason ->
+      replaced_graph_cleanup_error(
+        reason,
+        document.collection_id,
+        chunk_ids,
+        published_chunk_ids
+      )
+
+    kind, reason ->
+      replaced_graph_cleanup_error(
+        {kind, reason},
+        document.collection_id,
+        chunk_ids,
+        published_chunk_ids
+      )
+  end
+
+  defp mark_replaced_graph_cleaned(
+         {:ok, {document, chunk_ids, published_chunk_ids}},
+         cleaned?
+       ) do
+    {:ok, {document, chunk_ids, published_chunk_ids, cleaned?}}
+  end
+
+  defp mark_replaced_graph_cleaned({:error, reason}, _cleaned?), do: {:error, reason}
+
   defp do_finalize_replace(document, chunk_records, repo, opts) do
-    repo.transaction(fn ->
-      repo.query!("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
-        "arcana:replace:#{document.collection_id}:#{document.source_id}"
-      ])
+    repo.query!("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+      "arcana:replace:#{document.collection_id}:#{document.source_id}"
+    ])
 
-      if repo.get(Document, document.id) do
-        import Ecto.Query, only: [from: 2]
+    if repo.get(Document, document.id) do
+      import Ecto.Query, only: [from: 2]
 
-        replaced_chunk_ids =
-          repo.all(
-            from(c in Chunk,
-              join: d in Document,
-              on: c.document_id == d.id,
-              where:
-                d.collection_id == ^document.collection_id and
-                  d.source_id == ^document.source_id and d.id != ^document.id,
-              select: c.id
-            )
-          )
-
-        {:ok, document} =
-          document
-          |> Document.changeset(%{status: :completed, chunk_count: length(chunk_records)})
-          |> repo.update()
-
-        # Publish the replacement before retiring predecessor evidence. Graph
-        # cleanup can then see identical facts supported by the new document
-        # and won't dirty their communities during the handoff. The whole
-        # sequence is still one transaction, so a later failure rolls the
-        # publication back too.
-        maybe_delete_replaced_graph(replaced_chunk_ids, repo, opts)
-
-        repo.delete_all(
+      predecessor_documents =
+        repo.all(
           from(d in Document,
             where:
               d.collection_id == ^document.collection_id and
-                d.source_id == ^document.source_id and
-                d.id != ^document.id
+                d.source_id == ^document.source_id and d.id != ^document.id,
+            select: {d.id, d.status},
+            lock: "FOR UPDATE"
           )
         )
 
-        {document, replaced_chunk_ids}
-      else
-        repo.rollback(:replaced_by_concurrent_ingest)
-      end
-    end)
+      predecessor_ids = Enum.map(predecessor_documents, &elem(&1, 0))
+
+      replaced_chunks =
+        repo.all(
+          from(c in Chunk,
+            where: c.document_id in ^predecessor_ids,
+            select: {c.id, c.document_id}
+          )
+        )
+
+      replaced_chunk_ids = Enum.map(replaced_chunks, &elem(&1, 0))
+
+      published_document_ids =
+        predecessor_documents
+        |> Enum.filter(&(elem(&1, 1) == :completed))
+        |> MapSet.new(&elem(&1, 0))
+
+      published_chunk_ids =
+        for {chunk_id, document_id} <- replaced_chunks,
+            MapSet.member?(published_document_ids, document_id),
+            do: chunk_id
+
+      {:ok, document} =
+        document
+        |> Document.changeset(%{status: :completed, chunk_count: length(chunk_records)})
+        |> repo.update()
+
+      # Publish the replacement before retiring predecessor evidence. Graph
+      # cleanup can then see identical facts supported by the new document
+      # and won't dirty their communities during the handoff. The whole
+      # sequence is still one transaction, so a later failure rolls the
+      # publication back too.
+      maybe_delete_replaced_graph(replaced_chunk_ids, repo, opts)
+
+      repo.delete_all(
+        from(d in Document,
+          where: d.id in ^predecessor_ids
+        )
+      )
+
+      {document, replaced_chunk_ids, published_chunk_ids}
+    else
+      repo.rollback(:replaced_by_concurrent_ingest)
+    end
   end
 
   defp maybe_delete_replaced_graph(replaced_chunk_ids, repo, opts) do
@@ -391,17 +557,18 @@ defmodule Arcana.Ingest do
     end
   end
 
-  defp cleanup_replaced_graph([], _repo, _opts), do: :ok
+  defp cleanup_replaced_graph([], _published_chunk_ids, _repo, _opts), do: :ok
 
-  defp cleanup_replaced_graph(chunk_ids, repo, opts) do
+  defp cleanup_replaced_graph(chunk_ids, published_chunk_ids, repo, opts) do
     if Arcana.Config.graph_enabled?(opts) and not ecto_graph_store?(opts) do
-      case GraphStore.delete_by_chunks(chunk_ids, Keyword.put(opts, :repo, repo)) do
-        :ok ->
-          :ok
+      graph_opts =
+        opts
+        |> Keyword.put(:repo, repo)
+        |> Keyword.put(:published_chunk_ids, published_chunk_ids)
 
-        {:error, reason} ->
-          Logger.warning("Arcana: replaced graph cleanup failed: #{inspect(reason)}")
-          :ok
+      case GraphStore.delete_by_chunks(chunk_ids, graph_opts) do
+        :ok -> :ok
+        {:error, reason} -> {:error, reason}
       end
     else
       :ok

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -534,7 +534,12 @@ defmodule Arcana.Ingest do
       # and won't dirty their communities during the handoff. The whole
       # sequence is still one transaction, so a later failure rolls the
       # publication back too.
-      maybe_delete_replaced_graph(replaced_chunk_ids, repo, opts)
+      maybe_delete_replaced_graph(
+        replaced_chunk_ids,
+        document.collection_id,
+        repo,
+        opts
+      )
 
       repo.delete_all(
         from(d in Document,
@@ -548,9 +553,14 @@ defmodule Arcana.Ingest do
     end
   end
 
-  defp maybe_delete_replaced_graph(replaced_chunk_ids, repo, opts) do
+  defp maybe_delete_replaced_graph(replaced_chunk_ids, collection_id, repo, opts) do
     if Arcana.Config.graph_enabled?(opts) and ecto_graph_store?(opts) do
-      case GraphStore.delete_by_chunks(replaced_chunk_ids, Keyword.put(opts, :repo, repo)) do
+      graph_opts =
+        opts
+        |> Keyword.put(:repo, repo)
+        |> Keyword.put(:collection_id, collection_id)
+
+      case GraphStore.delete_by_chunks(replaced_chunk_ids, graph_opts) do
         :ok -> :ok
         {:error, reason} -> repo.rollback({:graph_cleanup_failed, reason})
       end

--- a/lib/arcana/ingest.ex
+++ b/lib/arcana/ingest.ex
@@ -257,7 +257,9 @@ defmodule Arcana.Ingest do
     build_graph_or_fail_document(document, chunk_records, collection, repo, opts)
 
     if Keyword.get(opts, :replace, false) do
-      with {:ok, document} <- finalize_replace(document, chunk_records, repo) do
+      with {:ok, {document, replaced_chunk_ids}} <-
+             finalize_replace(document, chunk_records, repo, opts) do
+        cleanup_replaced_graph(replaced_chunk_ids, repo, opts)
         sweep_graph_orphans(document.collection_id, repo, opts)
         {:ok, document}
       end
@@ -321,7 +323,17 @@ defmodule Arcana.Ingest do
   # concurrent replaces serialize HERE, at the fast DB-only step, never
   # around chunking/embedding. A run whose document was already deleted by a
   # faster concurrent replace loses cleanly.
-  defp finalize_replace(document, chunk_records, repo) do
+  defp finalize_replace(document, chunk_records, repo, opts) do
+    replace = fn -> do_finalize_replace(document, chunk_records, repo, opts) end
+
+    if Arcana.Config.graph_enabled?(opts) and ecto_graph_store?(opts) do
+      GraphStore.with_write_lock(document.collection_id, Keyword.put(opts, :repo, repo), replace)
+    else
+      replace.()
+    end
+  end
+
+  defp do_finalize_replace(document, chunk_records, repo, opts) do
     repo.transaction(fn ->
       repo.query!("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
         "arcana:replace:#{document.collection_id}:#{document.source_id}"
@@ -329,6 +341,30 @@ defmodule Arcana.Ingest do
 
       if repo.get(Document, document.id) do
         import Ecto.Query, only: [from: 2]
+
+        replaced_chunk_ids =
+          repo.all(
+            from(c in Chunk,
+              join: d in Document,
+              on: c.document_id == d.id,
+              where:
+                d.collection_id == ^document.collection_id and
+                  d.source_id == ^document.source_id and d.id != ^document.id,
+              select: c.id
+            )
+          )
+
+        {:ok, document} =
+          document
+          |> Document.changeset(%{status: :completed, chunk_count: length(chunk_records)})
+          |> repo.update()
+
+        # Publish the replacement before retiring predecessor evidence. Graph
+        # cleanup can then see identical facts supported by the new document
+        # and won't dirty their communities during the handoff. The whole
+        # sequence is still one transaction, so a later failure rolls the
+        # publication back too.
+        maybe_delete_replaced_graph(replaced_chunk_ids, repo, opts)
 
         repo.delete_all(
           from(d in Document,
@@ -339,16 +375,45 @@ defmodule Arcana.Ingest do
           )
         )
 
-        {:ok, document} =
-          document
-          |> Document.changeset(%{status: :completed, chunk_count: length(chunk_records)})
-          |> repo.update()
-
-        document
+        {document, replaced_chunk_ids}
       else
         repo.rollback(:replaced_by_concurrent_ingest)
       end
     end)
+  end
+
+  defp maybe_delete_replaced_graph(replaced_chunk_ids, repo, opts) do
+    if Arcana.Config.graph_enabled?(opts) and ecto_graph_store?(opts) do
+      case GraphStore.delete_by_chunks(replaced_chunk_ids, Keyword.put(opts, :repo, repo)) do
+        :ok -> :ok
+        {:error, reason} -> repo.rollback({:graph_cleanup_failed, reason})
+      end
+    end
+  end
+
+  defp cleanup_replaced_graph([], _repo, _opts), do: :ok
+
+  defp cleanup_replaced_graph(chunk_ids, repo, opts) do
+    if Arcana.Config.graph_enabled?(opts) and not ecto_graph_store?(opts) do
+      case GraphStore.delete_by_chunks(chunk_ids, Keyword.put(opts, :repo, repo)) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("Arcana: replaced graph cleanup failed: #{inspect(reason)}")
+          :ok
+      end
+    else
+      :ok
+    end
+  end
+
+  defp ecto_graph_store?(opts) do
+    case Keyword.get(opts, :graph_store, GraphStore.backend()) do
+      :ecto -> true
+      {:ecto, _opts} -> true
+      _other -> false
+    end
   end
 
   defp maybe_build_graph(chunk_records, collection, repo, opts) do

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -138,30 +138,42 @@ defmodule Arcana.Loop do
   ## Options
 
     * `:repo` - Ecto repo for retrieval tools. Falls back to `:repo` global config.
-    * `:collection` - Single collection name (becomes `[collection]`).
-    * `:collections` - List of collection names. Takes precedence over `:collection`.
+    * `:collection` - Collection scope as `:all`, a name, or a list of names.
+    * `:collections` - Alias for `:collection`. The two options are mutually exclusive.
   """
   @spec new(String.t(), keyword()) :: Context.t()
   def new(question, opts \\ []) when is_binary(question) do
     repo = Arcana.Config.get(opts, :repo)
 
-    collections =
-      case Keyword.fetch(opts, :collections) do
-        {:ok, list} ->
-          list
-
-        :error ->
-          case Keyword.fetch(opts, :collection) do
-            {:ok, name} -> [name]
-            :error -> [nil]
-          end
-      end
+    collections = normalize_collection_scope(opts)
 
     %Context{
       question: question,
       repo: repo,
       collections: collections
     }
+  end
+
+  # `[nil]` was the old internal marker for unrestricted retrieval. Keep
+  # accepting it at this boundary so existing stored contexts and callers do
+  # not become accidentally narrower while the public contract moves to :all.
+  defp normalize_collection_scope(opts) do
+    opts =
+      opts
+      |> normalize_legacy_scope(:collection)
+      |> normalize_legacy_scope(:collections)
+
+    case Arcana.CollectionScope.from_opts!(opts, :all) do
+      :all -> :all
+      {:only, names} -> names
+    end
+  end
+
+  defp normalize_legacy_scope(opts, key) do
+    case Keyword.fetch(opts, key) do
+      {:ok, [nil]} -> Keyword.put(opts, key, :all)
+      _ -> opts
+    end
   end
 
   @doc """

--- a/lib/arcana/loop.ex
+++ b/lib/arcana/loop.ex
@@ -139,13 +139,12 @@ defmodule Arcana.Loop do
 
     * `:repo` - Ecto repo for retrieval tools. Falls back to `:repo` global config.
     * `:collection` - Collection scope as `:all`, a name, or a list of names.
-    * `:collections` - Alias for `:collection`. The two options are mutually exclusive.
   """
   @spec new(String.t(), keyword()) :: Context.t()
   def new(question, opts \\ []) when is_binary(question) do
     repo = Arcana.Config.get(opts, :repo)
 
-    collections = normalize_collection_scope(opts)
+    collections = opts |> Arcana.CollectionScope.from_opts!(:all) |> collection_scope_input()
 
     %Context{
       question: question,
@@ -154,27 +153,8 @@ defmodule Arcana.Loop do
     }
   end
 
-  # `[nil]` was the old internal marker for unrestricted retrieval. Keep
-  # accepting it at this boundary so existing stored contexts and callers do
-  # not become accidentally narrower while the public contract moves to :all.
-  defp normalize_collection_scope(opts) do
-    opts =
-      opts
-      |> normalize_legacy_scope(:collection)
-      |> normalize_legacy_scope(:collections)
-
-    case Arcana.CollectionScope.from_opts!(opts, :all) do
-      :all -> :all
-      {:only, names} -> names
-    end
-  end
-
-  defp normalize_legacy_scope(opts, key) do
-    case Keyword.fetch(opts, key) do
-      {:ok, [nil]} -> Keyword.put(opts, key, :all)
-      _ -> opts
-    end
-  end
+  defp collection_scope_input(:all), do: :all
+  defp collection_scope_input({:only, names}), do: names
 
   @doc """
   Runs the agent loop until it terminates.

--- a/lib/arcana/loop/context.ex
+++ b/lib/arcana/loop/context.ex
@@ -9,8 +9,8 @@ defmodule Arcana.Loop.Context do
 
     * `:question` - The original user question.
     * `:repo` - Ecto repo to use for retrieval tools.
-    * `:collections` - Collection scope for retrieval tools. Either `:all` or a
-      list of names, where `[]` matches no collections.
+    * `:collections` - Collection scope for retrieval tools. Either `:all`, one
+      name, or a list of names, where `[]` matches no collections.
     * `:messages` - The `ReqLLM.Context` carrying the running conversation.
     * `:chunks` - Accumulated chunks from `search` tool calls (capped via `:chunk_cap`).
     * `:tool_history` - List of `%{tool, args, iteration, summary}` entries in call order.

--- a/lib/arcana/loop/context.ex
+++ b/lib/arcana/loop/context.ex
@@ -9,7 +9,8 @@ defmodule Arcana.Loop.Context do
 
     * `:question` - The original user question.
     * `:repo` - Ecto repo to use for retrieval tools.
-    * `:collections` - Collections to scope retrieval tools to (list of names).
+    * `:collections` - Collection scope for retrieval tools. Either `:all` or a
+      list of names, where `[]` matches no collections.
     * `:messages` - The `ReqLLM.Context` carrying the running conversation.
     * `:chunks` - Accumulated chunks from `search` tool calls (capped via `:chunk_cap`).
     * `:tool_history` - List of `%{tool, args, iteration, summary}` entries in call order.
@@ -32,7 +33,7 @@ defmodule Arcana.Loop.Context do
   @type t :: %__MODULE__{
           question: String.t(),
           repo: module() | nil,
-          collections: [String.t() | nil],
+          collections: Arcana.CollectionScope.input(),
           messages: term() | nil,
           chunks: [map()],
           tool_history: [tool_history_entry()],
@@ -45,7 +46,7 @@ defmodule Arcana.Loop.Context do
 
   defstruct question: nil,
             repo: nil,
-            collections: [nil],
+            collections: :all,
             messages: nil,
             chunks: [],
             tool_history: [],

--- a/lib/arcana/loop/system_prompt.ex
+++ b/lib/arcana/loop/system_prompt.ex
@@ -25,7 +25,7 @@ defmodule Arcana.Loop.SystemPrompt do
   @spec default(keyword()) :: String.t()
   def default(opts \\ []) do
     max_iterations = Keyword.get(opts, :max_iterations, 10)
-    collections = Keyword.get(opts, :collections, [nil])
+    collections = normalize_collection_scope(Keyword.get(opts, :collections, :all))
 
     """
     You are a research agent answering questions about a knowledge base.
@@ -102,7 +102,10 @@ defmodule Arcana.Loop.SystemPrompt do
   # and shouldn't pay the prompt tax.
   defp collections_section(collections) do
     case collections do
-      [nil] ->
+      :all ->
+        ""
+
+      [] ->
         ""
 
       [_single] ->
@@ -123,6 +126,15 @@ defmodule Arcana.Loop.SystemPrompt do
         across all of them when the question is ambiguous or spans
         multiple topics.
         """
+    end
+  end
+
+  defp normalize_collection_scope([nil]), do: :all
+
+  defp normalize_collection_scope(input) do
+    case Arcana.CollectionScope.normalize!(input) do
+      :all -> :all
+      {:only, names} -> names
     end
   end
 end

--- a/lib/arcana/loop/tools.ex
+++ b/lib/arcana/loop/tools.ex
@@ -65,7 +65,7 @@ defmodule Arcana.Loop.Tools do
   When called with a list of collection names longer than one, the
   `search` tool gains an optional `collection` parameter that the
   controller can use to narrow the search per call. When called with
-  no collections, `[nil]`, or a single-element list, the parameter is
+  `:all`, no collections, or a single-element list, the parameter is
   omitted and the caller-supplied collection (if any) is always used.
 
   That way, `Arcana.Loop.new(collection: "docs")` locks the controller
@@ -73,8 +73,10 @@ defmodule Arcana.Loop.Tools do
   a different one), while `Arcana.Loop.new(collections: ["a", "b"])`
   lets the controller pick per call.
   """
-  @spec default(collections :: [String.t() | nil]) :: [Tool.t()]
-  def default(collections \\ [nil]) do
+  @spec default(Arcana.CollectionScope.input() | [nil]) :: [Tool.t()]
+  def default(collections \\ :all) do
+    collections = normalize_collection_scope(collections)
+
     [
       search_tool(collections),
       answer_tool(),
@@ -234,15 +236,17 @@ defmodule Arcana.Loop.Tools do
   def execute(%Context{} = ctx, "search", %{query: query} = args, opts) do
     limit = Map.get(args, :limit, 5)
 
-    case resolve_search_collection(ctx.collections, Map.get(args, :collection)) do
+    collection_scope = normalize_collection_scope(ctx.collections)
+
+    case resolve_search_collection(collection_scope, Map.get(args, :collection)) do
       {:error, message} ->
         {:continue, ctx, "search error: #{message}", %{returned_chunk_ids: []}}
 
       {:ok, collection_opts} ->
         search_opts =
           [repo: ctx.repo, limit: limit]
-          |> Keyword.merge(collection_opts)
           |> Keyword.merge(Keyword.get(opts, :search_opts, []))
+          |> Keyword.merge(collection_opts)
 
         search_fn = Keyword.get(opts, :search_fn, &Arcana.search/2)
 
@@ -308,8 +312,8 @@ defmodule Arcana.Loop.Tools do
   # pass a `collection` arg. The resolution table:
   #
   #   ctx.collections    tool arg    result
-  #   [nil]              nil         unconstrained
-  #   [nil]              "x"         collection: "x" (no restriction to validate against)
+  #   :all               nil         collection: :all
+  #   :all               "x"         collection: "x" (no restriction to validate against)
   #   [single]           nil         collection: single
   #   [single]           _           collection: single (arg ignored, lock wins)
   #   [a, b]             nil         collections: [a, b]
@@ -317,8 +321,9 @@ defmodule Arcana.Loop.Tools do
   #   [a, b]             "c"         error: not in allowed list
   defp resolve_search_collection(ctx_collections, tool_arg)
 
-  defp resolve_search_collection([nil], nil), do: {:ok, []}
-  defp resolve_search_collection([nil], name) when is_binary(name), do: {:ok, [collection: name]}
+  defp resolve_search_collection(:all, nil), do: {:ok, [collection: :all]}
+  defp resolve_search_collection(:all, name) when is_binary(name), do: {:ok, [collection: name]}
+  defp resolve_search_collection([nil], tool_arg), do: resolve_search_collection(:all, tool_arg)
 
   defp resolve_search_collection([single], _arg) when is_binary(single),
     do: {:ok, [collection: single]}
@@ -332,6 +337,15 @@ defmodule Arcana.Loop.Tools do
     else
       {:error,
        "collection #{inspect(name)} is not in the allowed list (#{Enum.map_join(list, ", ", &inspect/1)})"}
+    end
+  end
+
+  defp normalize_collection_scope([nil]), do: :all
+
+  defp normalize_collection_scope(input) do
+    case Arcana.CollectionScope.normalize!(input) do
+      :all -> :all
+      {:only, names} -> names
     end
   end
 

--- a/lib/arcana/loop/tools.ex
+++ b/lib/arcana/loop/tools.ex
@@ -70,7 +70,7 @@ defmodule Arcana.Loop.Tools do
 
   That way, `Arcana.Loop.new(collection: "docs")` locks the controller
   to a single collection programmatically (the tool can't even express
-  a different one), while `Arcana.Loop.new(collections: ["a", "b"])`
+  a different one), while `Arcana.Loop.new(collection: ["a", "b"])`
   lets the controller pick per call.
   """
   @spec default(Arcana.CollectionScope.input() | [nil]) :: [Tool.t()]
@@ -246,6 +246,7 @@ defmodule Arcana.Loop.Tools do
         search_opts =
           [repo: ctx.repo, limit: limit]
           |> Keyword.merge(Keyword.get(opts, :search_opts, []))
+          |> Keyword.drop([:collection, :collections])
           |> Keyword.merge(collection_opts)
 
         search_fn = Keyword.get(opts, :search_fn, &Arcana.search/2)
@@ -316,7 +317,7 @@ defmodule Arcana.Loop.Tools do
   #   :all               "x"         collection: "x" (no restriction to validate against)
   #   [single]           nil         collection: single
   #   [single]           _           collection: single (arg ignored, lock wins)
-  #   [a, b]             nil         collections: [a, b]
+  #   [a, b]             nil         collection: [a, b]
   #   [a, b]             "a"         collection: "a"
   #   [a, b]             "c"         error: not in allowed list
   defp resolve_search_collection(ctx_collections, tool_arg)
@@ -329,7 +330,7 @@ defmodule Arcana.Loop.Tools do
     do: {:ok, [collection: single]}
 
   defp resolve_search_collection(list, nil) when is_list(list),
-    do: {:ok, [collections: list]}
+    do: {:ok, [collection: list]}
 
   defp resolve_search_collection(list, name) when is_list(list) and is_binary(name) do
     if name in list do

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -15,7 +15,7 @@ defmodule Arcana.Maintenance do
 
   """
 
-  alias Arcana.{Chunk, Chunker, Collection, Document, Embedder}
+  alias Arcana.{Chunk, Chunker, Collection, CollectionScope, Document, Embedder}
   alias Arcana.Graph.{CommunitySummarizer, EntityMention, GraphStore}
   alias Ecto.Adapters.SQL
 
@@ -29,6 +29,9 @@ defmodule Arcana.Maintenance do
 
   ## Options
 
+    * `:collection` / `:collections` - `:all`, one collection name, or a list
+      of collection names (default: `:all`). The options are mutually exclusive.
+      An empty list does no work.
     * `:batch_size` - Number of items to process at once (default: 50)
     * `:concurrency` - Number of parallel embedding requests (default: 5)
     * `:skip` - Number of chunks to skip (for resuming interrupted runs)
@@ -57,13 +60,12 @@ defmodule Arcana.Maintenance do
     concurrency = Keyword.get(opts, :concurrency, 5)
     skip = Keyword.get(opts, :skip, 0)
     progress_fn = Keyword.get(opts, :progress, fn _, _ -> :ok end)
-    collection_filter = Keyword.get(opts, :collection)
-
     embedder = Arcana.embedder()
     strict? = Arcana.Config.strict_collections?(opts)
 
-    with {:ok, collection_id} <- Collection.resolve_id(collection_filter, repo, strict?) do
-      do_reembed(repo, embedder, collection_id, %{
+    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+         {:ok, collection_ids} <- resolve_collection_ids(repo, scope, strict?) do
+      do_reembed(repo, embedder, collection_ids, %{
         batch_size: batch_size,
         concurrency: concurrency,
         skip: skip,
@@ -107,19 +109,21 @@ defmodule Arcana.Maintenance do
      }}
   end
 
-  defp fetch_docs_without_chunks(repo, nil) do
+  defp fetch_docs_without_chunks(repo, :all) do
     repo.all(from(d in Document, where: d.chunk_count == 0 or d.status == :pending))
   end
 
-  defp fetch_docs_without_chunks(repo, collection_id) do
+  defp fetch_docs_without_chunks(repo, collection_ids) do
     repo.all(
       from(d in Document,
-        where: d.collection_id == ^collection_id and (d.chunk_count == 0 or d.status == :pending)
+        where:
+          d.collection_id in ^collection_ids and
+            (d.chunk_count == 0 or d.status == :pending)
       )
     )
   end
 
-  defp reembed_filtered_chunks(repo, embedder, batch_size, concurrency, skip, progress_fn, nil) do
+  defp reembed_filtered_chunks(repo, embedder, batch_size, concurrency, skip, progress_fn, :all) do
     total_chunks = repo.aggregate(Chunk, :count)
     chunks_query = from(c in Chunk, order_by: c.id, select: [:id, :text])
 
@@ -149,13 +153,13 @@ defmodule Arcana.Maintenance do
          concurrency,
          skip,
          progress_fn,
-         collection_id
+         collection_ids
        ) do
     chunks_query =
       from(c in Chunk,
         join: d in Document,
         on: d.id == c.document_id,
-        where: d.collection_id == ^collection_id,
+        where: d.collection_id in ^collection_ids,
         order_by: c.id,
         select: [:id, :text]
       )
@@ -364,7 +368,9 @@ defmodule Arcana.Maintenance do
 
   ## Options
 
-    * `:collection` - Only embed entities in this collection
+    * `:collection` / `:collections` - `:all`, one collection name, or a list
+      of collection names (default: `:all`). The options are mutually exclusive.
+      An empty list does no work.
     * `:batch_size` - Entities per batch (default: 100)
     * `:progress` - Progress callback `fn current, total -> :ok end`
     * `:force` - Re-embed all entities, not just those without embeddings (default: false)
@@ -373,7 +379,6 @@ defmodule Arcana.Maintenance do
     import Ecto.Query
     alias Arcana.Graph.Entity
 
-    collection_filter = Keyword.get(opts, :collection)
     batch_size = Keyword.get(opts, :batch_size, 100)
     progress_fn = Keyword.get(opts, :progress, fn _, _ -> :ok end)
     force = Keyword.get(opts, :force, false)
@@ -382,11 +387,9 @@ defmodule Arcana.Maintenance do
     query = from(e in Entity, order_by: e.id, select: [:id, :name, :description, :embedding])
     strict? = Arcana.Config.strict_collections?(opts)
 
-    with {:ok, collection_id} <- Collection.resolve_id(collection_filter, repo, strict?) do
-      query =
-        if collection_id,
-          do: from(e in query, where: e.collection_id == ^collection_id),
-          else: query
+    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+         {:ok, collection_ids} <- resolve_collection_ids(repo, scope, strict?) do
+      query = scope_by_collection_ids(query, collection_ids)
 
       query = if force, do: query, else: from(e in query, where: is_nil(e.embedding))
 
@@ -480,12 +483,12 @@ defmodule Arcana.Maintenance do
   """
   def rebuild_graph(repo, opts \\ []) do
     progress_fn = Keyword.get(opts, :progress, fn _, _ -> :ok end)
-    collection_filter = Keyword.get(opts, :collection)
 
     strict? = Arcana.Config.strict_collections?(opts)
 
     # Get collections (optionally filtered)
-    with {:ok, collections} <- fetch_collections(repo, collection_filter, strict?) do
+    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+         {:ok, collections} <- fetch_collections(repo, scope, strict?) do
       if collections == [] do
         {:ok, %{collections: 0, entities: 0, relationships: 0, skipped: 0}}
       else
@@ -623,15 +626,38 @@ defmodule Arcana.Maintenance do
     |> MapSet.new()
   end
 
-  defp fetch_collections(repo, nil, _strict?) do
+  defp fetch_collections(repo, :all, _strict?) do
     {:ok, repo.all(from(c in Collection, select: c))}
   end
 
-  defp fetch_collections(repo, collection_name, strict?) when is_binary(collection_name) do
-    case repo.all(from(c in Collection, where: c.name == ^collection_name, select: c)) do
-      [] when strict? -> {:error, {:unknown_collection, collection_name}}
-      collections -> {:ok, collections}
+  defp fetch_collections(repo, {:only, names}, strict?) do
+    collections = repo.all(from(c in Collection, where: c.name in ^names, select: c))
+
+    if strict? do
+      found_names = MapSet.new(collections, & &1.name)
+
+      case Enum.find(names, &(not MapSet.member?(found_names, &1))) do
+        nil -> {:ok, collections}
+        name -> {:error, {:unknown_collection, name}}
+      end
+    else
+      {:ok, collections}
     end
+  end
+
+  defp resolve_collection_ids(_repo, :all, _strict?), do: {:ok, :all}
+
+  defp resolve_collection_ids(repo, {:only, _names} = scope, strict?) do
+    case fetch_collections(repo, scope, strict?) do
+      {:ok, collections} -> {:ok, Enum.map(collections, & &1.id)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp scope_by_collection_ids(query, :all), do: query
+
+  defp scope_by_collection_ids(query, collection_ids) do
+    from(row in query, where: row.collection_id in ^collection_ids)
   end
 
   @doc """
@@ -692,7 +718,9 @@ defmodule Arcana.Maintenance do
 
   ## Options
 
-    * `:collection` - Filter to a specific collection by name (default: all collections)
+    * `:collection` / `:collections` - `:all`, one collection name, or a list
+      of collection names (default: `:all`). The options are mutually exclusive.
+      An empty list does no work.
     * `:resolution` - Community detection resolution (default: 1.0)
     * `:objective` - Quality function (default: `:cpm`)
     * `:iterations` - Optimization iterations (default: 2)
@@ -736,11 +764,11 @@ defmodule Arcana.Maintenance do
   """
   def detect_communities(repo, opts \\ []) do
     progress_fn = Keyword.get(opts, :progress, fn _, _ -> :ok end)
-    collection_filter = Keyword.get(opts, :collection)
 
     strict? = Arcana.Config.strict_collections?(opts)
 
-    with {:ok, collections} <- fetch_collections(repo, collection_filter, strict?) do
+    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+         {:ok, collections} <- fetch_collections(repo, scope, strict?) do
       if collections == [] do
         {:ok, %{collections: 0, communities: 0}}
       else
@@ -1017,7 +1045,9 @@ defmodule Arcana.Maintenance do
 
   ## Options
 
-    - `:collection` - Only summarize communities in this collection (default: all)
+    - `:collection` / `:collections` - `:all`, one collection name, or a list
+      of collection names (default: `:all`). The options are mutually exclusive.
+      An empty list does no work.
     - `:progress` - Progress callback function
     - `:force` - Regenerate all summaries even if not dirty (default: false)
     - `:concurrency` - Number of parallel summarization tasks (default: 1)
@@ -1048,7 +1078,6 @@ defmodule Arcana.Maintenance do
   """
   def summarize_communities(repo, opts \\ []) do
     progress_fn = Keyword.get(opts, :progress, fn _, _ -> :ok end)
-    collection_filter = Keyword.get(opts, :collection)
     force = Keyword.get(opts, :force, false)
     concurrency = Keyword.get(opts, :concurrency, 1)
 
@@ -1056,7 +1085,8 @@ defmodule Arcana.Maintenance do
 
     # Validate the collection filter before requiring an LLM, so strict
     # callers get {:error, {:unknown_collection, name}} consistently.
-    with {:ok, collections} <- fetch_collections(repo, collection_filter, strict?) do
+    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+         {:ok, collections} <- fetch_collections(repo, scope, strict?) do
       summarize_fetched_collections(collections, repo, %{
         opts: opts,
         force: force,

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -860,7 +860,8 @@ defmodule Arcana.Maintenance do
          detector,
          progress_fn
        ) do
-    alias Arcana.Graph.{CommunityDetector, Entity, Relationship}
+    alias Arcana.Graph.{CommunityDetector, Entity}
+    alias Arcana.RetrievalScope
 
     # Report start
     try do
@@ -874,7 +875,7 @@ defmodule Arcana.Maintenance do
     # yields stable membership when the input order is stable too.
     entities =
       repo.all(
-        from(e in Entity,
+        from([entity: e] in RetrievalScope.entities(),
           where: e.collection_id == ^collection.id,
           order_by: e.id,
           select: %{id: e.id, name: e.name, type: e.type, description: e.description}
@@ -883,7 +884,7 @@ defmodule Arcana.Maintenance do
 
     relationships =
       repo.all(
-        from(r in Relationship,
+        from([relationship: r] in RetrievalScope.relationships(),
           join: e in Entity,
           on: r.source_id == e.id,
           where: e.collection_id == ^collection.id,
@@ -1117,7 +1118,8 @@ defmodule Arcana.Maintenance do
   end
 
   defp summarize_communities_for_collection(collection, repo, ctx) do
-    alias Arcana.Graph.{Community, CommunitySummarizer, Entity, Relationship}
+    alias Arcana.Graph.{Community, CommunitySummarizer, Entity}
+    alias Arcana.RetrievalScope
 
     %{llm: llm, force: force, concurrency: concurrency, progress_fn: progress_fn} = ctx
 
@@ -1189,13 +1191,14 @@ defmodule Arcana.Maintenance do
   defp level_filter(levels), do: dynamic([c], c.level in ^levels)
 
   defp summarize_single_community(community, repo, llm) do
-    alias Arcana.Graph.{Community, CommunitySummarizer, Entity, Relationship}
+    alias Arcana.Graph.{Community, CommunitySummarizer, Entity}
+    alias Arcana.RetrievalScope
 
     entity_ids = community.entity_ids || []
 
     entities =
       repo.all(
-        from(e in Entity,
+        from([entity: e] in RetrievalScope.entities(),
           where: e.id in ^entity_ids,
           select: %{id: e.id, name: e.name, type: e.type, description: e.description}
         )
@@ -1203,7 +1206,7 @@ defmodule Arcana.Maintenance do
 
     relationships =
       repo.all(
-        from(r in Relationship,
+        from([relationship: r] in RetrievalScope.relationships(),
           join: src in Entity,
           on: r.source_id == src.id,
           join: tgt in Entity,

--- a/lib/arcana/maintenance.ex
+++ b/lib/arcana/maintenance.ex
@@ -29,9 +29,8 @@ defmodule Arcana.Maintenance do
 
   ## Options
 
-    * `:collection` / `:collections` - `:all`, one collection name, or a list
-      of collection names (default: `:all`). The options are mutually exclusive.
-      An empty list does no work.
+    * `:collection` - `:all`, one collection name, or a list of collection
+      names (default: `:all`). An empty list does no work.
     * `:batch_size` - Number of items to process at once (default: 50)
     * `:concurrency` - Number of parallel embedding requests (default: 5)
     * `:skip` - Number of chunks to skip (for resuming interrupted runs)
@@ -63,7 +62,7 @@ defmodule Arcana.Maintenance do
     embedder = Arcana.embedder()
     strict? = Arcana.Config.strict_collections?(opts)
 
-    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+    with {:ok, scope} <- normalize_collection_scope(opts),
          {:ok, collection_ids} <- resolve_collection_ids(repo, scope, strict?) do
       do_reembed(repo, embedder, collection_ids, %{
         batch_size: batch_size,
@@ -368,9 +367,8 @@ defmodule Arcana.Maintenance do
 
   ## Options
 
-    * `:collection` / `:collections` - `:all`, one collection name, or a list
-      of collection names (default: `:all`). The options are mutually exclusive.
-      An empty list does no work.
+    * `:collection` - `:all`, one collection name, or a list of collection
+      names (default: `:all`). An empty list does no work.
     * `:batch_size` - Entities per batch (default: 100)
     * `:progress` - Progress callback `fn current, total -> :ok end`
     * `:force` - Re-embed all entities, not just those without embeddings (default: false)
@@ -387,7 +385,7 @@ defmodule Arcana.Maintenance do
     query = from(e in Entity, order_by: e.id, select: [:id, :name, :description, :embedding])
     strict? = Arcana.Config.strict_collections?(opts)
 
-    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+    with {:ok, scope} <- normalize_collection_scope(opts),
          {:ok, collection_ids} <- resolve_collection_ids(repo, scope, strict?) do
       query = scope_by_collection_ids(query, collection_ids)
 
@@ -487,7 +485,7 @@ defmodule Arcana.Maintenance do
     strict? = Arcana.Config.strict_collections?(opts)
 
     # Get collections (optionally filtered)
-    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+    with {:ok, scope} <- normalize_collection_scope(opts),
          {:ok, collections} <- fetch_collections(repo, scope, strict?) do
       if collections == [] do
         {:ok, %{collections: 0, entities: 0, relationships: 0, skipped: 0}}
@@ -626,6 +624,10 @@ defmodule Arcana.Maintenance do
     |> MapSet.new()
   end
 
+  defp normalize_collection_scope(opts) do
+    CollectionScope.from_opts(opts, :all)
+  end
+
   defp fetch_collections(repo, :all, _strict?) do
     {:ok, repo.all(from(c in Collection, select: c))}
   end
@@ -718,9 +720,8 @@ defmodule Arcana.Maintenance do
 
   ## Options
 
-    * `:collection` / `:collections` - `:all`, one collection name, or a list
-      of collection names (default: `:all`). The options are mutually exclusive.
-      An empty list does no work.
+    * `:collection` - `:all`, one collection name, or a list of collection
+      names (default: `:all`). An empty list does no work.
     * `:resolution` - Community detection resolution (default: 1.0)
     * `:objective` - Quality function (default: `:cpm`)
     * `:iterations` - Optimization iterations (default: 2)
@@ -767,7 +768,7 @@ defmodule Arcana.Maintenance do
 
     strict? = Arcana.Config.strict_collections?(opts)
 
-    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+    with {:ok, scope} <- normalize_collection_scope(opts),
          {:ok, collections} <- fetch_collections(repo, scope, strict?) do
       if collections == [] do
         {:ok, %{collections: 0, communities: 0}}
@@ -1045,9 +1046,8 @@ defmodule Arcana.Maintenance do
 
   ## Options
 
-    - `:collection` / `:collections` - `:all`, one collection name, or a list
-      of collection names (default: `:all`). The options are mutually exclusive.
-      An empty list does no work.
+    - `:collection` - `:all`, one collection name, or a list of collection
+      names (default: `:all`). An empty list does no work.
     - `:progress` - Progress callback function
     - `:force` - Regenerate all summaries even if not dirty (default: false)
     - `:concurrency` - Number of parallel summarization tasks (default: 1)
@@ -1085,7 +1085,7 @@ defmodule Arcana.Maintenance do
 
     # Validate the collection filter before requiring an LLM, so strict
     # callers get {:error, {:unknown_collection, name}} consistently.
-    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+    with {:ok, scope} <- normalize_collection_scope(opts),
          {:ok, collections} <- fetch_collections(repo, scope, strict?) do
       summarize_fetched_collections(collections, repo, %{
         opts: opts,

--- a/lib/arcana/migration.ex
+++ b/lib/arcana/migration.ex
@@ -78,16 +78,27 @@ defmodule Arcana.Migration do
 
     * 1 - collections, documents, chunks and the evaluation tables
 
+  ## Uninstall ownership
+
+  Target version 0 removes only the core tables listed above. It leaves the
+  Postgres schema and `vector` extension in place. GraphRAG is a separate,
+  downstream migration stream whose tables reference the core tables, so a
+  same-prefix graph install must be removed with `Arcana.Graph.Migration.down/1`
+  before the core stream. Arcana refuses that ordering mistake before changing
+  the schema instead of exposing Postgres's dependency error.
+
   """
 
   use Ecto.Migration
 
+  alias Arcana.Migration.Dependencies
   alias Arcana.Migration.Dimensions
+  alias Arcana.Migration.Registry
+  alias Arcana.Migration.SchemaScope
   alias Arcana.Migration.UniqueIndex
 
-  @current_version 1
-
-  @version_table "arcana_documents"
+  @current_version Registry.current_version(:core)
+  @version_table Registry.version_table(:core)
 
   @doc """
   Migrates up to `:version`, or to the latest version.
@@ -96,7 +107,8 @@ defmodule Arcana.Migration do
     target = Keyword.get(opts, :version, @current_version)
     validate_target!(target)
 
-    prefix = Keyword.get(opts, :prefix)
+    prefix = SchemaScope.resolve(repo(), :core, Keyword.get(opts, :prefix))
+    opts = Keyword.put(opts, :prefix, prefix)
     current = recorded_version(repo(), prefix: prefix)
     validate_recorded!(current)
 
@@ -122,17 +134,21 @@ defmodule Arcana.Migration do
   @doc """
   Migrates down to `:version`, or removes Arcana's tables entirely.
 
-  Defaults to version 0, which drops everything this module created.
+  Defaults to version 0, which drops everything this module created. A
+  same-prefix GraphRAG install must be removed first.
   """
   def down(opts \\ []) do
     target = Keyword.get(opts, :version, 0)
     validate_rollback_target!(target)
 
-    prefix = Keyword.get(opts, :prefix)
+    prefix = SchemaScope.resolve(repo(), :core, Keyword.get(opts, :prefix))
+    opts = Keyword.put(opts, :prefix, prefix)
     current = recorded_version(repo(), prefix: prefix)
     validate_recorded!(current)
 
     if current == 0, do: refuse_blind_rollback!(prefix)
+
+    if current > target and target == 0, do: preflight_uninstall!(prefix)
 
     if current > target do
       for version <- current..(target + 1)//-1, do: change(version, :down, opts)
@@ -207,27 +223,43 @@ defmodule Arcana.Migration do
   #
   # relkind is constrained to ordinary and partitioned tables, so a view or
   # sequence that happens to share a name is not mistaken for an install.
-  defp owned_tables_present(prefix) do
-    %{rows: rows} =
-      repo().query!(
-        "SELECT c.relname FROM pg_class c " <>
-          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
-          "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
-        [
-          ~w(
-                   arcana_collections
-                   arcana_documents
-                   arcana_chunks
-                   arcana_evaluation_test_cases
-                   arcana_evaluation_test_case_chunks
-                   arcana_evaluation_runs
-          ),
-          prefix
-        ]
-      )
+  defp owned_tables_present(prefix), do: Registry.present(repo(), :core, prefix)
 
-    List.flatten(rows)
+  defp preflight_uninstall!(prefix) do
+    execute(fn ->
+      graph_tables = Registry.present(repo(), :graph, prefix)
+
+      if graph_tables != [] do
+        tables = graph_tables
+        listed = tables |> Enum.sort() |> Enum.map_join("\n", &"    #{&1}")
+        prefix_opt = if prefix, do: "prefix: #{inspect(prefix)}", else: ""
+
+        raise """
+        Arcana.Migration.down/1 can't remove the core schema while GraphRAG is installed in the same prefix:
+
+        #{listed}
+
+        Run Arcana.Graph.Migration.down(#{prefix_opt}) first, then retry Arcana.Migration.down(#{prefix_opt}). Nothing was changed.
+        """
+      end
+
+      case Dependencies.external(repo(), :core, prefix) do
+        [] ->
+          :ok
+
+        dependents ->
+          listed = Enum.map_join(dependents, "\n", &"    #{&1}")
+          retry_scope = if prefix, do: "with prefix: #{inspect(prefix)}", else: "without a prefix"
+
+          raise """
+          Arcana.Migration.down/1 can't remove the core schema because objects Arcana does not own depend on it:
+
+          #{listed}
+
+          Drop or repoint these objects, then retry #{retry_scope}. Nothing was changed. Arcana will not use DROP ... CASCADE because that would delete host-owned objects.
+          """
+      end
+    end)
   end
 
   @doc """
@@ -255,7 +287,7 @@ defmodule Arcana.Migration do
       repo.query!(
         "SELECT obj_description(c.oid) FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
-          "WHERE c.relname = $1 AND n.nspname = COALESCE($2, current_schema())",
+          "WHERE c.relname = $1 AND " <> SchemaScope.visible("c", "n", "$2"),
         [@version_table, prefix]
       )
 
@@ -273,25 +305,20 @@ defmodule Arcana.Migration do
       0
   end
 
-  defp parse_version(nil), do: 0
-
   # Anchored, so only a comment that is exactly the marker counts. An
   # unanchored match read a version out of any prose that happened to
   # contain "arcana:2", and a bare integer (what Oban stores) would read a
   # host's own "1" as version 1. Anything we don't recognise reads as 0,
   # which is the same answer as "never installed" - see the moduledoc.
-  defp parse_version(comment) do
-    case Regex.run(~r/\Aarcana:(\d+)\z/, String.trim(comment)) do
-      [_, version] -> String.to_integer(version)
-      _ -> 0
-    end
-  end
+  defp parse_version(comment), do: Registry.parse_marker(:core, comment)
 
   # Everything is gone, so there is nothing left to comment on.
   defp record_version(0, _prefix), do: :ok
 
   defp record_version(version, prefix) do
-    execute("COMMENT ON TABLE #{qualify(@version_table, prefix)} IS 'arcana:#{version}'")
+    execute(
+      "COMMENT ON TABLE #{qualify(@version_table, prefix)} IS '#{Registry.marker(:core, version)}'"
+    )
   end
 
   # Raw SQL gets none of Ecto's prefix handling, so anything that doesn't go
@@ -518,12 +545,10 @@ defmodule Arcana.Migration do
   defp change(1, :down, opts) do
     prefix = Keyword.get(opts, :prefix)
 
-    drop_if_exists(table(:arcana_evaluation_runs, prefix: prefix))
-    drop_if_exists(table(:arcana_evaluation_test_case_chunks, prefix: prefix))
-    drop_if_exists(table(:arcana_evaluation_test_cases, prefix: prefix))
-    drop_if_exists(table(:arcana_chunks, prefix: prefix))
-    drop_if_exists(table(:arcana_documents, prefix: prefix))
-    drop_if_exists(table(:arcana_collections, prefix: prefix))
+    for table_name <- Registry.tables_added_in(:core, 1) |> Enum.reverse() do
+      drop_if_exists(table(String.to_atom(table_name), prefix: prefix))
+    end
+
     # The vector extension stays: other tables in the database may use it.
   end
 
@@ -568,7 +593,7 @@ defmodule Arcana.Migration do
             "JOIN pg_namespace n ON n.oid = t.relnamespace " <>
             "WHERE con.conname = 'arcana_documents_collection_id_fkey' " <>
             "AND t.relname = 'arcana_documents' " <>
-            "AND n.nspname = COALESCE($1, current_schema())",
+            "AND " <> SchemaScope.visible("t", "n", "$1"),
           [prefix]
         )
 

--- a/lib/arcana/migration/dependencies.ex
+++ b/lib/arcana/migration/dependencies.ex
@@ -1,0 +1,182 @@
+defmodule Arcana.Migration.Dependencies do
+  @moduledoc false
+
+  alias Arcana.Migration.Registry
+  alias Arcana.Migration.SchemaScope
+
+  def external(repo, stream, prefix) do
+    tables = Registry.owned_tables(stream)
+
+    (foreign_keys(repo, tables, prefix) ++
+       views(repo, tables, prefix) ++
+       composite_columns(repo, tables, prefix) ++
+       inherited_tables(repo, tables, prefix) ++
+       extension_memberships(repo, tables, prefix) ++
+       generic_dependencies(repo, tables, prefix))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp foreign_keys(repo, tables, prefix) do
+    %{rows: rows} =
+      repo.query!(
+        owned_cte() <>
+          "SELECT 'foreign key', source_ns.nspname, source.relname, con.conname, " <>
+          "target_ns.nspname, target.relname " <>
+          "FROM pg_constraint con " <>
+          "JOIN owned ON owned.oid = con.confrelid " <>
+          "JOIN pg_class source ON source.oid = con.conrelid " <>
+          "JOIN pg_namespace source_ns ON source_ns.oid = source.relnamespace " <>
+          "JOIN pg_class target ON target.oid = con.confrelid " <>
+          "JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace " <>
+          "WHERE con.contype = 'f' AND NOT EXISTS " <>
+          "(SELECT 1 FROM owned source_owned WHERE source_owned.oid = con.conrelid)",
+        [tables, prefix]
+      )
+
+    Enum.map(rows, fn [kind, schema, table, name, target_schema, target] ->
+      ~s(#{kind} #{quote_ident(schema)}.#{quote_ident(table)}.#{quote_ident(name)} -> #{quote_ident(target_schema)}.#{quote_ident(target)})
+    end)
+  end
+
+  defp views(repo, tables, prefix) do
+    %{rows: rows} =
+      repo.query!(
+        owned_cte() <>
+          "SELECT DISTINCT CASE view.relkind WHEN 'm' THEN 'materialized view' ELSE 'view' END, " <>
+          "view_ns.nspname, view.relname, target_ns.nspname, target.relname " <>
+          "FROM pg_depend dep " <>
+          "JOIN pg_rewrite rewrite ON rewrite.oid = dep.objid " <>
+          "JOIN pg_class view ON view.oid = rewrite.ev_class " <>
+          "JOIN pg_namespace view_ns ON view_ns.oid = view.relnamespace " <>
+          "JOIN owned ON owned.oid = dep.refobjid " <>
+          "JOIN pg_class target ON target.oid = owned.oid " <>
+          "JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace " <>
+          "WHERE dep.classid = 'pg_rewrite'::regclass " <>
+          "AND dep.refclassid = 'pg_class'::regclass AND dep.deptype = 'n' " <>
+          "AND view.relkind IN ('v', 'm') " <>
+          "AND NOT EXISTS (SELECT 1 FROM owned view_owned WHERE view_owned.oid = view.oid)",
+        [tables, prefix]
+      )
+
+    Enum.map(rows, fn [kind, schema, view, target_schema, target] ->
+      ~s(#{kind} #{quote_ident(schema)}.#{quote_ident(view)} -> #{quote_ident(target_schema)}.#{quote_ident(target)})
+    end)
+  end
+
+  defp composite_columns(repo, tables, prefix) do
+    %{rows: rows} =
+      repo.query!(
+        owned_cte() <>
+          "SELECT host_ns.nspname, host.relname, attr.attname, " <>
+          "target_ns.nspname, target.relname " <>
+          "FROM pg_attribute attr " <>
+          "JOIN pg_class host ON host.oid = attr.attrelid " <>
+          "JOIN pg_namespace host_ns ON host_ns.oid = host.relnamespace " <>
+          "JOIN owned ON owned.reltype = attr.atttypid " <>
+          "JOIN pg_class target ON target.oid = owned.oid " <>
+          "JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace " <>
+          "WHERE attr.attnum > 0 AND NOT attr.attisdropped " <>
+          "AND NOT EXISTS (SELECT 1 FROM owned host_owned WHERE host_owned.oid = host.oid)",
+        [tables, prefix]
+      )
+
+    Enum.map(rows, fn [schema, table, column, target_schema, target] ->
+      ~s(column #{quote_ident(schema)}.#{quote_ident(table)}.#{quote_ident(column)} uses row type #{quote_ident(target_schema)}.#{quote_ident(target)})
+    end)
+  end
+
+  defp inherited_tables(repo, tables, prefix) do
+    %{rows: rows} =
+      repo.query!(
+        owned_cte() <>
+          "SELECT child_ns.nspname, child.relname, parent_ns.nspname, parent.relname " <>
+          "FROM pg_inherits inheritance " <>
+          "JOIN owned ON owned.oid = inheritance.inhparent " <>
+          "JOIN pg_class child ON child.oid = inheritance.inhrelid " <>
+          "JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace " <>
+          "JOIN pg_class parent ON parent.oid = inheritance.inhparent " <>
+          "JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace " <>
+          "WHERE NOT EXISTS (SELECT 1 FROM owned child_owned WHERE child_owned.oid = child.oid)",
+        [tables, prefix]
+      )
+
+    Enum.map(rows, fn [schema, child, parent_schema, parent] ->
+      ~s(inherited table #{quote_ident(schema)}.#{quote_ident(child)} -> #{quote_ident(parent_schema)}.#{quote_ident(parent)})
+    end)
+  end
+
+  defp generic_dependencies(repo, tables, prefix) do
+    %{rows: rows} =
+      repo.query!(
+        dependency_cte() <>
+          "SELECT DISTINCT identified.type, identified.schema, identified.identity " <>
+          "FROM pg_depend dependency " <>
+          "CROSS JOIN LATERAL pg_identify_object(" <>
+          "dependency.classid, dependency.objid, dependency.objsubid) identified " <>
+          "WHERE dependency.deptype = 'n' AND (" <>
+          "(dependency.refclassid = 'pg_class'::regclass " <>
+          "AND dependency.refobjid IN (SELECT oid FROM owned)) OR " <>
+          "(dependency.refclassid = 'pg_type'::regclass " <>
+          "AND dependency.refobjid IN (SELECT oid FROM dependent_types))) " <>
+          "AND NOT (dependency.classid = 'pg_constraint'::regclass " <>
+          "AND dependency.objid IN (SELECT con.oid FROM pg_constraint con " <>
+          "WHERE con.conrelid IN (SELECT oid FROM owned))) " <>
+          "AND NOT (dependency.classid = 'pg_rewrite'::regclass " <>
+          "AND dependency.objid IN (SELECT rewrite.oid FROM pg_rewrite rewrite " <>
+          "WHERE rewrite.ev_class IN (SELECT oid FROM owned))) " <>
+          "AND NOT (dependency.classid = 'pg_class'::regclass " <>
+          "AND dependency.objid IN (SELECT oid FROM owned))",
+        [tables, prefix]
+      )
+
+    Enum.map(rows, fn [type, schema, identity] ->
+      schema_part = if schema, do: " in #{quote_ident(schema)}", else: ""
+      "#{type} #{identity}#{schema_part}"
+    end)
+  end
+
+  defp extension_memberships(repo, tables, prefix) do
+    %{rows: rows} =
+      repo.query!(
+        owned_cte() <>
+          "SELECT extension.extname, target_ns.nspname, target.relname " <>
+          "FROM pg_depend dependency " <>
+          "JOIN owned ON owned.oid = dependency.objid " <>
+          "JOIN pg_extension extension ON extension.oid = dependency.refobjid " <>
+          "JOIN pg_class target ON target.oid = owned.oid " <>
+          "JOIN pg_namespace target_ns ON target_ns.oid = target.relnamespace " <>
+          "WHERE dependency.classid = 'pg_class'::regclass " <>
+          "AND dependency.refclassid = 'pg_extension'::regclass " <>
+          "AND dependency.deptype = 'e'",
+        [tables, prefix]
+      )
+
+    Enum.map(rows, fn [extension, schema, table] ->
+      ~s(extension #{quote_ident(extension)} requires #{quote_ident(schema)}.#{quote_ident(table)})
+    end)
+  end
+
+  defp owned_cte do
+    "WITH owned AS (" <>
+      "SELECT c.oid, c.reltype FROM pg_class c " <>
+      "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+      "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
+      "AND " <> SchemaScope.visible("c", "n", "$2") <> ") "
+  end
+
+  defp dependency_cte do
+    "WITH RECURSIVE owned AS (" <>
+      "SELECT c.oid, c.reltype FROM pg_class c " <>
+      "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+      "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
+      "AND " <>
+      SchemaScope.visible("c", "n", "$2") <>
+      "), dependent_types(oid) AS (" <>
+      "SELECT reltype FROM owned UNION " <>
+      "SELECT type.oid FROM pg_type type JOIN dependent_types dependency " <>
+      "ON type.typbasetype = dependency.oid OR type.typelem = dependency.oid) "
+  end
+
+  defp quote_ident(identifier), do: ~s("#{String.replace(identifier, ~s("), ~s(""))}")
+end

--- a/lib/arcana/migration/dependencies.ex
+++ b/lib/arcana/migration/dependencies.ex
@@ -114,7 +114,7 @@ defmodule Arcana.Migration.Dependencies do
           "FROM pg_depend dependency " <>
           "CROSS JOIN LATERAL pg_identify_object(" <>
           "dependency.classid, dependency.objid, dependency.objsubid) identified " <>
-          "WHERE dependency.deptype = 'n' AND (" <>
+          "WHERE dependency.deptype IN ('n', 'a') AND (" <>
           "(dependency.refclassid = 'pg_class'::regclass " <>
           "AND dependency.refobjid IN (SELECT oid FROM owned)) OR " <>
           "(dependency.refclassid = 'pg_type'::regclass " <>
@@ -125,6 +125,14 @@ defmodule Arcana.Migration.Dependencies do
           "AND NOT (dependency.classid = 'pg_rewrite'::regclass " <>
           "AND dependency.objid IN (SELECT rewrite.oid FROM pg_rewrite rewrite " <>
           "WHERE rewrite.ev_class IN (SELECT oid FROM owned))) " <>
+          "AND NOT (dependency.deptype = 'a' " <>
+          "AND dependency.classid = 'pg_attrdef'::regclass " <>
+          "AND dependency.objid IN (SELECT def.oid FROM pg_attrdef def " <>
+          "WHERE def.adrelid IN (SELECT oid FROM owned))) " <>
+          "AND NOT (dependency.deptype = 'a' " <>
+          "AND dependency.classid = 'pg_class'::regclass " <>
+          "AND dependency.objid IN (SELECT idx.indexrelid FROM pg_index idx " <>
+          "WHERE idx.indrelid IN (SELECT oid FROM owned))) " <>
           "AND NOT (dependency.classid = 'pg_class'::regclass " <>
           "AND dependency.objid IN (SELECT oid FROM owned))",
         [tables, prefix]

--- a/lib/arcana/migration/dimensions.ex
+++ b/lib/arcana/migration/dimensions.ex
@@ -1,6 +1,8 @@
 defmodule Arcana.Migration.Dimensions do
   @moduledoc false
 
+  alias Arcana.Migration.SchemaScope
+
   # Shared by `Arcana.Migration` and `Arcana.Graph.Migration`, which each size
   # an embedding column and each need the same required-option check and the
   # same comparison against what the database already has.
@@ -99,7 +101,7 @@ defmodule Arcana.Migration.Dimensions do
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = $1 AND a.attname = 'embedding' " <>
           "AND a.attnum > 0 AND NOT a.attisdropped " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
+          "AND " <> SchemaScope.visible("c", "n", "$2"),
         [table, prefix]
       )
 

--- a/lib/arcana/migration/registry.ex
+++ b/lib/arcana/migration/registry.ex
@@ -59,8 +59,12 @@ defmodule Arcana.Migration.Registry do
   def owned_tables(stream, target \\ nil) do
     target = target || current_version(stream)
 
-    1..target
-    |> Enum.flat_map(&tables_added_in(stream, &1))
+    if target < 1 do
+      []
+    else
+      1..target
+      |> Enum.flat_map(&tables_added_in(stream, &1))
+    end
   end
 
   def present(repo, stream, prefix) do

--- a/lib/arcana/migration/registry.ex
+++ b/lib/arcana/migration/registry.ex
@@ -1,0 +1,80 @@
+defmodule Arcana.Migration.Registry do
+  @moduledoc false
+
+  alias Arcana.Migration.SchemaScope
+
+  @streams %{
+    core: %{
+      marker: %{table: "arcana_documents", namespace: "arcana"},
+      versions: %{
+        1 => ~w(
+          arcana_collections
+          arcana_documents
+          arcana_chunks
+          arcana_evaluation_test_cases
+          arcana_evaluation_test_case_chunks
+          arcana_evaluation_runs
+        )
+      }
+    },
+    graph: %{
+      marker: %{table: "arcana_graph_entities", namespace: "arcana_graph"},
+      versions: %{
+        1 => ~w(
+          arcana_graph_entities
+          arcana_graph_entity_mentions
+          arcana_graph_relationships
+          arcana_graph_communities
+        ),
+        2 => ~w(arcana_graph_relationship_evidence)
+      }
+    }
+  }
+
+  def current_version(stream),
+    do: @streams |> stream!(stream) |> Map.fetch!(:versions) |> map_size()
+
+  def version_table(stream), do: @streams |> stream!(stream) |> get_in([:marker, :table])
+
+  def marker(stream, version) when is_integer(version) and version > 0 do
+    namespace = @streams |> stream!(stream) |> get_in([:marker, :namespace])
+    "#{namespace}:#{version}"
+  end
+
+  def parse_marker(stream, comment) when is_binary(comment) do
+    namespace = @streams |> stream!(stream) |> get_in([:marker, :namespace])
+
+    case Regex.run(~r/\A#{Regex.escape(namespace)}:(\d+)\z/, String.trim(comment)) do
+      [_, version] -> String.to_integer(version)
+      _ -> 0
+    end
+  end
+
+  def parse_marker(_stream, nil), do: 0
+
+  def tables_added_in(stream, version) do
+    @streams |> stream!(stream) |> Map.fetch!(:versions) |> Map.fetch!(version)
+  end
+
+  def owned_tables(stream, target \\ nil) do
+    target = target || current_version(stream)
+
+    1..target
+    |> Enum.flat_map(&tables_added_in(stream, &1))
+  end
+
+  def present(repo, stream, prefix) do
+    %{rows: rows} =
+      repo.query!(
+        "SELECT c.relname FROM pg_class c " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
+          "AND " <> SchemaScope.visible("c", "n", "$2"),
+        [owned_tables(stream), prefix]
+      )
+
+    List.flatten(rows)
+  end
+
+  defp stream!(streams, stream), do: Map.fetch!(streams, stream)
+end

--- a/lib/arcana/migration/schema_scope.ex
+++ b/lib/arcana/migration/schema_scope.ex
@@ -86,8 +86,8 @@ defmodule Arcana.Migration.SchemaScope do
         "SELECT n.nspname, obj_description(c.oid) FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = $1 AND c.relkind IN ('r', 'p') " <>
-          "AND n.nspname = ANY(current_schemas(false)) " <>
-          "ORDER BY array_position(current_schemas(false), n.nspname)",
+          "AND n.nspname = ANY(current_schemas(true)) " <>
+          "ORDER BY array_position(current_schemas(true), n.nspname)",
         [marker_table]
       )
 

--- a/lib/arcana/migration/schema_scope.ex
+++ b/lib/arcana/migration/schema_scope.ex
@@ -7,10 +7,12 @@ defmodule Arcana.Migration.SchemaScope do
 
   def resolve(repo, stream, nil) do
     marker_table = Registry.version_table(stream)
+    marker_rows = marker_rows(repo, marker_table)
 
-    case visible_schemas(repo, [marker_table]) do
+    case marked_schemas(stream, marker_rows) do
       [schema] -> schema
-      [] -> resolve_from_owned_tables(repo, stream)
+      [] -> resolve_without_marker(repo, stream, marker_table, marker_rows)
+      schemas -> raise_ambiguous_markers!(stream, schemas)
     end
   end
 
@@ -24,23 +26,88 @@ defmodule Arcana.Migration.SchemaScope do
       "ELSE #{namespace_alias}.nspname = #{parameter}::text END"
   end
 
-  defp resolve_from_owned_tables(repo, stream) do
-    case visible_schemas(repo, Registry.owned_tables(stream)) do
-      [] ->
-        nil
+  defp resolve_without_marker(repo, stream, marker_table, marker_rows) do
+    owned_tables = List.delete(Registry.owned_tables(stream), marker_table)
 
-      [schema] ->
-        schema
-
-      schemas ->
-        raise """
-        Arcana found #{stream} migration tables spread across multiple visible schemas:
-
-            #{Enum.join(schemas, "\n    ")}
-
-        Nothing was changed. Pass an explicit :prefix for the Arcana install you want to migrate, or repair the partial schemas first.
-        """
+    case visible_schemas(repo, owned_tables) do
+      [] -> resolve_legacy_marker(stream, marker_rows)
+      [schema] -> resolve_complete_legacy(repo, stream, schema)
+      schemas -> raise_split_install!(stream, schemas)
     end
+  end
+
+  defp resolve_complete_legacy(repo, stream, schema) do
+    present = MapSet.new(Registry.present(repo, stream, schema))
+
+    complete? =
+      Enum.any?(1..Registry.current_version(stream), fn version ->
+        present == MapSet.new(Registry.owned_tables(stream, version))
+      end)
+
+    if complete?, do: schema, else: raise_partial_install!(stream, schema)
+  end
+
+  defp resolve_legacy_marker(_stream, []), do: nil
+  defp resolve_legacy_marker(stream, marker_rows), do: raise_unmarked_marker!(stream, marker_rows)
+
+  defp raise_split_install!(stream, schemas) do
+    raise """
+    Arcana found #{stream} migration tables spread across multiple visible schemas:
+
+        #{Enum.join(schemas, "\n    ")}
+
+    Nothing was changed. Pass an explicit :prefix for the Arcana install you want to migrate, or repair the partial schemas first.
+    """
+  end
+
+  defp raise_partial_install!(stream, schema) do
+    raise """
+    Arcana found an unmarked partial #{stream} migration install in #{schema}.
+
+    Nothing was changed. Pass an explicit :prefix to adopt that schema, or repair the partial install first.
+    """
+  end
+
+  defp raise_unmarked_marker!(stream, rows) do
+    schemas = Enum.map(rows, fn [schema, _comment] -> schema end)
+
+    raise """
+    Arcana found an unmarked table named like its #{stream} migration marker in:
+
+        #{Enum.join(schemas, "\n    ")}
+
+    Nothing was changed. Pass an explicit :prefix for the Arcana install you want to migrate.
+    """
+  end
+
+  defp marker_rows(repo, marker_table) do
+    %{rows: rows} =
+      repo.query!(
+        "SELECT n.nspname, obj_description(c.oid) FROM pg_class c " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "WHERE c.relname = $1 AND c.relkind IN ('r', 'p') " <>
+          "AND n.nspname = ANY(current_schemas(false)) " <>
+          "ORDER BY array_position(current_schemas(false), n.nspname)",
+        [marker_table]
+      )
+
+    rows
+  end
+
+  defp marked_schemas(stream, rows) do
+    for [schema, comment] <- rows,
+        Registry.parse_marker(stream, comment) > 0,
+        do: schema
+  end
+
+  defp raise_ambiguous_markers!(stream, schemas) do
+    raise """
+    Arcana found multiple marked #{stream} migration installs on the current search path:
+
+        #{Enum.join(schemas, "\n    ")}
+
+    Nothing was changed. Pass an explicit :prefix for the Arcana install you want to migrate.
+    """
   end
 
   defp visible_schemas(repo, tables) do

--- a/lib/arcana/migration/schema_scope.ex
+++ b/lib/arcana/migration/schema_scope.ex
@@ -1,0 +1,58 @@
+defmodule Arcana.Migration.SchemaScope do
+  @moduledoc false
+
+  alias Arcana.Migration.Registry
+
+  def resolve(_repo, _stream, prefix) when is_binary(prefix), do: prefix
+
+  def resolve(repo, stream, nil) do
+    marker_table = Registry.version_table(stream)
+
+    case visible_schemas(repo, [marker_table]) do
+      [schema] -> schema
+      [] -> resolve_from_owned_tables(repo, stream)
+    end
+  end
+
+  @doc """
+  Returns the catalog predicate matching the relation unqualified DDL would
+  resolve, or the exact schema selected by an explicit prefix.
+  """
+  def visible(relation_alias, namespace_alias, parameter) do
+    "CASE WHEN #{parameter}::text IS NULL " <>
+      "THEN pg_table_is_visible(#{relation_alias}.oid) " <>
+      "ELSE #{namespace_alias}.nspname = #{parameter}::text END"
+  end
+
+  defp resolve_from_owned_tables(repo, stream) do
+    case visible_schemas(repo, Registry.owned_tables(stream)) do
+      [] ->
+        nil
+
+      [schema] ->
+        schema
+
+      schemas ->
+        raise """
+        Arcana found #{stream} migration tables spread across multiple visible schemas:
+
+            #{Enum.join(schemas, "\n    ")}
+
+        Nothing was changed. Pass an explicit :prefix for the Arcana install you want to migrate, or repair the partial schemas first.
+        """
+    end
+  end
+
+  defp visible_schemas(repo, tables) do
+    %{rows: rows} =
+      repo.query!(
+        "SELECT DISTINCT n.nspname FROM pg_class c " <>
+          "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
+          "WHERE c.relname = ANY($1) AND c.relkind IN ('r', 'p') " <>
+          "AND pg_table_is_visible(c.oid) ORDER BY n.nspname",
+        [tables]
+      )
+
+    List.flatten(rows)
+  end
+end

--- a/lib/arcana/migration/unique_index.ex
+++ b/lib/arcana/migration/unique_index.ex
@@ -1,6 +1,8 @@
 defmodule Arcana.Migration.UniqueIndex do
   @moduledoc false
 
+  alias Arcana.Migration.SchemaScope
+
   # Shared by `Arcana.Migration` and `Arcana.Graph.Migration`, which each own
   # unique indexes that adoption has to verify rather than merely create.
   #
@@ -22,8 +24,8 @@ defmodule Arcana.Migration.UniqueIndex do
   Ensures `table` has a plain unique index on `columns`, rebuilding one that
   exists under the same name with a different shape.
   """
-  def converge!(repo, table, columns, prefix, qualify) do
-    name = Enum.join([table | columns] ++ ["index"], "_")
+  def converge!(repo, table, columns, prefix, qualify, opts \\ []) do
+    name = Keyword.get(opts, :name, Enum.join([table | columns] ++ ["index"], "_"))
 
     # This runs from up/1, before the version comparison, so on a fresh
     # install the table does not exist yet. Creating an index on it would
@@ -61,7 +63,7 @@ defmodule Arcana.Migration.UniqueIndex do
         "SELECT count(*) FROM pg_class c " <>
           "JOIN pg_namespace n ON n.oid = c.relnamespace " <>
           "WHERE c.relname = $1 AND c.relkind IN ('r', 'p') " <>
-          "AND n.nspname = COALESCE($2, current_schema())",
+          "AND " <> SchemaScope.visible("c", "n", "$2"),
         [table, prefix]
       )
 
@@ -87,7 +89,9 @@ defmodule Arcana.Migration.UniqueIndex do
           "LEFT JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true " <>
           "LEFT JOIN pg_attribute a ON a.attrelid = tc.oid AND a.attnum = k.attnum " <>
           "WHERE ic.relname = $1 AND tc.relname = $2 " <>
-          "AND n.nspname = COALESCE($3, current_schema()) " <>
+          "AND " <>
+          SchemaScope.visible("tc", "n", "$3") <>
+          " " <>
           "GROUP BY i.indisunique, i.indpred IS NOT NULL, i.indkey, " <>
           "i.indisvalid, i.indisready",
         [name, table, prefix]

--- a/lib/arcana/pipeline.ex
+++ b/lib/arcana/pipeline.ex
@@ -549,7 +549,7 @@ defmodule Arcana.Pipeline do
   ## Collection Selection
 
   Collection scope is determined in this priority order:
-  1. `:collection` or `:collections` option passed to this function
+  1. `:collection` option passed to this function
   2. `ctx.collections` (set by `select/2` if LLM selection was used)
   3. Falls back to `"default"` collection
 
@@ -563,13 +563,12 @@ defmodule Arcana.Pipeline do
       ctx |> Pipeline.search(collection: "technical_docs")
 
       # Search multiple specific collections
-      ctx |> Pipeline.search(collections: ["docs", "faq"])
+      ctx |> Pipeline.search(collection: ["docs", "faq"])
 
   ## Options
 
   - `:searcher` - Custom searcher module or function (default: `Arcana.Searcher.Arcana`)
   - `:collection` - `:all`, a collection name, or a list of collection names
-  - `:collections` - Alias for `:collection`. The two options are mutually exclusive.
   - `:self_correct` - Enable self-correcting search (default: false)
   - `:max_iterations` - Max retry attempts for self-correct (default: 3)
   - `:sufficient_prompt` - Custom prompt function `fn question, chunks -> prompt_string end`

--- a/lib/arcana/pipeline.ex
+++ b/lib/arcana/pipeline.ex
@@ -548,12 +548,12 @@ defmodule Arcana.Pipeline do
 
   ## Collection Selection
 
-  Collections are determined in this priority order:
+  Collection scope is determined in this priority order:
   1. `:collection` or `:collections` option passed to this function
   2. `ctx.collections` (set by `select/2` if LLM selection was used)
   3. Falls back to `"default"` collection
 
-  The resolved list is recorded on `ctx.collections`, so later steps that
+  The resolved scope is recorded on `ctx.collections`, so later steps that
   retrieve (like `reason/2`) search the same scope instead of picking one
   of their own.
 
@@ -568,8 +568,8 @@ defmodule Arcana.Pipeline do
   ## Options
 
   - `:searcher` - Custom searcher module or function (default: `Arcana.Searcher.Arcana`)
-  - `:collection` - Single collection name to search (string)
-  - `:collections` - List of collection names to search
+  - `:collection` - `:all`, a collection name, or a list of collection names
+  - `:collections` - Alias for `:collection`. The two options are mutually exclusive.
   - `:self_correct` - Enable self-correcting search (default: false)
   - `:max_iterations` - Max retry attempts for self-correct (default: 3)
   - `:sufficient_prompt` - Custom prompt function `fn question, chunks -> prompt_string end`
@@ -616,7 +616,8 @@ defmodule Arcana.Pipeline do
   def search(%Context{} = ctx, opts) do
     searcher = Keyword.get(opts, :searcher, Arcana.Searcher.Arcana)
 
-    collections = resolve_collections(ctx, opts)
+    collection_scope = resolve_collection_scope(ctx, opts)
+    collections = collection_targets(collection_scope)
 
     start_metadata = %{
       question: ctx.question,
@@ -627,7 +628,11 @@ defmodule Arcana.Pipeline do
 
     :telemetry.span([:arcana, :pipeline, :search], start_metadata, fn ->
       questions = ctx.sub_questions || [ctx.expanded_query || ctx.question]
-      searcher_opts = [repo: ctx.repo, limit: ctx.limit, threshold: ctx.threshold]
+
+      searcher_opts =
+        opts
+        |> Keyword.drop([:searcher, :collection, :collections])
+        |> Keyword.merge(repo: ctx.repo, limit: ctx.limit, threshold: ctx.threshold)
 
       results =
         for question <- questions,
@@ -636,7 +641,14 @@ defmodule Arcana.Pipeline do
           %{question: question, collection: collection, chunks: chunks}
         end
 
-      updated_ctx = %{ctx | results: results, searcher: searcher, collections: collections}
+      updated_ctx = %{
+        ctx
+        | results: results,
+          searcher: searcher,
+          searcher_opts: searcher_opts,
+          collections: collection_scope_input(collection_scope)
+      }
+
       total_chunks = results |> Enum.flat_map(& &1.chunks) |> length()
 
       stop_metadata = %{
@@ -654,14 +666,16 @@ defmodule Arcana.Pipeline do
   # search/2 records what this returns on the context, so every later step
   # that retrieves resolves the same scope by calling this with no options
   # instead of guessing one from whatever results survived.
-  defp resolve_collections(ctx, opts) do
-    cond do
-      Keyword.has_key?(opts, :collections) -> Keyword.get(opts, :collections)
-      Keyword.has_key?(opts, :collection) -> [Keyword.get(opts, :collection)]
-      ctx.collections != nil -> ctx.collections
-      true -> ["default"]
-    end
+  defp resolve_collection_scope(ctx, opts) do
+    default = if is_nil(ctx.collections), do: "default", else: ctx.collections
+    Arcana.CollectionScope.from_opts!(opts, default)
   end
+
+  defp collection_targets(:all), do: [:all]
+  defp collection_targets({:only, names}), do: names
+
+  defp collection_scope_input(:all), do: :all
+  defp collection_scope_input({:only, names}), do: names
 
   defp searcher_name(searcher) when is_atom(searcher), do: searcher
   defp searcher_name(_searcher), do: :custom_function
@@ -699,6 +713,10 @@ defmodule Arcana.Pipeline do
     `search/2` used, so a scoped searcher keeps applying without repeating
     the option. Falls back to `Arcana.Searcher.Arcana` when `search/2` never
     ran.
+  - `:searcher_opts` - Extra options for follow-up searches. These merge over
+    the original search options when the searcher is inherited. Replacing the
+    searcher starts from repo, limit, and threshold so backend-specific options
+    do not leak between implementations.
 
   Follow-up searches run against `ctx.collections`, which `search/2` records,
   so the collection scope keeps applying too.
@@ -737,11 +755,22 @@ defmodule Arcana.Pipeline do
           :error -> ctx.searcher || Arcana.Searcher.Arcana
         end
 
+      searcher_opts = reason_searcher_opts(ctx, opts)
+
       # Initialize queries_tried if not set
       queries_tried = ctx.queries_tried || MapSet.new([ctx.question])
 
       updated_ctx =
-        do_reason_loop(ctx, llm, custom_prompt_fn, max_iterations, queries_tried, 0, searcher)
+        do_reason_loop(
+          ctx,
+          llm,
+          custom_prompt_fn,
+          max_iterations,
+          queries_tried,
+          0,
+          searcher,
+          searcher_opts
+        )
 
       stop_metadata = %{iterations: updated_ctx.reason_iterations}
 
@@ -749,14 +778,54 @@ defmodule Arcana.Pipeline do
     end)
   end
 
-  defp do_reason_loop(ctx, llm, prompt_fn, max_iterations, queries_tried, iteration, searcher)
+  defp reason_searcher_opts(ctx, opts) do
+    defaults = [repo: ctx.repo, limit: ctx.limit, threshold: ctx.threshold]
 
-  defp do_reason_loop(ctx, _llm, _prompt_fn, max_iterations, queries_tried, iteration, _searcher)
+    base =
+      if Keyword.has_key?(opts, :searcher) do
+        defaults
+      else
+        ctx.searcher_opts || defaults
+      end
+
+    Keyword.merge(base, Keyword.get(opts, :searcher_opts, []))
+  end
+
+  defp do_reason_loop(
+         ctx,
+         llm,
+         prompt_fn,
+         max_iterations,
+         queries_tried,
+         iteration,
+         searcher,
+         searcher_opts
+       )
+
+  defp do_reason_loop(
+         ctx,
+         _llm,
+         _prompt_fn,
+         max_iterations,
+         queries_tried,
+         iteration,
+         _searcher,
+         _searcher_opts
+       )
        when iteration >= max_iterations do
     %{ctx | queries_tried: queries_tried, reason_iterations: iteration}
   end
 
-  defp do_reason_loop(ctx, llm, prompt_fn, max_iterations, queries_tried, iteration, searcher) do
+  defp do_reason_loop(
+         ctx,
+         llm,
+         prompt_fn,
+         max_iterations,
+         queries_tried,
+         iteration,
+         searcher,
+         searcher_opts
+       ) do
     all_chunks =
       (ctx.results || [])
       |> Enum.flat_map(& &1.chunks)
@@ -773,7 +842,7 @@ defmodule Arcana.Pipeline do
           # Search with follow-up query
           updated_queries = MapSet.put(queries_tried, follow_up_query)
 
-          new_results = do_additional_search(ctx, follow_up_query, searcher)
+          new_results = do_additional_search(ctx, follow_up_query, searcher, searcher_opts)
           merged_results = merge_results(ctx.results, new_results)
           updated_ctx = %{ctx | results: merged_results}
 
@@ -784,7 +853,8 @@ defmodule Arcana.Pipeline do
             max_iterations,
             updated_queries,
             iteration + 1,
-            searcher
+            searcher,
+            searcher_opts
           )
         end
 
@@ -845,20 +915,15 @@ defmodule Arcana.Pipeline do
     end
   end
 
-  defp do_additional_search(ctx, query, searcher) do
+  defp do_additional_search(ctx, query, searcher, search_opts) do
     # Follow-ups search exactly what search/2 searched. Deriving the scope
     # from ctx.results instead would drift: merge_results drops results
     # whose chunks came back empty, so one dry follow-up leaves nothing to
     # derive from and the next one widens past what the caller asked for.
-    collections = resolve_collections(ctx, [])
+    collection_scope = resolve_collection_scope(ctx, [])
+    collections = collection_targets(collection_scope)
 
     Enum.map(collections, fn collection ->
-      search_opts = [
-        repo: ctx.repo,
-        limit: ctx.limit,
-        threshold: ctx.threshold
-      ]
-
       chunks = do_simple_search(searcher, query, collection, search_opts)
 
       %{question: query, collection: collection, chunks: chunks}

--- a/lib/arcana/pipeline/context.ex
+++ b/lib/arcana/pipeline/context.ex
@@ -39,6 +39,8 @@ defmodule Arcana.Pipeline.Context do
   - `:searcher` - The searcher used, so later steps that retrieve (like
     `reason/2`) stay on the caller's searcher instead of silently falling
     back to the default one
+  - `:searcher_opts` - The effective backend options passed to that searcher,
+    reused by later retrieval steps so tenant, auth, and backend settings survive
   - `:collections` - The collections actually searched, for the same reason.
     `search/2` resolves them from its own options first, then this field
     (which `select/2` may have set), so an explicit option still wins
@@ -93,6 +95,7 @@ defmodule Arcana.Pipeline.Context do
     # Populated by search/2
     :results,
     :searcher,
+    :searcher_opts,
 
     # Populated by reason/2
     :queries_tried,

--- a/lib/arcana/retrieval_scope.ex
+++ b/lib/arcana/retrieval_scope.ex
@@ -7,6 +7,14 @@ defmodule Arcana.RetrievalScope do
   alias Arcana.Graph.{Community, Entity, EntityMention, Relationship, RelationshipEvidence}
 
   @doc false
+  def documents do
+    from(d in Document,
+      as: :document,
+      where: d.status == :completed
+    )
+  end
+
+  @doc false
   def chunks do
     from(c in Chunk,
       as: :chunk,

--- a/lib/arcana/retrieval_scope.ex
+++ b/lib/arcana/retrieval_scope.ex
@@ -4,7 +4,7 @@ defmodule Arcana.RetrievalScope do
   import Ecto.Query
 
   alias Arcana.{Chunk, Document}
-  alias Arcana.Graph.{Entity, EntityMention, Relationship, RelationshipEvidence}
+  alias Arcana.Graph.{Community, Entity, EntityMention, Relationship, RelationshipEvidence}
 
   @doc false
   def chunks do
@@ -67,6 +67,19 @@ defmodule Arcana.RetrievalScope do
     from(r in Relationship,
       as: :relationship,
       where: exists(subquery(evidence))
+    )
+  end
+
+  @doc false
+  def communities do
+    published_entity =
+      from([entity: e] in entities(),
+        where: fragment("? = ANY(?)", e.id, parent_as(:community).entity_ids)
+      )
+
+    from(c in Community,
+      as: :community,
+      where: exists(subquery(published_entity))
     )
   end
 end

--- a/lib/arcana/retrieval_scope.ex
+++ b/lib/arcana/retrieval_scope.ex
@@ -1,0 +1,72 @@
+defmodule Arcana.RetrievalScope do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias Arcana.{Chunk, Document}
+  alias Arcana.Graph.{Entity, EntityMention, Relationship, RelationshipEvidence}
+
+  @doc false
+  def chunks do
+    from(c in Chunk,
+      as: :chunk,
+      join: d in Document,
+      as: :document,
+      on: d.id == c.document_id,
+      where: d.status == :completed
+    )
+  end
+
+  @doc false
+  def mentions do
+    from(m in EntityMention,
+      as: :mention,
+      join: c in Chunk,
+      as: :chunk,
+      on: c.id == m.chunk_id,
+      join: d in Document,
+      as: :document,
+      on: d.id == c.document_id,
+      where: d.status == :completed
+    )
+  end
+
+  @doc false
+  def entities do
+    published_mention =
+      from([mention: m] in mentions(),
+        where: m.entity_id == parent_as(:entity).id
+      )
+
+    from(e in Entity,
+      as: :entity,
+      where: exists(subquery(published_mention))
+    )
+  end
+
+  @doc false
+  def relationships(source_id \\ nil) do
+    evidence =
+      from(e in RelationshipEvidence,
+        join: c in Chunk,
+        on: c.id == e.chunk_id,
+        join: d in Document,
+        on: d.id == c.document_id,
+        where:
+          e.relationship_id == parent_as(:relationship).id and
+            d.status == :completed
+      )
+
+    evidence =
+      if source_id do
+        from([e, c, d] in evidence, where: d.source_id == ^source_id)
+      else
+        evidence
+      end
+
+    from(r in Relationship,
+      as: :relationship,
+      where: exists(subquery(evidence))
+    )
+  end
+end

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -60,10 +60,8 @@ defmodule Arcana.Search do
     * `:threshold` - Minimum similarity score (default: 0.0)
     * `:mode` - Search mode: `:vector` (default), `:keyword`, or `:hybrid`.
       `:semantic` and `:fulltext` are deprecated aliases.
-    * `:collection` - Collection scope as `:all`, a collection name, or a list
-      of collection names
-    * `:collections` - Alias for `:collection`. The two options are mutually
-      exclusive.
+    * `:collection` - Collection scope as `:all`, a collection name, a list of
+      collection names, or `[]` to match nothing
     * `:strict_collections` - When `true`, an unknown collection name
       returns `{:error, {:unknown_collection, name}}` instead of matching
       nothing. Defaults to `config :arcana, strict_collections: false`.

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -15,7 +15,7 @@ defmodule Arcana.Search do
 
   require Logger
 
-  alias Arcana.{Collection, Embedder, SearchResult, VectorStore}
+  alias Arcana.{Collection, CollectionScope, Embedder, SearchResult, VectorStore}
   alias Arcana.VectorStore.Pgvector
 
   @valid_modes [:vector, :keyword, :hybrid]
@@ -60,10 +60,13 @@ defmodule Arcana.Search do
     * `:threshold` - Minimum similarity score (default: 0.0)
     * `:mode` - Search mode: `:vector` (default), `:keyword`, or `:hybrid`.
       `:semantic` and `:fulltext` are deprecated aliases.
-    * `:collection` - Filter results to a specific collection by name
+    * `:collection` - Collection scope as `:all`, a collection name, or a list
+      of collection names
+    * `:collections` - Alias for `:collection`. The two options are mutually
+      exclusive.
     * `:strict_collections` - When `true`, an unknown collection name
-      returns `{:error, {:unknown_collection, name}}` instead of searching
-      unscoped. Defaults to `config :arcana, strict_collections: false`.
+      returns `{:error, {:unknown_collection, name}}` instead of matching
+      nothing. Defaults to `config :arcana, strict_collections: false`.
     * `:vector_store` - Override the configured vector store backend
     * `:vector_weight` - Weight for vector scores in hybrid mode (default: 0.5)
     * `:keyword_weight` - Weight for keyword scores in hybrid mode (default: 0.5)
@@ -98,50 +101,59 @@ defmodule Arcana.Search do
     rewriter = Keyword.get(opts, :rewriter)
     vector_store_opt = Keyword.get(opts, :vector_store)
 
-    collections = Collection.names_from_opts(opts)
-
     unless mode in @valid_modes do
       raise ArgumentError,
             "invalid search mode: #{inspect(mode)}. Must be one of #{inspect(@valid_modes)}"
     end
 
-    with {:ok, id_by_name} <- resolve_strict_ids(collections, repo, opts) do
-      do_search_with_telemetry(query, collections, mode, repo, opts, %{
+    with {:ok, scope} <- CollectionScope.from_opts(opts, :all),
+         {:ok, resolved_scope} <- resolve_scope(scope, repo, opts) do
+      do_search_with_telemetry(query, resolved_scope, mode, repo, opts, %{
         reranker: reranker,
         limit: limit,
         source_id: source_id,
         threshold: threshold,
         rewriter: rewriter,
         vector_store_opt: vector_store_opt,
-        id_by_name: id_by_name
+        collection_scope: scope
       })
     end
   end
 
-  # Under strict mode, resolve every named collection up front and keep the
-  # name => id map so backends query by the validated id instead of
-  # re-resolving the name (which could silently widen to a global search if
-  # the collection disappeared in between). Returns {:ok, nil} when strict
-  # is off or the search is unscoped.
-  defp resolve_strict_ids(collections, repo, opts) do
-    if repo && Arcana.Config.strict_collections?(opts) do
-      case Collection.resolve_ids(collections, repo, strict: true) do
-        {:ok, nil} ->
-          {:ok, nil}
+  defp resolve_scope(:all, _repo, _opts), do: {:ok, %{targets: [{:all, nil}], ids: nil}}
 
-        {:ok, ids} ->
-          names = Enum.reject(collections, &is_nil/1)
-          {:ok, names |> Enum.zip(ids) |> Map.new()}
+  defp resolve_scope({:only, names}, nil, _opts) do
+    {:ok, %{targets: Enum.map(names, &{&1, nil}), ids: []}}
+  end
 
-        {:error, _} = error ->
-          error
-      end
-    else
-      {:ok, nil}
+  defp resolve_scope({:only, []}, _repo, _opts), do: {:ok, %{targets: [], ids: []}}
+
+  defp resolve_scope({:only, names}, repo, opts) do
+    import Ecto.Query
+
+    strict? = Arcana.Config.strict_collections?(opts)
+
+    ids_by_name =
+      from(c in Collection, where: c.name in ^names, select: {c.name, c.id})
+      |> repo.all()
+      |> Map.new()
+
+    case strict? && Enum.find(names, &(not Map.has_key?(ids_by_name, &1))) do
+      missing when is_binary(missing) ->
+        {:error, {:unknown_collection, missing}}
+
+      _ ->
+        targets =
+          for name <- names,
+              id = Map.get(ids_by_name, name),
+              not is_nil(id),
+              do: {name, id}
+
+        {:ok, %{targets: targets, ids: Enum.map(targets, &elem(&1, 1))}}
     end
   end
 
-  defp do_search_with_telemetry(query, collections, mode, repo, opts, config) do
+  defp do_search_with_telemetry(query, resolved_scope, mode, repo, opts, config) do
     %{
       reranker: reranker,
       limit: limit,
@@ -149,14 +161,15 @@ defmodule Arcana.Search do
       threshold: threshold,
       rewriter: rewriter,
       vector_store_opt: vector_store_opt,
-      id_by_name: id_by_name
+      collection_scope: collection_scope
     } = config
 
     start_metadata = %{
       query: query,
       repo: repo,
       mode: mode,
-      limit: limit
+      limit: limit,
+      collections: collection_scope
     }
 
     :telemetry.span([:arcana, :search], start_metadata, fn ->
@@ -174,7 +187,6 @@ defmodule Arcana.Search do
         vector_store: vector_store_opt,
         vector_weight: Keyword.get(opts, :vector_weight, 0.5),
         keyword_weight: Keyword.get(opts, :keyword_weight, 0.5),
-        id_by_name: id_by_name,
         # Original opts so backends can pick up their own knobs, such as
         # :hnsw_ef_search for pgvector
         opts: opts
@@ -182,14 +194,14 @@ defmodule Arcana.Search do
 
       retrieval_opts = Keyword.put(opts, :limit, retrieval_limit)
 
-      collection_results = search_collections(collections, mode, search_query, params)
+      collection_results = search_collections(resolved_scope.targets, mode, search_query, params)
 
       search_result =
         if Arcana.Config.graph_enabled?(opts) and repo do
           enhance_with_graph_search(
             collection_results,
             search_query,
-            {collections, id_by_name},
+            resolved_scope.ids,
             repo,
             retrieval_opts
           )
@@ -265,15 +277,13 @@ defmodule Arcana.Search do
     fun.(query, chunks, opts)
   end
 
-  defp search_collections(collections, mode, search_query, params) do
-    Enum.reduce_while(collections, {:ok, []}, fn collection_name, {:ok, acc} ->
-      search_single_collection(mode, search_query, params, collection_name, acc)
+  defp search_collections(targets, mode, search_query, params) do
+    Enum.reduce_while(targets, {:ok, []}, fn target, {:ok, acc} ->
+      search_single_collection(mode, search_query, params, target, acc)
     end)
   end
 
-  defp search_single_collection(mode, search_query, params, collection_name, acc) do
-    collection_id = params.id_by_name && Map.get(params.id_by_name, collection_name)
-
+  defp search_single_collection(mode, search_query, params, {collection_name, collection_id}, acc) do
     params =
       params
       |> Map.put(:collection, collection_name)
@@ -303,10 +313,14 @@ defmodule Arcana.Search do
     {{:error, reason}, %{error: reason}}
   end
 
+  defp enhance_with_graph_search({:ok, _results}, _query, [], _repo, opts) do
+    format_search_results({:ok, []}, Keyword.get(opts, :limit, 10))
+  end
+
   defp enhance_with_graph_search(
          {:ok, vector_results},
          query,
-         {collections, id_by_name},
+         collection_ids,
          repo,
          opts
        ) do
@@ -314,11 +328,6 @@ defmodule Arcana.Search do
     graph_config = Arcana.Graph.config()
     rrf_k = graph_config[:rrf_k] || 60
     rrf_pool = graph_config[:rrf_pool_multiplier] || 2
-
-    # Reuse the ids validated up front under strict mode instead of
-    # re-resolving names (which could pick up a recreated collection).
-    collection_ids =
-      if id_by_name, do: Map.values(id_by_name), else: resolve_collection_ids(collections, repo)
 
     {matcher, matcher_opts} = resolve_entity_matcher(opts, graph_config)
     matcher_opts = matcher_opts |> Keyword.put(:repo, repo) |> Keyword.merge(opts)
@@ -478,14 +487,6 @@ defmodule Arcana.Search do
       end)
     end)
     |> Enum.map(fn {chunk_id, score} -> %{chunk_id: chunk_id, score: score} end)
-  end
-
-  # Strict validation already ran at the entry point, so unknown names can
-  # only appear here in non-strict mode; they resolve to [] which downstream
-  # graph queries treat as "match nothing".
-  defp resolve_collection_ids(collections, repo) do
-    {:ok, ids} = Collection.resolve_ids(collections, repo)
-    ids
   end
 
   defp do_search(:vector, query, params) do

--- a/lib/arcana/search.ex
+++ b/lib/arcana/search.ex
@@ -332,7 +332,10 @@ defmodule Arcana.Search do
           %{query: query, entity_count: length(entity_ids), matcher: matcher},
           fn ->
             ids_by_hop =
-              Arcana.Graph.expand_entity_ids(entity_ids, graph_depth, collection_ids, repo: repo)
+              Arcana.Graph.expand_entity_ids(entity_ids, graph_depth, collection_ids,
+                repo: repo,
+                source_id: Keyword.get(opts, :source_id)
+              )
 
             graph_results =
               graph_search_by_entity_ids(
@@ -381,8 +384,7 @@ defmodule Arcana.Search do
 
   defp graph_search_by_entity_ids(ids_by_hop, repo, depth_decay, source_id) do
     import Ecto.Query
-    alias Arcana.Chunk
-    alias Arcana.Graph.EntityMention
+    alias Arcana.RetrievalScope
 
     all_entity_ids = ids_by_hop |> Map.values() |> List.flatten()
 
@@ -390,7 +392,7 @@ defmodule Arcana.Search do
     # do; without this a source-scoped search leaks chunks from other
     # documents that happen to mention a matched entity.
     mentions_query =
-      from(m in EntityMention,
+      from([mention: m] in RetrievalScope.mentions(),
         where: m.entity_id in ^all_entity_ids,
         select: m.chunk_id,
         distinct: true
@@ -406,7 +408,12 @@ defmodule Arcana.Search do
       scored = score_chunks_by_hop(chunk_ids, ids_by_hop, depth_decay, repo)
 
       chunk_map =
-        repo.all(from(c in Chunk, where: c.id in ^chunk_ids, select: {c.id, c}))
+        repo.all(
+          from([chunk: c] in RetrievalScope.chunks(),
+            where: c.id in ^chunk_ids,
+            select: {c.id, c}
+          )
+        )
         |> Map.new()
 
       Enum.flat_map(scored, fn %{chunk_id: cid, score: score} ->
@@ -440,13 +447,8 @@ defmodule Arcana.Search do
 
   defp filter_mentions_by_source(query, source_id) do
     import Ecto.Query
-    alias Arcana.{Chunk, Document}
 
-    from(m in query,
-      join: c in Chunk,
-      on: c.id == m.chunk_id,
-      join: d in Document,
-      on: d.id == c.document_id,
+    from([document: d] in query,
       where: d.source_id == ^source_id
     )
   end

--- a/lib/arcana/searcher.ex
+++ b/lib/arcana/searcher.ex
@@ -68,7 +68,7 @@ defmodule Arcana.Searcher do
   ## Parameters
 
   - `question` - The search query
-  - `collection` - The collection name to search in
+  - `collection` - A collection name, or `:all` to search every collection
   - `opts` - Options passed to `Pipeline.search/2`, including:
     - `:repo` - The Ecto repo (for database-backed searchers)
     - `:limit` - Maximum chunks to return (default: 5)
@@ -79,10 +79,13 @@ defmodule Arcana.Searcher do
 
   - `{:ok, chunks}` - List of chunk maps with :id, :text, :metadata, :similarity
   - `{:error, reason}` - On failure
+
+  For `:all`, the searcher is called once and must apply its global limit and
+  ranking across the full corpus.
   """
   @callback search(
               question :: String.t(),
-              collection :: String.t(),
+              collection :: String.t() | :all,
               opts :: keyword()
             ) :: {:ok, [map()]} | {:error, term()}
 end

--- a/lib/arcana/searcher/arcana.ex
+++ b/lib/arcana/searcher/arcana.ex
@@ -20,7 +20,7 @@ defmodule Arcana.Searcher.Arcana do
   ## Options
 
   - `:repo` - The Ecto repo (required)
-  - `:collection` - Collection name to search
+  - `:collection` - A collection name, or `:all`
   - `:limit` - Maximum chunks to return (default: 5)
   - `:threshold` - Minimum similarity threshold (default: 0.5)
   """
@@ -33,11 +33,14 @@ defmodule Arcana.Searcher.Arcana do
     limit = Keyword.get(opts, :limit, 5)
     threshold = Keyword.get(opts, :threshold, 0.5)
 
-    Arcana.search(question,
+    opts
+    |> Keyword.drop([:collections])
+    |> Keyword.merge(
       repo: repo,
       collection: collection,
       limit: limit,
       threshold: threshold
     )
+    |> then(&Arcana.search(question, &1))
   end
 end

--- a/lib/arcana/searcher/arcana.ex
+++ b/lib/arcana/searcher/arcana.ex
@@ -34,7 +34,6 @@ defmodule Arcana.Searcher.Arcana do
     threshold = Keyword.get(opts, :threshold, 0.5)
 
     opts
-    |> Keyword.drop([:collections])
     |> Keyword.merge(
       repo: repo,
       collection: collection,

--- a/lib/arcana/vector_store.ex
+++ b/lib/arcana/vector_store.ex
@@ -69,6 +69,8 @@ defmodule Arcana.VectorStore do
 
   alias Arcana.VectorStore.{Memory, Pgvector}
 
+  @type search_scope :: :all | String.t()
+
   @doc """
   Stores a vector with its id and metadata in a collection.
   """
@@ -78,17 +80,22 @@ defmodule Arcana.VectorStore do
   @doc """
   Searches for similar vectors in a collection (semantic search).
 
+  The scope is either one collection name or `:all`. Implementations must
+  return no results for an unknown name rather than widening it to `:all`.
+
   Returns a list of results with `:id`, `:metadata`, and `:score` keys.
   """
-  @callback search(binary(), list(), opts :: keyword()) :: [map()]
+  @callback search(search_scope(), list(), opts :: keyword()) :: [map()]
 
   @doc """
   Searches for matching text in a collection (fulltext search).
 
+  The scope has the same `:all` and unknown-name semantics as `search/3`.
+
   Returns a list of results with `:id`, `:metadata`, and `:score` keys.
   Score represents relevance based on term matching.
   """
-  @callback search_text(binary(), query :: String.t(), opts :: keyword()) :: [map()]
+  @callback search_text(search_scope(), query :: String.t(), opts :: keyword()) :: [map()]
 
   @doc """
   Deletes a vector from a collection.
@@ -163,6 +170,9 @@ defmodule Arcana.VectorStore do
 
       # Use global config
       VectorStore.search("products", query_embedding, limit: 10)
+
+      # Search every collection. Custom backends must implement this scope.
+      VectorStore.search(:all, query_embedding, limit: 10)
 
       # Override with memory backend
       VectorStore.search("products", query_embedding,

--- a/lib/arcana/vector_store/memory.ex
+++ b/lib/arcana/vector_store/memory.ex
@@ -78,6 +78,8 @@ defmodule Arcana.VectorStore.Memory do
   ## Returns
 
     * `:ok` on success
+    * `{:error, {:dimension_mismatch, details}}` when the embedding dimension
+      differs from vectors already stored by this server
 
   """
   def store(server, collection, id, embedding, metadata) do
@@ -180,37 +182,51 @@ defmodule Arcana.VectorStore.Memory do
   @impl true
   def handle_call({:store, collection, id, embedding, metadata}, _from, state) do
     dims = length(embedding)
-    state = ensure_dimensions(state, dims)
 
-    {collection_data, state} = get_or_create_collection(state, collection, dims)
+    case ensure_dimensions(state, dims) do
+      {:ok, state} ->
+        {collection_data, state} = get_or_create_collection(state, collection, dims)
 
-    # Check if id already exists - if so, mark old one as deleted
-    collection_data =
-      case Enum.find_index(collection_data.ids, &(&1 == id)) do
-        nil ->
+        # Check if id already exists - if so, mark old one as deleted
+        collection_data =
+          case Enum.find_index(collection_data.ids, &(&1 == id)) do
+            nil ->
+              collection_data
+
+            existing_idx ->
+              %{collection_data | deleted: MapSet.put(collection_data.deleted, existing_idx)}
+          end
+
+        # Add to index (use apply to avoid compile-time warning for optional dep)
+        tensor = Nx.tensor([embedding], type: :f32)
+        :ok = apply(HNSWLib.Index, :add_items, [collection_data.index, tensor])
+
+        # Track id and metadata
+        collection_data = %{
           collection_data
+          | ids: collection_data.ids ++ [id],
+            metadata: collection_data.metadata ++ [metadata]
+        }
 
-        existing_idx ->
-          %{collection_data | deleted: MapSet.put(collection_data.deleted, existing_idx)}
-      end
+        state = put_in(state, [:collections, collection], collection_data)
 
-    # Add to index (use apply to avoid compile-time warning for optional dep)
-    tensor = Nx.tensor([embedding], type: :f32)
-    :ok = apply(HNSWLib.Index, :add_items, [collection_data.index, tensor])
+        {:reply, :ok, state}
 
-    # Track id and metadata
-    collection_data = %{
-      collection_data
-      | ids: collection_data.ids ++ [id],
-        metadata: collection_data.metadata ++ [metadata]
-    }
-
-    state = put_in(state, [:collections, collection], collection_data)
-
-    {:reply, :ok, state}
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
   end
 
   @impl true
+  def handle_call(
+        {:search, _collection, query_embedding, _opts},
+        _from,
+        %{dimensions: dimensions} = state
+      )
+      when is_integer(dimensions) and length(query_embedding) != dimensions do
+    {:reply, [], state}
+  end
+
   def handle_call({:search, collection, query_embedding, opts}, _from, state) do
     limit = Keyword.get(opts, :limit, 10)
 
@@ -257,9 +273,14 @@ defmodule Arcana.VectorStore.Memory do
   end
 
   @impl true
+  def handle_call({:clear, collection}, _from, %{dimensions: nil} = state) do
+    state = update_in(state.collections, &Map.delete(&1, collection))
+    {:reply, :ok, state}
+  end
+
   def handle_call({:clear, collection}, _from, state) do
-    dims = state.dimensions || 384
-    {:ok, index} = apply(HNSWLib.Index, :new, [:cosine, dims, state.max_elements])
+    {:ok, index} =
+      apply(HNSWLib.Index, :new, [:cosine, state.dimensions, state.max_elements])
 
     collection_data = %{
       index: index,
@@ -285,11 +306,13 @@ defmodule Arcana.VectorStore.Memory do
     end
   end
 
-  defp ensure_dimensions(%{dimensions: nil} = state, dims) do
-    %{state | dimensions: dims}
-  end
+  defp ensure_dimensions(%{dimensions: nil} = state, dims),
+    do: {:ok, %{state | dimensions: dims}}
 
-  defp ensure_dimensions(state, _dims), do: state
+  defp ensure_dimensions(%{dimensions: dims} = state, dims), do: {:ok, state}
+
+  defp ensure_dimensions(%{dimensions: expected}, actual),
+    do: {:error, {:dimension_mismatch, expected: expected, actual: actual}}
 
   defp get_or_create_collection(state, collection, dims) do
     case get_in(state, [:collections, collection]) do

--- a/lib/arcana/vector_store/memory.ex
+++ b/lib/arcana/vector_store/memory.ex
@@ -90,7 +90,7 @@ defmodule Arcana.VectorStore.Memory do
   ## Parameters
 
     * `server` - The GenServer pid or name
-    * `collection` - The collection name to search in
+    * `collection` - A collection name, or `:all` to search every collection
     * `query_embedding` - The query vector as a list of floats
     * `opts` - Search options
       * `:limit` - Maximum number of results to return (default: 10)
@@ -115,7 +115,7 @@ defmodule Arcana.VectorStore.Memory do
   ## Parameters
 
     * `server` - The GenServer pid or name
-    * `collection` - The collection name to search in
+    * `collection` - A collection name, or `:all` to search every collection
     * `query_text` - The query string
     * `opts` - Search options
       * `:limit` - Maximum number of results to return (default: 10)
@@ -215,10 +215,11 @@ defmodule Arcana.VectorStore.Memory do
     limit = Keyword.get(opts, :limit, 10)
 
     results =
-      case get_in(state, [:collections, collection]) do
-        nil -> []
-        collection_data -> search_collection(collection_data, query_embedding, limit)
-      end
+      state.collections
+      |> collections_for_search(collection)
+      |> Enum.flat_map(&search_collection(&1, query_embedding, limit))
+      |> Enum.sort_by(& &1.score, :desc)
+      |> Enum.take(limit)
 
     {:reply, results, state}
   end
@@ -228,10 +229,11 @@ defmodule Arcana.VectorStore.Memory do
     limit = Keyword.get(opts, :limit, 10)
 
     results =
-      case get_in(state, [:collections, collection]) do
-        nil -> []
-        collection_data -> search_text_collection(collection_data, query_text, limit)
-      end
+      state.collections
+      |> collections_for_search(collection)
+      |> Enum.flat_map(&search_text_collection(&1, query_text, limit))
+      |> Enum.sort_by(& &1.score, :desc)
+      |> Enum.take(limit)
 
     {:reply, results, state}
   end
@@ -271,6 +273,17 @@ defmodule Arcana.VectorStore.Memory do
   end
 
   # Private Functions
+
+  defp collections_for_search(collections, collection) when collection in [:all, nil] do
+    Map.values(collections)
+  end
+
+  defp collections_for_search(collections, collection) do
+    case Map.fetch(collections, collection) do
+      {:ok, collection_data} -> [collection_data]
+      :error -> []
+    end
+  end
 
   defp ensure_dimensions(%{dimensions: nil} = state, dims) do
     %{state | dimensions: dims}

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -56,7 +56,7 @@ defmodule Arcana.VectorStore.Pgvector do
   Raising it finds more of the true nearest neighbours, at the cost of more work
   per query:
 
-      Arcana.search("question", collections: ["docs"], hnsw_ef_search: 200)
+      Arcana.search("question", collection: ["docs"], hnsw_ef_search: 200)
 
   It can also be a global search default:
 

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -567,11 +567,9 @@ defmodule Arcana.VectorStore.Pgvector do
     end
   end
 
-  # Prefer a pre-resolved :collection_id (set by Arcana.Search under strict
-  # mode so the query is pinned to the validated id); otherwise resolve the
-  # name. For unknown names: under strict mode return :unknown so callers
-  # match nothing (direct backend calls bypass Arcana.Search's up-front
-  # validation), otherwise keep the historical no-filter fallback.
+  # Prefer a pre-resolved :collection_id so the query is pinned to the ID
+  # resolved by Arcana.Search. Only nil and :all are unscoped. An unknown
+  # explicit name always matches nothing, including direct backend calls.
   defp resolve_filter_collection_id(collection, repo, opts) do
     case Keyword.get(opts, :collection_id) do
       nil -> resolve_filter_by_name(collection, repo, opts)
@@ -580,10 +578,11 @@ defmodule Arcana.VectorStore.Pgvector do
   end
 
   defp resolve_filter_by_name(nil, _repo, _opts), do: {:ok, nil}
+  defp resolve_filter_by_name(:all, _repo, _opts), do: {:ok, nil}
 
-  defp resolve_filter_by_name(collection, repo, opts) do
+  defp resolve_filter_by_name(collection, repo, _opts) do
     case repo.get_by(Collection, name: collection) do
-      nil -> if Arcana.Config.strict_collections?(opts), do: :unknown, else: {:ok, nil}
+      nil -> :unknown
       coll -> {:ok, coll.id}
     end
   end

--- a/lib/arcana/vector_store/pgvector.ex
+++ b/lib/arcana/vector_store/pgvector.ex
@@ -97,7 +97,7 @@ defmodule Arcana.VectorStore.Pgvector do
 
   @behaviour Arcana.VectorStore
 
-  alias Arcana.{Chunk, Collection, Document}
+  alias Arcana.{Chunk, Collection, Document, RetrievalScope}
 
   import Ecto.Query
 
@@ -186,9 +186,7 @@ defmodule Arcana.VectorStore.Pgvector do
 
       {:ok, collection_id} ->
         base_query =
-          from(c in Chunk,
-            join: d in Document,
-            on: c.document_id == d.id,
+          from([chunk: c] in RetrievalScope.chunks(),
             select: %{
               id: c.id,
               metadata:
@@ -225,9 +223,7 @@ defmodule Arcana.VectorStore.Pgvector do
 
       {:ok, collection_id} ->
         base_query =
-          from(c in Chunk,
-            join: d in Document,
-            on: c.document_id == d.id,
+          from([chunk: c] in RetrievalScope.chunks(),
             where:
               fragment(
                 "to_tsvector('english', ?) @@ plainto_tsquery('english', ?)",
@@ -387,6 +383,7 @@ defmodule Arcana.VectorStore.Pgvector do
       CROSS JOIN LATERAL (SELECT to_tsvector('english', c.text) AS tsv OFFSET 0) v
       WHERE ($3::uuid IS NULL OR d.collection_id = $3::uuid)
         AND ($4::text IS NULL OR d.source_id = $4::text)
+        AND d.status = 'completed'
     ),
     score_bounds AS (
       SELECT MAX(keyword_score) AS max_kw

--- a/lib/arcana_web/background_task.ex
+++ b/lib/arcana_web/background_task.ex
@@ -14,7 +14,7 @@ defmodule ArcanaWeb.BackgroundTask do
     callers = [owner | Process.get(:"$callers", [])]
     run_ref = Keyword.get_lazy(opts, :run_ref, &make_ref/0)
     cleanup = Keyword.get(opts, :cleanup, fn -> :ok end)
-    on_worker_registered = Keyword.get(opts, :on_worker_registered, fn _worker -> :ok end)
+    on_worker_registered = Keyword.get(opts, :on_worker_registered)
     task_supervisor = Keyword.get(opts, :task_supervisor, ArcanaWeb.TaskSupervisor)
 
     started =
@@ -74,9 +74,19 @@ defmodule ArcanaWeb.BackgroundTask do
     receive do
       {:background_worker_registered, ^guardian, worker} ->
         worker_ref = Process.monitor(worker)
-        on_worker_registered.(worker)
-        send(worker, {:background_worker_ready, guardian})
-        await(owner, owner_ref, worker, worker_ref, supervisor, tag, run_ref)
+
+        context = %{
+          owner: owner,
+          owner_ref: owner_ref,
+          worker: worker,
+          worker_ref: worker_ref,
+          guardian: guardian,
+          supervisor: supervisor,
+          tag: tag,
+          run_ref: run_ref
+        }
+
+        run_registration_hook(context, on_worker_registered)
 
       {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
         :ok
@@ -84,6 +94,58 @@ defmodule ArcanaWeb.BackgroundTask do
       {:EXIT, ^supervisor, reason} ->
         exit(reason)
     end
+  end
+
+  defp run_registration_hook(context, nil) do
+    %{worker: worker, guardian: guardian} = context
+    send(worker, {:background_worker_ready, guardian})
+    await_registered_worker(context)
+  end
+
+  defp run_registration_hook(context, on_worker_registered)
+       when is_function(on_worker_registered, 1) do
+    %{
+      owner: owner,
+      owner_ref: owner_ref,
+      worker: worker,
+      worker_ref: worker_ref,
+      guardian: guardian,
+      supervisor: supervisor
+    } = context
+
+    {hook, hook_ref} =
+      :erlang.spawn_opt(fn -> on_worker_registered.(worker) end, [:link, :monitor])
+
+    receive do
+      {:DOWN, ^hook_ref, :process, ^hook, :normal} ->
+        send(worker, {:background_worker_ready, guardian})
+        await_registered_worker(context)
+
+      {:DOWN, ^hook_ref, :process, ^hook, reason} ->
+        Process.exit(worker, :kill)
+        await_worker_exit(worker, worker_ref)
+        exit(reason)
+
+      {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+        stop_registration(hook, hook_ref, worker, worker_ref)
+
+      {:EXIT, ^supervisor, reason} ->
+        stop_registration(hook, hook_ref, worker, worker_ref)
+        exit(reason)
+    end
+  end
+
+  defp await_registered_worker(context) do
+    %{owner: owner, owner_ref: owner_ref, worker: worker, worker_ref: worker_ref} = context
+    %{supervisor: supervisor, tag: tag, run_ref: run_ref} = context
+    await(owner, owner_ref, worker, worker_ref, supervisor, tag, run_ref)
+  end
+
+  defp stop_registration(hook, hook_ref, worker, worker_ref) do
+    Process.exit(hook, :kill)
+    Process.exit(worker, :kill)
+    await_process_exit(hook, hook_ref)
+    await_worker_exit(worker, worker_ref)
   end
 
   defp await(owner, owner_ref, worker, worker_ref, supervisor, tag, run_ref) do
@@ -199,8 +261,12 @@ defmodule ArcanaWeb.BackgroundTask do
   end
 
   defp await_worker_exit(worker, worker_ref) do
+    await_process_exit(worker, worker_ref)
+  end
+
+  defp await_process_exit(process, monitor_ref) do
     receive do
-      {:DOWN, ^worker_ref, :process, ^worker, _reason} -> :ok
+      {:DOWN, ^monitor_ref, :process, ^process, _reason} -> :ok
     end
   end
 

--- a/lib/arcana_web/background_task.ex
+++ b/lib/arcana_web/background_task.ex
@@ -1,0 +1,118 @@
+defmodule ArcanaWeb.BackgroundTask do
+  @moduledoc false
+
+  @doc """
+  Runs dashboard work under ArcanaWeb.TaskSupervisor and ties its lifetime
+  to the owning LiveView.
+
+  The coordinator catches worker failures and always sends a tagged result.
+  If the owner exits first, it kills the worker before the worker can keep
+  using the owner's sandbox connection or other request-scoped resources.
+  """
+  def start(owner, tag, fun, opts \\ [])
+      when is_pid(owner) and is_atom(tag) and is_function(fun, 0) and is_list(opts) do
+    callers = [owner | Process.get(:"$callers", [])]
+    run_ref = Keyword.get_lazy(opts, :run_ref, &make_ref/0)
+    cleanup = Keyword.get(opts, :cleanup, fn -> :ok end)
+
+    started =
+      try do
+        ArcanaWeb.TaskSupervisor.start_child(fn ->
+          Process.flag(:trap_exit, true)
+          owner_ref = Process.monitor(owner)
+
+          receive do
+            {:background_start, ^run_ref} ->
+              coordinator = self()
+
+              worker =
+                spawn_link(fn ->
+                  Process.put(:"$callers", callers)
+                  send(coordinator, {:background_result, self(), safely(fun)})
+                end)
+
+              await(owner, owner_ref, worker, tag, run_ref)
+
+            {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+              :ok
+          end
+        end)
+      catch
+        :exit, reason -> {:error, reason}
+      end
+
+    case started do
+      {:ok, coordinator} ->
+        monitor_ref = Process.monitor(coordinator)
+        start_cleanup_guardian(owner, coordinator, cleanup)
+        send(coordinator, {:background_start, run_ref})
+        {:ok, %{pid: coordinator, monitor_ref: monitor_ref, run_ref: run_ref}}
+
+      {:error, _reason} = error ->
+        safely_cleanup(cleanup)
+        error
+    end
+  end
+
+  defp await(owner, owner_ref, worker, tag, run_ref) do
+    receive do
+      {:background_result, ^worker, result} ->
+        Process.demonitor(owner_ref, [:flush])
+        Process.unlink(worker)
+        send(owner, {tag, run_ref, result})
+        :ok
+
+      {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+        Process.exit(worker, :kill)
+        await_worker_exit(worker)
+
+      {:EXIT, ^worker, reason} ->
+        Process.demonitor(owner_ref, [:flush])
+        send(owner, {tag, run_ref, {:error, Exception.format_exit(reason)}})
+        :ok
+    end
+  end
+
+  # The guardian is deliberately independent of both owner and coordinator.
+  # Whichever one disappears first ends the run and owns cleanup; this covers
+  # both LiveView navigation and coordinator failure. It is ready before the
+  # coordinator receives its start handshake, so even a zero-work task cannot
+  # finish before cleanup is protected.
+  defp start_cleanup_guardian(owner, coordinator, cleanup) do
+    starter = self()
+
+    guardian =
+      spawn(fn ->
+        owner_ref = Process.monitor(owner)
+        coordinator_ref = Process.monitor(coordinator)
+        send(starter, {:background_cleanup_ready, self()})
+
+        receive do
+          {:DOWN, ^owner_ref, :process, ^owner, _reason} -> safely_cleanup(cleanup)
+          {:DOWN, ^coordinator_ref, :process, ^coordinator, _reason} -> safely_cleanup(cleanup)
+        end
+      end)
+
+    receive do
+      {:background_cleanup_ready, ^guardian} -> :ok
+    end
+  end
+
+  defp safely_cleanup(cleanup) do
+    cleanup.()
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp await_worker_exit(worker) do
+    receive do
+      {:EXIT, ^worker, _reason} -> :ok
+    end
+  end
+
+  defp safely(fun) do
+    fun.()
+  catch
+    kind, reason -> {:error, Exception.format_banner(kind, reason)}
+  end
+end

--- a/lib/arcana_web/background_task.ex
+++ b/lib/arcana_web/background_task.ex
@@ -14,27 +14,33 @@ defmodule ArcanaWeb.BackgroundTask do
     callers = [owner | Process.get(:"$callers", [])]
     run_ref = Keyword.get_lazy(opts, :run_ref, &make_ref/0)
     cleanup = Keyword.get(opts, :cleanup, fn -> :ok end)
+    on_worker_registered = Keyword.get(opts, :on_worker_registered, fn _worker -> :ok end)
+    task_supervisor = Keyword.get(opts, :task_supervisor, ArcanaWeb.TaskSupervisor)
 
     started =
       try do
-        ArcanaWeb.TaskSupervisor.start_child(fn ->
+        Task.Supervisor.start_child(task_supervisor, fn ->
+          supervisor = task_supervisor_parent()
           Process.flag(:trap_exit, true)
           owner_ref = Process.monitor(owner)
 
           receive do
-            {:background_start, ^run_ref} ->
-              coordinator = self()
-
-              worker =
-                spawn_link(fn ->
-                  Process.put(:"$callers", callers)
-                  send(coordinator, {:background_result, self(), safely(fun)})
-                end)
-
-              await(owner, owner_ref, worker, tag, run_ref)
+            {:background_start, ^run_ref, guardian} ->
+              start_worker(
+                owner,
+                owner_ref,
+                guardian,
+                {callers, fun, on_worker_registered},
+                supervisor,
+                tag,
+                run_ref
+              )
 
             {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
               :ok
+
+            {:EXIT, ^supervisor, reason} ->
+              exit(reason)
           end
         end)
       catch
@@ -44,8 +50,8 @@ defmodule ArcanaWeb.BackgroundTask do
     case started do
       {:ok, coordinator} ->
         monitor_ref = Process.monitor(coordinator)
-        start_cleanup_guardian(owner, coordinator, cleanup)
-        send(coordinator, {:background_start, run_ref})
+        guardian = start_cleanup_guardian(coordinator, cleanup)
+        send(coordinator, {:background_start, run_ref, guardian})
         {:ok, %{pid: coordinator, monitor_ref: monitor_ref, run_ref: run_ref}}
 
       {:error, _reason} = error ->
@@ -54,47 +60,135 @@ defmodule ArcanaWeb.BackgroundTask do
     end
   end
 
-  defp await(owner, owner_ref, worker, tag, run_ref) do
+  defp start_worker(
+         owner,
+         owner_ref,
+         guardian,
+         {callers, fun, on_worker_registered},
+         supervisor,
+         tag,
+         run_ref
+       ) do
+    send(guardian, {:background_spawn_worker, self(), callers, fun})
+
+    receive do
+      {:background_worker_registered, ^guardian, worker} ->
+        worker_ref = Process.monitor(worker)
+        on_worker_registered.(worker)
+        send(worker, {:background_worker_ready, guardian})
+        await(owner, owner_ref, worker, worker_ref, supervisor, tag, run_ref)
+
+      {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+        :ok
+
+      {:EXIT, ^supervisor, reason} ->
+        exit(reason)
+    end
+  end
+
+  defp await(owner, owner_ref, worker, worker_ref, supervisor, tag, run_ref) do
     receive do
       {:background_result, ^worker, result} ->
         Process.demonitor(owner_ref, [:flush])
-        Process.unlink(worker)
+        Process.demonitor(worker_ref, [:flush])
         send(owner, {tag, run_ref, result})
         :ok
 
       {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
         Process.exit(worker, :kill)
-        await_worker_exit(worker)
+        await_worker_exit(worker, worker_ref)
 
-      {:EXIT, ^worker, reason} ->
+      {:EXIT, ^supervisor, reason} ->
+        Process.exit(worker, :kill)
+        await_worker_exit(worker, worker_ref)
+        exit(reason)
+
+      {:DOWN, ^worker_ref, :process, ^worker, reason} ->
         Process.demonitor(owner_ref, [:flush])
         send(owner, {tag, run_ref, {:error, Exception.format_exit(reason)}})
         :ok
     end
   end
 
-  # The guardian is deliberately independent of both owner and coordinator.
-  # Whichever one disappears first ends the run and owns cleanup; this covers
-  # both LiveView navigation and coordinator failure. It is ready before the
-  # coordinator receives its start handshake, so even a zero-work task cannot
-  # finish before cleanup is protected.
-  defp start_cleanup_guardian(owner, coordinator, cleanup) do
+  # The guardian is independent of the coordinator so cleanup still runs after
+  # an untrappable exit. It waits for both coordinator and worker termination,
+  # preventing cleanup from racing setup or in-flight request-scoped work.
+  defp start_cleanup_guardian(coordinator, cleanup) do
     starter = self()
 
     guardian =
       spawn(fn ->
-        owner_ref = Process.monitor(owner)
         coordinator_ref = Process.monitor(coordinator)
         send(starter, {:background_cleanup_ready, self()})
-
-        receive do
-          {:DOWN, ^owner_ref, :process, ^owner, _reason} -> safely_cleanup(cleanup)
-          {:DOWN, ^coordinator_ref, :process, ^coordinator, _reason} -> safely_cleanup(cleanup)
-        end
+        await_worker_registration(coordinator, coordinator_ref, cleanup)
       end)
 
     receive do
       {:background_cleanup_ready, ^guardian} -> :ok
+    end
+
+    guardian
+  end
+
+  defp await_worker_registration(coordinator, coordinator_ref, cleanup) do
+    receive do
+      {:background_spawn_worker, ^coordinator, callers, fun} ->
+        guardian = self()
+
+        {worker, worker_ref} =
+          spawn_monitor(fn ->
+            receive do
+              {:background_worker_ready, ^guardian} ->
+                Process.put(:"$callers", callers)
+                send(coordinator, {:background_result, self(), safely(fun)})
+            end
+          end)
+
+        send(coordinator, {:background_worker_registered, guardian, worker})
+        await_cleanup(coordinator, coordinator_ref, worker, worker_ref, false, false, cleanup)
+
+      {:DOWN, ^coordinator_ref, :process, ^coordinator, _reason} ->
+        safely_cleanup(cleanup)
+    end
+  end
+
+  defp await_cleanup(
+         coordinator,
+         coordinator_ref,
+         worker,
+         worker_ref,
+         coordinator_down?,
+         worker_down?,
+         cleanup
+       ) do
+    if coordinator_down? and worker_down? do
+      safely_cleanup(cleanup)
+    else
+      receive do
+        {:DOWN, ^coordinator_ref, :process, ^coordinator, _reason} ->
+          if not worker_down?, do: Process.exit(worker, :kill)
+
+          await_cleanup(
+            coordinator,
+            coordinator_ref,
+            worker,
+            worker_ref,
+            true,
+            worker_down?,
+            cleanup
+          )
+
+        {:DOWN, ^worker_ref, :process, ^worker, _reason} ->
+          await_cleanup(
+            coordinator,
+            coordinator_ref,
+            worker,
+            worker_ref,
+            coordinator_down?,
+            true,
+            cleanup
+          )
+      end
     end
   end
 
@@ -104,10 +198,15 @@ defmodule ArcanaWeb.BackgroundTask do
     _kind, _reason -> :ok
   end
 
-  defp await_worker_exit(worker) do
+  defp await_worker_exit(worker, worker_ref) do
     receive do
-      {:EXIT, ^worker, _reason} -> :ok
+      {:DOWN, ^worker_ref, :process, ^worker, _reason} -> :ok
     end
+  end
+
+  defp task_supervisor_parent do
+    {:links, [supervisor]} = Process.info(self(), :links)
+    supervisor
   end
 
   defp safely(fun) do

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -41,6 +41,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
          ask_sub_tab: :advanced,
          ask_question: "",
          ask_running: false,
+         ask_task: nil,
          ask_context: nil,
          ask_error: nil,
          stats: nil,
@@ -147,6 +148,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     @impl true
+    def handle_event("ask_submit", _params, %{assigns: %{ask_running: true}} = socket) do
+      {:noreply, socket}
+    end
+
     def handle_event("ask_submit", params, socket) do
       question = params["question"] || ""
       requested = params["collections"] || []
@@ -253,8 +258,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
               trace_history: []
             )
 
-          start_ask_task(socket, params, llm, question, collections)
-          {:noreply, socket}
+          {:noreply, start_ask_task(socket, params, llm, question, collections)}
       end
     end
 
@@ -356,6 +360,17 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       repo = socket.assigns.repo
       sub_tab = params["sub_tab"] || "advanced"
       parent = self()
+      run_ref = make_ref()
+      suffix = inspect(run_ref)
+      handler_id = "pipeline-progress-#{suffix}"
+      trace_handler_id = "trace-progress-#{suffix}"
+      loop_handler_id = "loop-progress-#{suffix}"
+
+      cleanup = fn ->
+        :telemetry.detach(handler_id)
+        :telemetry.detach(trace_handler_id)
+        :telemetry.detach(loop_handler_id)
+      end
 
       # Carries both halves of the scoping decision into the task: what the
       # user picked, and whether this dashboard is restricted at all (which
@@ -365,147 +380,260 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         allowed: socket.assigns.allowed_collections
       }
 
-      ArcanaWeb.TaskSupervisor.start_child(fn ->
-        handler_id = "pipeline-progress-#{inspect(parent)}"
-        trace_handler_id = "trace-progress-#{inspect(parent)}"
-        loop_handler_id = "loop-progress-#{inspect(parent)}"
+      task_context = %{
+        parent: parent,
+        run_ref: run_ref,
+        handler_ids: {handler_id, trace_handler_id, loop_handler_id},
+        sub_tab: sub_tab,
+        question: question,
+        repo: repo,
+        llm: llm,
+        collections: socket.assigns.collections,
+        params: params,
+        scope: scope
+      }
 
-        graph_enabled = params["graph_search"] == "true"
-
-        pipeline_steps = [
-          :gate,
-          :rewrite,
-          :expand,
-          :decompose,
-          :select,
-          :search,
-          :reason,
-          :self_correct,
-          :rerank,
-          :answer,
-          :ground
-        ]
-
-        # Pipeline progress label events (the old "Running X..." text that
-        # updates the spinner label).
-        label_events =
-          Enum.map(pipeline_steps, &[:arcana, :pipeline, &1, :start]) ++
-            [[:arcana, :graph, :search, :start]]
-
-        :telemetry.attach_many(
-          handler_id,
-          label_events,
-          fn
-            [:arcana, :graph, :search, :start], _measurements, _metadata, _config ->
-              send(parent, {:pipeline_progress, "Searching with graph connections..."})
-
-            [:arcana, :pipeline, step, :start], _measurements, _metadata, _config ->
-              label =
-                if step == :search and graph_enabled,
-                  do: "Searching with graph connections...",
-                  else: pipeline_step_label(step)
-
-              if label, do: send(parent, {:pipeline_progress, label})
-          end,
-          nil
+      started =
+        ArcanaWeb.BackgroundTask.start(
+          parent,
+          :ask_complete,
+          fn -> run_ask_task(task_context) end,
+          run_ref: run_ref,
+          cleanup: cleanup
         )
 
-        # Trace events for the live step-by-step panel. Every sub-tab
-        # subscribes, the handler normalizes the event path to a
-        # `{:trace_step_start, atom}` / `{:trace_step_stop, atom, ms, meta}`
-        # tuple. Pipeline and Advanced both flow through this pathway.
-        trace_events =
-          Enum.flat_map(pipeline_steps, fn step ->
-            [
-              [:arcana, :pipeline, step, :start],
-              [:arcana, :pipeline, step, :stop]
-            ]
-          end) ++
-            [
-              [:arcana, :search, :start],
-              [:arcana, :search, :stop],
-              [:arcana, :graph, :search, :start],
-              [:arcana, :graph, :search, :stop],
-              [:arcana, :llm, :complete, :start],
-              [:arcana, :llm, :complete, :stop]
-            ]
+      case started do
+        {:ok, task} ->
+          assign(socket, ask_task: task)
 
-        :telemetry.attach_many(
-          trace_handler_id,
-          trace_events,
-          fn event, measurements, metadata, _config ->
-            case {event, measurements} do
-              {[:arcana, :pipeline, step, :start], _} ->
-                send(parent, {:trace_step_start, step})
-
-              {[:arcana, :pipeline, step, :stop], %{duration: d}} ->
-                send(parent, {:trace_step_stop, step, native_to_ms(d), metadata})
-
-              {[:arcana, :search, :start], _} ->
-                send(parent, {:trace_step_start, :search})
-
-              {[:arcana, :search, :stop], %{duration: d}} ->
-                send(parent, {:trace_step_stop, :search, native_to_ms(d), metadata})
-
-              {[:arcana, :graph, :search, :start], _} ->
-                send(parent, {:trace_step_start, :graph_search})
-
-              {[:arcana, :graph, :search, :stop], %{duration: d}} ->
-                send(parent, {:trace_step_stop, :graph_search, native_to_ms(d), metadata})
-
-              {[:arcana, :llm, :complete, :start], _} ->
-                send(parent, {:trace_step_start, :llm_complete})
-
-              {[:arcana, :llm, :complete, :stop], %{duration: d}} ->
-                send(parent, {:trace_step_stop, :llm_complete, native_to_ms(d), metadata})
-
-              _ ->
-                :ok
-            end
-          end,
-          nil
-        )
-
-        # Per-tool-call telemetry for the Loop sub-tab. Each event carries
-        # the same shape as a tool_history entry, so the LV can render
-        # the live trace incrementally as the loop unfolds.
-        :telemetry.attach_many(
-          loop_handler_id,
-          [
-            [:arcana, :loop, :tool_call],
-            [:arcana, :loop, :ground, :start],
-            [:arcana, :loop, :ground, :stop]
-          ],
-          fn
-            [:arcana, :loop, :tool_call], _measurements, metadata, _config ->
-              send(parent, {:loop_progress, metadata})
-
-            [:arcana, :loop, :ground, :start], _measurements, _metadata, _config ->
-              send(parent, {:loop_phase, :grounding})
-
-            [:arcana, :loop, :ground, :stop], _measurements, _metadata, _config ->
-              send(parent, {:loop_phase, :idle})
-          end,
-          nil
-        )
-
-        result =
-          run_ask(
-            sub_tab,
-            question,
-            repo,
-            llm,
-            socket.assigns.collections,
-            params,
-            scope
+        {:error, reason} ->
+          assign(socket,
+            ask_running: false,
+            ask_task: nil,
+            ask_error: "Could not start ask task: #{inspect(reason)}"
           )
-
-        :telemetry.detach(handler_id)
-        :telemetry.detach(trace_handler_id)
-        :telemetry.detach(loop_handler_id)
-        send(parent, {:ask_complete, result})
-      end)
+      end
     end
+
+    defp run_ask_task(%{
+           parent: parent,
+           run_ref: run_ref,
+           handler_ids: {handler_id, trace_handler_id, loop_handler_id},
+           sub_tab: sub_tab,
+           question: question,
+           repo: repo,
+           llm: llm,
+           collections: collections,
+           params: params,
+           scope: scope
+         }) do
+      pipeline_steps = pipeline_steps()
+      attach_pipeline_progress(handler_id, parent, run_ref, pipeline_steps, params)
+      attach_trace_progress(trace_handler_id, parent, run_ref, pipeline_steps)
+      attach_loop_progress(loop_handler_id, parent, run_ref)
+      run_ask(sub_tab, question, repo, llm, collections, params, scope)
+    end
+
+    defp pipeline_steps do
+      [
+        :gate,
+        :rewrite,
+        :expand,
+        :decompose,
+        :select,
+        :search,
+        :reason,
+        :self_correct,
+        :rerank,
+        :answer,
+        :ground
+      ]
+    end
+
+    # Pipeline progress label events (the old "Running X..." text that updates
+    # the spinner label).
+    defp attach_pipeline_progress(handler_id, parent, run_ref, pipeline_steps, params) do
+      graph_enabled = params["graph_search"] == "true"
+      events = Enum.map(pipeline_steps, &[:arcana, :pipeline, &1, :start])
+      events = events ++ [[:arcana, :graph, :search, :start]]
+
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event, measurements, metadata, config ->
+          handle_pipeline_progress(
+            event,
+            measurements,
+            metadata,
+            config,
+            parent,
+            run_ref,
+            graph_enabled
+          )
+        end,
+        nil
+      )
+    end
+
+    defp handle_pipeline_progress(
+           [:arcana, :graph, :search, :start],
+           _measurements,
+           _metadata,
+           _config,
+           parent,
+           run_ref,
+           _graph_enabled
+         ) do
+      send(parent, {:pipeline_progress, run_ref, "Searching with graph connections..."})
+    end
+
+    defp handle_pipeline_progress(
+           [:arcana, :pipeline, step, :start],
+           _measurements,
+           _metadata,
+           _config,
+           parent,
+           run_ref,
+           graph_enabled
+         ) do
+      label =
+        if step == :search and graph_enabled,
+          do: "Searching with graph connections...",
+          else: pipeline_step_label(step)
+
+      if label, do: send(parent, {:pipeline_progress, run_ref, label})
+    end
+
+    # Every sub-tab subscribes to the live step-by-step trace. The callback
+    # normalizes pipeline and direct search events to the same message shape.
+    defp attach_trace_progress(handler_id, parent, run_ref, pipeline_steps) do
+      events =
+        Enum.flat_map(pipeline_steps, fn step ->
+          [[:arcana, :pipeline, step, :start], [:arcana, :pipeline, step, :stop]]
+        end) ++
+          [
+            [:arcana, :search, :start],
+            [:arcana, :search, :stop],
+            [:arcana, :graph, :search, :start],
+            [:arcana, :graph, :search, :stop],
+            [:arcana, :llm, :complete, :start],
+            [:arcana, :llm, :complete, :stop]
+          ]
+
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event, measurements, metadata, _config ->
+          handle_trace_progress(event, measurements, metadata, parent, run_ref)
+        end,
+        nil
+      )
+    end
+
+    defp handle_trace_progress([:arcana, :pipeline, step, :start], _, _, parent, run_ref),
+      do: send(parent, {:trace_step_start, run_ref, step})
+
+    defp handle_trace_progress(
+           [:arcana, :pipeline, step, :stop],
+           %{duration: duration},
+           metadata,
+           parent,
+           run_ref
+         ),
+         do: send(parent, {:trace_step_stop, run_ref, step, native_to_ms(duration), metadata})
+
+    defp handle_trace_progress([:arcana, :search, :start], _, _, parent, run_ref),
+      do: send(parent, {:trace_step_start, run_ref, :search})
+
+    defp handle_trace_progress(
+           [:arcana, :search, :stop],
+           %{duration: duration},
+           metadata,
+           parent,
+           run_ref
+         ),
+         do: send(parent, {:trace_step_stop, run_ref, :search, native_to_ms(duration), metadata})
+
+    defp handle_trace_progress([:arcana, :graph, :search, :start], _, _, parent, run_ref),
+      do: send(parent, {:trace_step_start, run_ref, :graph_search})
+
+    defp handle_trace_progress(
+           [:arcana, :graph, :search, :stop],
+           %{duration: duration},
+           metadata,
+           parent,
+           run_ref
+         ),
+         do:
+           send(
+             parent,
+             {:trace_step_stop, run_ref, :graph_search, native_to_ms(duration), metadata}
+           )
+
+    defp handle_trace_progress([:arcana, :llm, :complete, :start], _, _, parent, run_ref),
+      do: send(parent, {:trace_step_start, run_ref, :llm_complete})
+
+    defp handle_trace_progress(
+           [:arcana, :llm, :complete, :stop],
+           %{duration: duration},
+           metadata,
+           parent,
+           run_ref
+         ),
+         do:
+           send(
+             parent,
+             {:trace_step_stop, run_ref, :llm_complete, native_to_ms(duration), metadata}
+           )
+
+    defp handle_trace_progress(_event, _measurements, _metadata, _parent, _run_ref), do: :ok
+
+    # Loop tool events carry the same metadata shape as a tool_history entry,
+    # so the LiveView can append them without another transformation.
+    defp attach_loop_progress(handler_id, parent, run_ref) do
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:arcana, :loop, :tool_call],
+          [:arcana, :loop, :ground, :start],
+          [:arcana, :loop, :ground, :stop]
+        ],
+        fn event, measurements, metadata, config ->
+          handle_loop_progress(event, measurements, metadata, config, parent, run_ref)
+        end,
+        nil
+      )
+    end
+
+    defp handle_loop_progress(
+           [:arcana, :loop, :tool_call],
+           _measurements,
+           metadata,
+           _config,
+           parent,
+           run_ref
+         ),
+         do: send(parent, {:loop_progress, run_ref, metadata})
+
+    defp handle_loop_progress(
+           [:arcana, :loop, :ground, :start],
+           _measurements,
+           _metadata,
+           _config,
+           parent,
+           run_ref
+         ),
+         do: send(parent, {:loop_phase, run_ref, :grounding})
+
+    defp handle_loop_progress(
+           [:arcana, :loop, :ground, :stop],
+           _measurements,
+           _metadata,
+           _config,
+           parent,
+           run_ref
+         ),
+         do: send(parent, {:loop_phase, run_ref, :idle})
 
     defp native_to_ms(duration) do
       System.convert_time_unit(duration, :native, :millisecond)
@@ -542,27 +670,42 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     @impl true
-    def handle_info({:pipeline_progress, step}, socket) do
+    def handle_info(
+          {:pipeline_progress, run_ref, step},
+          %{assigns: %{ask_task: %{run_ref: run_ref}}} = socket
+        ) do
       {:noreply, assign(socket, pipeline_step: step)}
     end
 
-    def handle_info({:loop_progress, entry}, socket) do
+    def handle_info(
+          {:loop_progress, run_ref, entry},
+          %{assigns: %{ask_task: %{run_ref: run_ref}}} = socket
+        ) do
       # Append, not prepend: render order matches iteration order so the
       # newest entry visually lands at the bottom of the trace.
       {:noreply, assign(socket, loop_live_history: socket.assigns.loop_live_history ++ [entry])}
     end
 
-    def handle_info({:loop_phase, phase}, socket) do
+    def handle_info(
+          {:loop_phase, run_ref, phase},
+          %{assigns: %{ask_task: %{run_ref: run_ref}}} = socket
+        ) do
       {:noreply, assign(socket, loop_phase: phase)}
     end
 
-    def handle_info({:trace_step_start, step}, socket) do
+    def handle_info(
+          {:trace_step_start, run_ref, step},
+          %{assigns: %{ask_task: %{run_ref: run_ref}}} = socket
+        ) do
       entry = %{step: step, status: :running, duration_ms: nil, meta: nil}
 
       {:noreply, assign(socket, trace_history: socket.assigns.trace_history ++ [entry])}
     end
 
-    def handle_info({:trace_step_stop, step, duration_ms, metadata}, socket) do
+    def handle_info(
+          {:trace_step_stop, run_ref, step, duration_ms, metadata},
+          %{assigns: %{ask_task: %{run_ref: run_ref}}} = socket
+        ) do
       history =
         socket.assigns.trace_history
         |> Enum.reverse()
@@ -572,24 +715,69 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       {:noreply, assign(socket, trace_history: history)}
     end
 
-    def handle_info({:ask_complete, result}, socket) do
-      socket =
-        case result do
-          {:ok, ctx} ->
-            ctx = Map.put(ctx, :document_titles, load_document_titles(ctx, socket.assigns.repo))
+    def handle_info(
+          {:ask_complete, run_ref, result},
+          %{assigns: %{ask_task: %{run_ref: run_ref, monitor_ref: monitor_ref}}} = socket
+        ) do
+      Process.demonitor(monitor_ref, [:flush])
+      {:noreply, finish_ask(socket, result)}
+    end
 
-            assign(socket,
-              ask_running: false,
-              ask_context: ctx,
-              ask_error: nil,
-              pipeline_step: nil
-            )
+    # Some callers use this message to render a completed result without
+    # starting background work. Keep that path only while idle so an old,
+    # uncorrelated message can never overwrite an active run.
+    def handle_info(
+          {:ask_complete, result},
+          %{assigns: %{ask_running: false, ask_task: nil}} = socket
+        ) do
+      {:noreply, finish_ask(socket, result)}
+    end
 
-          {:error, reason} ->
-            assign(socket, ask_running: false, ask_error: inspect(reason), pipeline_step: nil)
-        end
+    def handle_info(
+          {:DOWN, monitor_ref, :process, _pid, reason},
+          %{assigns: %{ask_task: %{monitor_ref: monitor_ref}}} = socket
+        ) do
+      {:noreply,
+       assign(socket,
+         ask_running: false,
+         ask_task: nil,
+         ask_error: "Ask task stopped: #{inspect(reason)}",
+         pipeline_step: nil
+       )}
+    end
 
-      {:noreply, socket}
+    def handle_info({tag, _run_ref, _payload}, socket)
+        when tag in [
+               :pipeline_progress,
+               :loop_progress,
+               :loop_phase,
+               :trace_step_start,
+               :ask_complete
+             ],
+        do: {:noreply, socket}
+
+    def handle_info({:trace_step_stop, _run_ref, _step, _duration_ms, _metadata}, socket),
+      do: {:noreply, socket}
+
+    defp finish_ask(socket, {:ok, ctx}) do
+      ctx = Map.put(ctx, :document_titles, load_document_titles(ctx, socket.assigns.repo))
+
+      assign(socket,
+        ask_running: false,
+        ask_task: nil,
+        ask_context: ctx,
+        ask_error: nil,
+        pipeline_step: nil
+      )
+    end
+
+    defp finish_ask(socket, {:error, reason}) do
+      assign(socket,
+        ask_running: false,
+        ask_task: nil,
+        ask_error: inspect(reason),
+        pipeline_step: nil
+      )
     end
 
     # Batch-loads document titles for every chunk in the result. All three

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -428,9 +428,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
            scope: scope
          }) do
       pipeline_steps = pipeline_steps()
-      attach_pipeline_progress(handler_id, parent, run_ref, pipeline_steps, params)
-      attach_trace_progress(trace_handler_id, parent, run_ref, pipeline_steps)
-      attach_loop_progress(loop_handler_id, parent, run_ref)
+      worker = self()
+      attach_pipeline_progress(handler_id, parent, worker, run_ref, pipeline_steps, params)
+      attach_trace_progress(trace_handler_id, parent, worker, run_ref, pipeline_steps)
+      attach_loop_progress(loop_handler_id, parent, worker, run_ref)
       run_ask(sub_tab, question, repo, llm, collections, params, scope)
     end
 
@@ -452,7 +453,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     # Pipeline progress label events (the old "Running X..." text that updates
     # the spinner label).
-    defp attach_pipeline_progress(handler_id, parent, run_ref, pipeline_steps, params) do
+    defp attach_pipeline_progress(handler_id, parent, worker, run_ref, pipeline_steps, params) do
       graph_enabled = params["graph_search"] == "true"
       events = Enum.map(pipeline_steps, &[:arcana, :pipeline, &1, :start])
       events = events ++ [[:arcana, :graph, :search, :start]]
@@ -461,15 +462,17 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         handler_id,
         events,
         fn event, measurements, metadata, config ->
-          handle_pipeline_progress(
-            event,
-            measurements,
-            metadata,
-            config,
-            parent,
-            run_ref,
-            graph_enabled
-          )
+          if telemetry_owned_by?(worker) do
+            handle_pipeline_progress(
+              event,
+              measurements,
+              metadata,
+              config,
+              parent,
+              run_ref,
+              graph_enabled
+            )
+          end
         end,
         nil
       )
@@ -506,7 +509,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     # Every sub-tab subscribes to the live step-by-step trace. The callback
     # normalizes pipeline and direct search events to the same message shape.
-    defp attach_trace_progress(handler_id, parent, run_ref, pipeline_steps) do
+    defp attach_trace_progress(handler_id, parent, worker, run_ref, pipeline_steps) do
       events =
         Enum.flat_map(pipeline_steps, fn step ->
           [[:arcana, :pipeline, step, :start], [:arcana, :pipeline, step, :stop]]
@@ -524,7 +527,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         handler_id,
         events,
         fn event, measurements, metadata, _config ->
-          handle_trace_progress(event, measurements, metadata, parent, run_ref)
+          if telemetry_owned_by?(worker) do
+            handle_trace_progress(event, measurements, metadata, parent, run_ref)
+          end
         end,
         nil
       )
@@ -590,7 +595,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     # Loop tool events carry the same metadata shape as a tool_history entry,
     # so the LiveView can append them without another transformation.
-    defp attach_loop_progress(handler_id, parent, run_ref) do
+    defp attach_loop_progress(handler_id, parent, worker, run_ref) do
       :telemetry.attach_many(
         handler_id,
         [
@@ -599,7 +604,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           [:arcana, :loop, :ground, :stop]
         ],
         fn event, measurements, metadata, config ->
-          handle_loop_progress(event, measurements, metadata, config, parent, run_ref)
+          if telemetry_owned_by?(worker) do
+            handle_loop_progress(event, measurements, metadata, config, parent, run_ref)
+          end
         end,
         nil
       )
@@ -634,6 +641,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
            run_ref
          ),
          do: send(parent, {:loop_phase, run_ref, :idle})
+
+    defp telemetry_owned_by?(worker) do
+      self() == worker or
+        worker in Process.get(:"$callers", []) or
+        worker in Process.get(:"$ancestors", [])
+    end
 
     defp native_to_ms(duration) do
       System.convert_time_unit(duration, :native, :millisecond)

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -266,15 +266,30 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp resolve_ask_collections(requested, allowed) do
       requested = Enum.reject(requested, &(&1 == ""))
-      requested = if requested == [], do: :all, else: requested
 
-      case effective_collection_scope(allowed, requested) do
-        [] -> :error
-        scope -> {:ok, scope}
+      case requested do
+        [] ->
+          case public_collection_scope(CollectionScope.normalize!(allowed)) do
+            [] -> :error
+            scope -> {:ok, scope}
+          end
+
+        names ->
+          requested_scope = CollectionScope.normalize!(names)
+          allowed_scope = CollectionScope.normalize!(allowed)
+
+          if CollectionScope.subset?(requested_scope, allowed_scope) do
+            {:ok, public_collection_scope(requested_scope)}
+          else
+            :error
+          end
       end
     rescue
       ArgumentError -> :error
     end
+
+    defp public_collection_scope(:all), do: :all
+    defp public_collection_scope({:only, names}), do: names
 
     defp effective_collection_scope(allowed, requested) do
       requested_scope = CollectionScope.normalize!(requested)
@@ -852,7 +867,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp load_document_titles(_ctx, _repo, _collection_scope), do: %{}
 
     defp collection_scope_opts(:all), do: [collection: :all]
-    defp collection_scope_opts(names) when is_list(names), do: [collections: names]
+    defp collection_scope_opts(names) when is_list(names), do: [collection: names]
 
     defp extract_title(nil), do: nil
 
@@ -951,7 +966,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     # Pass every run's effective scope explicitly. In particular, [] must
     # stay "no collections" and :all must stay unrestricted.
     defp maybe_put_collection_opt(opts, :all), do: Keyword.put(opts, :collection, :all)
-    defp maybe_put_collection_opt(opts, list), do: Keyword.put(opts, :collections, list)
+    defp maybe_put_collection_opt(opts, list), do: Keyword.put(opts, :collection, list)
 
     # Restricted dashboards keep strict resolution so a collection deleted
     # mid-run is reported instead of quietly producing a partial answer.
@@ -1154,7 +1169,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     defp add_collection_opts(opts, :all), do: Keyword.put(opts, :collection, :all)
-    defp add_collection_opts(opts, list), do: Keyword.put(opts, :collections, list)
+    defp add_collection_opts(opts, list), do: Keyword.put(opts, :collection, list)
 
     # Keep an authorization check around LLM-selected collection names. The
     # selector can return a name outside the offered set, so this fence checks

--- a/lib/arcana_web/live/ask_live.ex
+++ b/lib/arcana_web/live/ask_live.ex
@@ -12,7 +12,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     import Ecto.Query
     import ArcanaWeb.DashboardComponents
 
-    alias Arcana.Document
+    alias Arcana.CollectionScope
     alias Arcana.Graph.Entity
     alias ArcanaWeb.ChunkResultsComponent
 
@@ -262,22 +262,28 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       end
     end
 
-    # Resolves the user's collection selection against the allowed set.
-    # Unrestricted dashboards pass the selection through untouched ([] keeps
-    # today's semantics). Restricted ones fail closed: an empty allowed set
-    # refuses every ask, no selection means "all allowed collections", and a
-    # selection naming anything outside the allowed set is rejected whole.
-    #
-    # The non-list clause comes first so a forged scalar or map selection is
-    # rejected rather than blowing up in Enum.all?/2 (or slipping through
-    # the :all clause untouched).
     defp resolve_ask_collections(requested, _allowed) when not is_list(requested), do: :error
-    defp resolve_ask_collections(requested, :all), do: {:ok, requested}
-    defp resolve_ask_collections(_requested, []), do: :error
-    defp resolve_ask_collections([], allowed), do: {:ok, allowed}
 
     defp resolve_ask_collections(requested, allowed) do
-      if Enum.all?(requested, &(&1 in allowed)), do: {:ok, requested}, else: :error
+      requested = Enum.reject(requested, &(&1 == ""))
+      requested = if requested == [], do: :all, else: requested
+
+      case effective_collection_scope(allowed, requested) do
+        [] -> :error
+        scope -> {:ok, scope}
+      end
+    rescue
+      ArgumentError -> :error
+    end
+
+    defp effective_collection_scope(allowed, requested) do
+      requested_scope = CollectionScope.normalize!(requested)
+      allowed_scope = CollectionScope.normalize!(allowed)
+
+      case CollectionScope.intersect(requested_scope, allowed_scope) do
+        :all -> :all
+        {:only, names} -> names
+      end
     end
 
     defp ask_loading_label(:advanced, _step, _phase), do: "Generating answer..."
@@ -372,12 +378,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         :telemetry.detach(loop_handler_id)
       end
 
-      # Carries both halves of the scoping decision into the task: what the
-      # user picked, and whether this dashboard is restricted at all (which
-      # decides whether retrieval runs under :strict_collections).
       scope = %{
         collections: selected_collections,
-        allowed: socket.assigns.allowed_collections
+        allowed: selected_collections
       }
 
       task_context = %{
@@ -432,8 +435,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       attach_pipeline_progress(handler_id, parent, worker, run_ref, pipeline_steps, params)
       attach_trace_progress(trace_handler_id, parent, worker, run_ref, pipeline_steps)
       attach_loop_progress(loop_handler_id, parent, worker, run_ref)
+
       run_ask(sub_tab, question, repo, llm, collections, params, scope)
+      |> attach_collection_scope(scope.collections)
     end
+
+    defp attach_collection_scope({:ok, context}, collection_scope),
+      do: {:ok, Map.put(context, :collection_scope, collection_scope)}
+
+    defp attach_collection_scope(result, _collection_scope), do: result
 
     defp pipeline_steps do
       [
@@ -773,7 +783,16 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       do: {:noreply, socket}
 
     defp finish_ask(socket, {:ok, ctx}) do
-      ctx = Map.put(ctx, :document_titles, load_document_titles(ctx, socket.assigns.repo))
+      collection_scope =
+        socket.assigns.allowed_collections
+        |> effective_collection_scope(Map.get(ctx, :collection_scope, :all))
+
+      ctx =
+        Map.put(
+          ctx,
+          :document_titles,
+          load_document_titles(ctx, socket.assigns.repo, collection_scope)
+        )
 
       assign(socket,
         ask_running: false,
@@ -797,7 +816,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     # sub-tabs put chunks under :results, so one helper covers everything.
     # Falls back to an empty map on any error — the component already
     # degrades to a shortened UUID when a title is missing.
-    defp load_document_titles(%{results: chunks}, repo)
+    defp load_document_titles(%{results: chunks}, repo, collection_scope)
          when is_list(chunks) and not is_nil(repo) do
       ids =
         chunks
@@ -811,16 +830,29 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
         ids ->
           try do
-            from(d in Document, where: d.id in ^ids, select: {d.id, d.metadata})
-            |> repo.all()
-            |> Map.new(fn {id, metadata} -> {id, extract_title(metadata)} end)
+            opts =
+              [repo: repo]
+              |> Keyword.merge(collection_scope_opts(collection_scope))
+
+            case Arcana.get_document_metadata(ids, opts) do
+              {:ok, metadata_by_id} ->
+                Map.new(metadata_by_id, fn {id, document} ->
+                  {id, extract_title(document.metadata)}
+                end)
+
+              {:error, _reason} ->
+                %{}
+            end
           rescue
             _ -> %{}
           end
       end
     end
 
-    defp load_document_titles(_ctx, _repo), do: %{}
+    defp load_document_titles(_ctx, _repo, _collection_scope), do: %{}
+
+    defp collection_scope_opts(:all), do: [collection: :all]
+    defp collection_scope_opts(names) when is_list(names), do: [collections: names]
 
     defp extract_title(nil), do: nil
 
@@ -916,17 +948,13 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       Arcana.Config.get_env(:loop_runner) || (&Arcana.Loop.run/2)
     end
 
-    # Arcana.Loop.new/2 (and Arcana.search, Arcana.ask, Arcana.Pipeline.new)
-    # all normalize `:collection` and `:collections` to the same internal
-    # representation, so we can always pass the plural form and let the
-    # library sort it out.
-    defp maybe_put_collection_opt(opts, []), do: opts
+    # Pass every run's effective scope explicitly. In particular, [] must
+    # stay "no collections" and :all must stay unrestricted.
+    defp maybe_put_collection_opt(opts, :all), do: Keyword.put(opts, :collection, :all)
     defp maybe_put_collection_opt(opts, list), do: Keyword.put(opts, :collections, list)
 
-    # Restricted dashboards retrieve strictly: an allowed collection that
-    # doesn't exist (never created, or deleted mid-session) has to error out
-    # instead of resolving to "no filter", which would widen retrieval to
-    # every collection. Unrestricted dashboards keep the library default.
+    # Restricted dashboards keep strict resolution so a collection deleted
+    # mid-run is reported instead of quietly producing a partial answer.
     defp maybe_put_strict_opt(opts, :all), do: opts
 
     defp maybe_put_strict_opt(opts, allowed) when is_list(allowed),
@@ -992,13 +1020,17 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp run_pipeline_ask(question, repo, llm, all_collections, opts) do
       alias Arcana.Pipeline
 
-      all_collection_names = Enum.map(all_collections, & &1.name)
-      search_opts = build_search_opts(opts, all_collection_names)
+      available_collection_names =
+        all_collections
+        |> Enum.map(& &1.name)
+        |> collection_names_in_scope(Keyword.fetch!(opts, :collections))
+
+      search_opts = build_search_opts(opts, available_collection_names)
 
       Pipeline.new(question, repo: repo, llm: llm)
       |> maybe_gate(opts)
       |> maybe_rewrite(opts)
-      |> maybe_select(opts, all_collection_names)
+      |> maybe_select(opts, available_collection_names)
       |> maybe_expand(opts)
       |> maybe_decompose(opts)
       |> Pipeline.search(search_opts)
@@ -1010,6 +1042,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     rescue
       e -> {:error, Exception.message(e)}
     end
+
+    defp collection_names_in_scope(names, :all), do: names
+    defp collection_names_in_scope(names, scope), do: Enum.filter(names, &(&1 in scope))
 
     defp maybe_gate(ctx, opts) do
       if Keyword.get(opts, :use_gate, false), do: Arcana.Pipeline.gate(ctx), else: ctx
@@ -1118,15 +1153,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       end
     end
 
-    defp add_collection_opts(opts, []), do: opts
+    defp add_collection_opts(opts, :all), do: Keyword.put(opts, :collection, :all)
     defp add_collection_opts(opts, list), do: Keyword.put(opts, :collections, list)
 
-    # `Arcana.Pipeline.search/2` builds its own searcher opts and drops
-    # everything else, so :strict_collections can't just ride along like it
-    # does on the advanced and loop paths. Swapping in an explicit searcher
-    # is the supported hook: it re-checks the collection against the allowed
-    # set (the LLM-select step can name anything) and searches strictly, so
-    # a missing collection returns an error instead of widening.
+    # Keep an authorization check around LLM-selected collection names. The
+    # selector can return a name outside the offered set, so this fence checks
+    # it again before strict retrieval.
     defp maybe_put_strict_searcher(opts, :all), do: opts
 
     defp maybe_put_strict_searcher(opts, allowed) when is_list(allowed) do

--- a/lib/arcana_web/live/collections_live.ex
+++ b/lib/arcana_web/live/collections_live.ex
@@ -110,7 +110,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
       community_counts =
         repo.all(
-          from(c in Arcana.Graph.Community,
+          from([community: c] in Arcana.RetrievalScope.communities(),
             group_by: c.collection_id,
             select: {c.collection_id, count(c.id)}
           )

--- a/lib/arcana_web/live/collections_live.ex
+++ b/lib/arcana_web/live/collections_live.ex
@@ -89,7 +89,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp add_graph_stats(repo, collections) do
       entity_counts =
         repo.all(
-          from(e in Arcana.Graph.Entity,
+          from([entity: e] in Arcana.RetrievalScope.entities(),
             group_by: e.collection_id,
             select: {e.collection_id, count(e.id)}
           )
@@ -99,7 +99,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       # Relationships don't have collection_id directly - join through source entity
       relationship_counts =
         repo.all(
-          from(r in Arcana.Graph.Relationship,
+          from([relationship: r] in Arcana.RetrievalScope.relationships(),
             join: e in Arcana.Graph.Entity,
             on: r.source_id == e.id,
             group_by: e.collection_id,

--- a/lib/arcana_web/live/dashboard_components.ex
+++ b/lib/arcana_web/live/dashboard_components.ex
@@ -243,10 +243,13 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp load_graph_stats(repo, :all) do
       import Ecto.Query
 
-      entity_count = repo.one(from(e in Arcana.Graph.Entity, select: count(e.id))) || 0
+      entity_count =
+        repo.one(from([entity: e] in Arcana.RetrievalScope.entities(), select: count(e.id))) || 0
 
       relationship_count =
-        repo.one(from(r in Arcana.Graph.Relationship, select: count(r.id))) || 0
+        repo.one(
+          from([relationship: r] in Arcana.RetrievalScope.relationships(), select: count(r.id))
+        ) || 0
 
       community_count = repo.one(from(c in Arcana.Graph.Community, select: count(c.id))) || 0
 
@@ -263,7 +266,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
       entity_count =
         repo.one(
-          from(e in Arcana.Graph.Entity,
+          from([entity: e] in Arcana.RetrievalScope.entities(),
             where: e.collection_id in subquery(collection_ids),
             select: count(e.id)
           )
@@ -272,7 +275,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       # Relationships carry no collection_id; scope through the source entity
       relationship_count =
         repo.one(
-          from(r in Arcana.Graph.Relationship,
+          from([relationship: r] in Arcana.RetrievalScope.relationships(),
             join: e in Arcana.Graph.Entity,
             on: r.source_id == e.id,
             where: e.collection_id in subquery(collection_ids),

--- a/lib/arcana_web/live/dashboard_components.ex
+++ b/lib/arcana_web/live/dashboard_components.ex
@@ -251,7 +251,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           from([relationship: r] in Arcana.RetrievalScope.relationships(), select: count(r.id))
         ) || 0
 
-      community_count = repo.one(from(c in Arcana.Graph.Community, select: count(c.id))) || 0
+      community_count =
+        repo.one(from([community: c] in Arcana.RetrievalScope.communities(), select: count(c.id))) ||
+          0
 
       %{entities: entity_count, relationships: relationship_count, communities: community_count}
     rescue
@@ -285,7 +287,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
       community_count =
         repo.one(
-          from(c in Arcana.Graph.Community,
+          from([community: c] in Arcana.RetrievalScope.communities(),
             where: c.collection_id in subquery(collection_ids),
             select: count(c.id)
           )

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -13,7 +13,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     import ArcanaWeb.DashboardComponents
 
-    alias Arcana.Document
+    alias Arcana.{CollectionScope, Document}
 
     import Ecto.Query
 
@@ -68,14 +68,18 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       |> load_documents()
     end
 
-    defp load_documents(%{assigns: %{allowed_collections: :all}} = socket) do
+    defp load_documents(socket) do
       page = socket.assigns.page
       per_page = socket.assigns.per_page
 
-      filters = [
-        repo: socket.assigns.repo,
-        collection: socket.assigns.filter_collection
-      ]
+      filters =
+        [repo: socket.assigns.repo]
+        |> Keyword.merge(
+          collection_scope_opts(
+            socket.assigns.allowed_collections,
+            socket.assigns.filter_collection || :all
+          )
+        )
 
       {:ok, total_count} = Arcana.count_documents(filters)
       total_pages = max(1, ceil(total_count / per_page))
@@ -90,77 +94,88 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       )
     end
 
-    # Restricted listing: Arcana.list_documents/1 only takes a single
-    # :collection, so scope by the allowed name list here. Ordering mirrors
-    # Arcana.Documents so pagination behaves identically across modes.
-    defp load_documents(%{assigns: %{allowed_collections: allowed}} = socket) do
-      repo = socket.assigns.repo
-      page = socket.assigns.page
-      per_page = socket.assigns.per_page
-
-      names =
-        case socket.assigns.filter_collection do
-          nil -> allowed
-          name -> Enum.filter([name], &(&1 in allowed))
-        end
-
-      base = from(d in Document, join: c in assoc(d, :collection), where: c.name in ^names)
-
-      total_count = repo.aggregate(base, :count)
-      total_pages = max(1, ceil(total_count / per_page))
-
-      documents =
-        base
-        |> order_by([d], desc: d.inserted_at, desc: d.id)
-        |> limit(^per_page)
-        |> offset(^((page - 1) * per_page))
-        |> preload([:collection])
-        |> repo.all()
-
-      assign(socket,
-        documents: documents,
-        total_pages: total_pages,
-        total_count: total_count
-      )
-    end
-
     defp load_document_detail(socket, doc_id) do
       repo = socket.assigns.repo
+      allowed = socket.assigns.allowed_collections
 
-      query = from(d in Document, where: d.id == ^doc_id, preload: [:collection])
+      case scoped_document(repo, doc_id, allowed) do
+        {:ok, document} -> load_document_chunks(socket, document, doc_id)
+        {:error, :not_found} -> socket
+      end
+    end
 
-      # Forged or bookmarked ids pointing outside the allowed collections
-      # resolve to nothing, same as a missing document.
-      query =
-        case socket.assigns.allowed_collections do
-          :all ->
-            query
+    defp collection_scope_opts(allowed, requested) do
+      requested_scope = CollectionScope.normalize!(requested)
+      allowed_scope = CollectionScope.normalize!(allowed)
 
-          names when is_list(names) ->
-            from(d in query, join: c in assoc(d, :collection), where: c.name in ^names)
-        end
-
-      document = repo.one(query)
-
-      if document do
-        load_document_chunks(socket, document, doc_id)
-      else
-        socket
+      case CollectionScope.intersect(requested_scope, allowed_scope) do
+        :all -> [collection: :all]
+        {:only, names} -> [collections: names]
       end
     end
 
     defp load_document_chunks(socket, document, doc_id) do
       repo = socket.assigns.repo
-
-      chunks =
-        repo.all(
-          from(c in Arcana.Chunk,
-            where: c.document_id == ^doc_id,
-            order_by: c.chunk_index
-          )
-        )
+      chunks = scoped_chunks(repo, doc_id, socket.assigns.allowed_collections)
 
       assign(socket, viewing_document: %{document: document, chunks: chunks})
+    end
+
+    defp scoped_document(repo, doc_id, allowed) do
+      case Ecto.UUID.cast(doc_id) do
+        {:ok, uuid} -> fetch_scoped_document(repo, uuid, allowed)
+        :error -> {:error, :not_found}
+      end
+    end
+
+    defp fetch_scoped_document(repo, document_id, allowed) do
+      document =
+        Document
+        |> where([row], row.id == ^document_id)
+        |> apply_document_scope(allowed)
+        |> preload([:collection])
+        |> repo.one()
+
+      if document, do: {:ok, document}, else: {:error, :not_found}
+    end
+
+    defp scoped_chunks(repo, doc_id, allowed) do
+      Arcana.Chunk
+      |> join(:inner, [chunk], document in assoc(chunk, :document))
+      |> where([chunk], chunk.document_id == ^doc_id)
+      |> apply_chunk_scope(allowed)
+      |> order_by([chunk], chunk.chunk_index)
+      |> repo.all()
+    end
+
+    defp apply_document_scope(query, allowed) do
+      case CollectionScope.normalize!(allowed) do
+        :all ->
+          query
+
+        {:only, []} ->
+          where(query, [document], is_nil(document.id))
+
+        {:only, names} ->
+          query
+          |> join(:inner, [document], collection in assoc(document, :collection))
+          |> where([_document, collection], collection.name in ^names)
+      end
+    end
+
+    defp apply_chunk_scope(query, allowed) do
+      case CollectionScope.normalize!(allowed) do
+        :all ->
+          query
+
+        {:only, []} ->
+          where(query, [chunk, _document], is_nil(chunk.id))
+
+        {:only, names} ->
+          query
+          |> join(:inner, [_chunk, document], collection in assoc(document, :collection))
+          |> where([_chunk, _document, collection], collection.name in ^names)
+      end
     end
 
     # A forged id that isn't a UUID can't match anything, so it's rejected
@@ -299,7 +314,32 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     def handle_event("build_graph", _params, socket) do
-      %{document: document, chunks: chunks} = socket.assigns.viewing_document
+      document_id = socket.assigns.viewing_document.document.id
+
+      case scoped_document(
+             socket.assigns.repo,
+             document_id,
+             socket.assigns.allowed_collections
+           ) do
+        {:ok, document} ->
+          chunks =
+            scoped_chunks(
+              socket.assigns.repo,
+              document_id,
+              socket.assigns.allowed_collections
+            )
+
+          start_graph_build(socket, document, chunks)
+
+        {:error, :not_found} ->
+          {:noreply,
+           socket
+           |> assign(viewing_document: nil)
+           |> put_flash(:error, "This document is no longer available.")}
+      end
+    end
+
+    defp start_graph_build(socket, document, chunks) do
       collection = document.collection
       repo = socket.assigns.repo
       parent = self()

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -110,7 +110,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
       case CollectionScope.intersect(requested_scope, allowed_scope) do
         :all -> [collection: :all]
-        {:only, names} -> [collections: names]
+        {:only, names} -> [collection: names]
       end
     end
 

--- a/lib/arcana_web/live/documents_live.ex
+++ b/lib/arcana_web/live/documents_live.ex
@@ -39,7 +39,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
        # otherwise. When the graph is off the button does not render, so the
        # guard below is only reachable by a forged event either way.
        |> assign(graph_installed: graph_enabled and Arcana.Graph.installed?(repo))
-       |> assign(graph_indexing: false, graph_task_ref: nil)
+       |> assign(graph_indexing: false, graph_task: nil)
        |> assign(stats: nil, collections: [], documents: [], total_pages: 1, total_count: 0)
        |> allow_upload(:files,
          accept: ~w(.txt .md .markdown .pdf),
@@ -281,8 +281,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     # A build already running. The button renders disabled while graph_indexing
     # is true so this is not reachable by clicking, but a forged or raced event
-    # would otherwise start a second task and overwrite graph_task_ref: the
-    # first completion would then demonitor the *second* task, dropping its
+    # would otherwise start a second task and overwrite graph_task: the first
+    # completion would then demonitor the *second* task, dropping its
     # failure monitoring and clearing the spinner out from under it.
     def handle_event("build_graph", _params, %{assigns: %{graph_indexing: true}} = socket) do
       {:noreply, socket}
@@ -303,36 +303,42 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       collection = document.collection
       repo = socket.assigns.repo
       parent = self()
+      run_ref = make_ref()
 
       started =
-        ArcanaWeb.TaskSupervisor.start_child(fn ->
-          # The task is supervised, not linked to this LiveView, so a failure
-          # in here dies silently: no {:graph_complete, _} arrives and
-          # graph_indexing stays true, spinning forever. Report it instead.
-          #
-          # `catch` rather than `rescue`, for the reason Arcana.Ingest gives at
-          # build_graph_or_fail_document/5: an extractor or store is as free to
-          # throw or exit as to raise, and a GenServer.call timeout exits. A
-          # rescue here left an exiting extractor stranding the spinner exactly
-          # the way the missing schema did.
-          result =
-            try do
-              Arcana.Graph.build_and_persist(chunks, collection, repo, [])
-            catch
-              kind, reason ->
-                Logger.error(
-                  "Arcana: graph build failed for document #{document.id}: " <>
-                    Exception.format(kind, reason, __STACKTRACE__)
-                )
+        ArcanaWeb.BackgroundTask.start(
+          parent,
+          :graph_complete,
+          fn ->
+            # The task is supervised, not linked to this LiveView, so a failure
+            # in here dies silently: no {:graph_complete, _} arrives and
+            # graph_indexing stays true, spinning forever. Report it instead.
+            #
+            # `catch` rather than `rescue`, for the reason Arcana.Ingest gives at
+            # build_graph_or_fail_document/5: an extractor or store is as free to
+            # throw or exit as to raise, and a GenServer.call timeout exits. A
+            # rescue here left an exiting extractor stranding the spinner exactly
+            # the way the missing schema did.
+            result =
+              try do
+                Arcana.Graph.build_and_persist(chunks, collection, repo, [])
+              catch
+                kind, reason ->
+                  Logger.error(
+                    "Arcana: graph build failed for document #{document.id}: " <>
+                      Exception.format(kind, reason, __STACKTRACE__)
+                  )
 
-                {:error, Exception.format_banner(kind, reason)}
-            end
+                  {:error, Exception.format_banner(kind, reason)}
+              end
 
-          send(parent, {:graph_complete, result})
-        end)
+            result
+          end,
+          run_ref: run_ref
+        )
 
       case started do
-        {:ok, task_pid} ->
+        {:ok, task} ->
           # The catch above enumerates the ways the build itself fails. A
           # monitor covers the ways it stops without running our code at all -
           # the supervisor shutting the task down, an external kill, the node
@@ -342,8 +348,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           # The ref is kept so the DOWN clause can tell this task's death from
           # any other monitor's: clearing the spinner on someone else's DOWN
           # would flash a graph error for an unrelated process.
-          {:noreply,
-           assign(socket, graph_indexing: true, graph_task_ref: Process.monitor(task_pid))}
+          {:noreply, assign(socket, graph_indexing: true, graph_task: task)}
 
         {:error, reason} ->
           # The supervisor can refuse (max_children, or it is not running).
@@ -353,7 +358,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           Logger.error("Arcana: could not start the graph build task: #{inspect(reason)}")
 
           {:noreply,
-           put_flash(socket, :error, "Could not start the graph build: #{inspect(reason)}")}
+           socket
+           |> assign(graph_indexing: false, graph_task: nil)
+           |> put_flash(:error, "Could not start the graph build: #{inspect(reason)}")}
       end
     end
 
@@ -395,12 +402,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     @impl true
     def handle_info(
           {:DOWN, ref, :process, _pid, reason},
-          %{assigns: %{graph_task_ref: ref}} = socket
-        )
-        when reason != :normal do
+          %{assigns: %{graph_task: %{monitor_ref: ref}}} = socket
+        ) do
       {:noreply,
        socket
-       |> assign(graph_indexing: false, graph_task_ref: nil)
+       |> assign(graph_indexing: false, graph_task: nil)
        |> put_flash(:error, "Graph build stopped: #{inspect(reason)}")}
     end
 
@@ -408,12 +414,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     def handle_info({:DOWN, _ref, :process, _pid, _reason}, socket), do: {:noreply, socket}
 
     @impl true
-    def handle_info({:graph_complete, result}, socket) do
+    def handle_info(
+          {:graph_complete, run_ref, result},
+          %{assigns: %{graph_task: %{run_ref: run_ref, monitor_ref: monitor_ref}}} = socket
+        ) do
       # The task reported, so its DOWN carries no information. Flush it rather
       # than leaving a stale message to be matched against a later build's ref.
-      if ref = socket.assigns.graph_task_ref, do: Process.demonitor(ref, [:flush])
+      Process.demonitor(monitor_ref, [:flush])
 
-      socket = assign(socket, graph_task_ref: nil)
+      socket = assign(socket, graph_task: nil)
 
       socket =
         case result do
@@ -433,6 +442,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
       {:noreply, socket}
     end
+
+    def handle_info({:graph_complete, _run_ref, _result}, socket), do: {:noreply, socket}
 
     @impl true
     def render(assigns) do

--- a/lib/arcana_web/live/evaluation_live.ex
+++ b/lib/arcana_web/live/evaluation_live.ex
@@ -23,7 +23,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
        |> assign(
          eval_view: :test_cases,
          eval_running: false,
+         eval_run_task: nil,
          eval_generating: false,
+         eval_generate_task: nil,
          eval_progress: nil,
          eval_tick: 0,
          eval_message: nil,
@@ -81,6 +83,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       {:noreply, assign(socket, eval_view: parse_eval_view(view))}
     end
 
+    def handle_event("eval_run", _params, %{assigns: %{eval_running: true}} = socket) do
+      {:noreply, socket}
+    end
+
     def handle_event("eval_run", params, socket) do
       mode = parse_mode(params["mode"])
       retriever_name = params["retriever"] || "pipeline"
@@ -106,6 +112,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         true ->
           {:noreply, start_eval_run(socket, mode, evaluate_answers, llm, retriever_name)}
       end
+    end
+
+    def handle_event("eval_generate", _params, %{assigns: %{eval_generating: true}} = socket) do
+      {:noreply, socket}
     end
 
     def handle_event("eval_generate", params, socket) do
@@ -175,7 +185,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       opts = Keyword.put(opts, :run_ref, run_ref)
 
       parent = self()
-      handler_id = "eval-progress-#{inspect(parent)}"
+      handler_id = "eval-progress-#{inspect(run_ref)}"
 
       :telemetry.attach_many(
         handler_id,
@@ -185,25 +195,36 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         ],
         fn event, measurements, metadata, _config ->
           if metadata[:run_ref] == run_ref do
-            send(parent, {:eval_progress, event, measurements, metadata})
+            send(parent, {:eval_progress, run_ref, event, measurements, metadata})
           end
         end,
         nil
       )
 
-      Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
-        result = Evaluation.run(opts)
-        :telemetry.detach(handler_id)
-        send(parent, {:eval_run_complete, result})
-      end)
+      cleanup = fn -> :telemetry.detach(handler_id) end
 
-      # Self-tick every second so the elapsed-time counter updates live
-      # while a test case is in flight. LiveView only re-renders on
-      # messages; without a tick the elapsed-time label freezes at
-      # whatever it was when the last telemetry event fired.
-      Process.send_after(self(), :eval_tick, 1000)
+      case ArcanaWeb.BackgroundTask.start(
+             parent,
+             :eval_run_complete,
+             fn -> Evaluation.run(opts) end,
+             run_ref: run_ref,
+             cleanup: cleanup
+           ) do
+        {:ok, task} ->
+          # Self-tick every second so the elapsed-time counter updates live
+          # while a test case is in flight. LiveView only re-renders on
+          # messages; without a tick the elapsed display freezes.
+          Process.send_after(self(), :eval_tick, 1000)
+          assign(socket, eval_run_task: task)
 
-      socket
+        {:error, reason} ->
+          assign(socket,
+            eval_running: false,
+            eval_run_task: nil,
+            eval_progress: nil,
+            eval_message: {:error, "Could not start evaluation: #{inspect(reason)}"}
+          )
+      end
     end
 
     # nil means "sample from every collection", which restricted dashboards
@@ -228,11 +249,25 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
           parent = self()
           opts = build_generate_opts(repo, llm, sample_size, collection)
+          run_ref = make_ref()
 
-          Task.Supervisor.start_child(ArcanaWeb.TaskSupervisor, fn ->
-            result = Evaluation.generate_test_cases(opts)
-            send(parent, {:eval_generate_complete, result})
-          end)
+          socket =
+            case ArcanaWeb.BackgroundTask.start(
+                   parent,
+                   :eval_generate_complete,
+                   fn -> Evaluation.generate_test_cases(opts) end,
+                   run_ref: run_ref
+                 ) do
+              {:ok, task} ->
+                assign(socket, eval_generate_task: task)
+
+              {:error, reason} ->
+                assign(socket,
+                  eval_generating: false,
+                  eval_generate_task: nil,
+                  eval_message: {:error, "Could not start generation: #{inspect(reason)}"}
+                )
+            end
 
           {:noreply, socket}
       end
@@ -251,7 +286,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       end
     end
 
-    def handle_info({:eval_progress, event, _measurements, metadata}, socket) do
+    def handle_info(
+          {:eval_progress, run_ref, event, _measurements, metadata},
+          %{assigns: %{eval_run_task: %{run_ref: run_ref}}} = socket
+        ) do
       %{index: index, total: total, question: question} = metadata
 
       base =
@@ -275,13 +313,19 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       {:noreply, assign(socket, eval_progress: progress)}
     end
 
-    def handle_info({:eval_run_complete, result}, socket) do
+    def handle_info(
+          {:eval_run_complete, run_ref, result},
+          %{assigns: %{eval_run_task: %{run_ref: run_ref, monitor_ref: monitor_ref}}} = socket
+        ) do
+      Process.demonitor(monitor_ref, [:flush])
+
       socket =
         case result do
           {:ok, _run} ->
             socket
             |> assign(
               eval_running: false,
+              eval_run_task: nil,
               eval_progress: nil,
               eval_message: {:success, "Evaluation completed!"}
             )
@@ -291,6 +335,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           {:error, :no_test_cases} ->
             assign(socket,
               eval_running: false,
+              eval_run_task: nil,
               eval_progress: nil,
               eval_message: {:error, "No test cases. Generate some first."}
             )
@@ -304,6 +349,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
             assign(socket,
               eval_running: false,
+              eval_run_task: nil,
               eval_progress: nil,
               eval_message: {:error, "Evaluation failed: #{inspect(other)}"}
             )
@@ -312,13 +358,23 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       {:noreply, socket}
     end
 
-    def handle_info({:eval_generate_complete, result}, socket) do
+    def handle_info(
+          {:eval_generate_complete, run_ref, result},
+          %{
+            assigns: %{
+              eval_generate_task: %{run_ref: run_ref, monitor_ref: monitor_ref}
+            }
+          } = socket
+        ) do
+      Process.demonitor(monitor_ref, [:flush])
+
       socket =
         case result do
           {:ok, test_cases} ->
             socket
             |> assign(
               eval_generating: false,
+              eval_generate_task: nil,
               eval_message: {:success, "Generated #{length(test_cases)} test case(s)!"}
             )
             |> load_evaluation_data()
@@ -326,12 +382,45 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           {:error, reason} ->
             assign(socket,
               eval_generating: false,
+              eval_generate_task: nil,
               eval_message: {:error, "Generation failed: #{inspect(reason)}"}
             )
         end
 
       {:noreply, socket}
     end
+
+    def handle_info(
+          {:DOWN, monitor_ref, :process, _pid, reason},
+          %{assigns: %{eval_run_task: %{monitor_ref: monitor_ref}}} = socket
+        ) do
+      {:noreply,
+       assign(socket,
+         eval_running: false,
+         eval_run_task: nil,
+         eval_progress: nil,
+         eval_message: {:error, "Evaluation task stopped: #{inspect(reason)}"}
+       )}
+    end
+
+    def handle_info(
+          {:DOWN, monitor_ref, :process, _pid, reason},
+          %{assigns: %{eval_generate_task: %{monitor_ref: monitor_ref}}} = socket
+        ) do
+      {:noreply,
+       assign(socket,
+         eval_generating: false,
+         eval_generate_task: nil,
+         eval_message: {:error, "Generation task stopped: #{inspect(reason)}"}
+       )}
+    end
+
+    def handle_info({tag, _run_ref, _result}, socket)
+        when tag in [:eval_run_complete, :eval_generate_complete],
+        do: {:noreply, socket}
+
+    def handle_info({:eval_progress, _run_ref, _event, _measurements, _metadata}, socket),
+      do: {:noreply, socket}
 
     defp build_run_opts(socket, mode, evaluate_answers, llm, retriever_name) do
       repo = socket.assigns.repo

--- a/lib/arcana_web/live/evaluation_live.ex
+++ b/lib/arcana_web/live/evaluation_live.ex
@@ -74,7 +74,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp eval_opts(socket) do
       case socket.assigns.allowed_collections do
         :all -> [repo: socket.assigns.repo]
-        allowed when is_list(allowed) -> [repo: socket.assigns.repo, collections: allowed]
+        allowed when is_list(allowed) -> [repo: socket.assigns.repo, collection: allowed]
       end
     end
 
@@ -440,7 +440,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp maybe_put_eval_scope(opts, :all), do: opts
 
     defp maybe_put_eval_scope(opts, allowed) when is_list(allowed),
-      do: Keyword.merge(opts, collections: allowed, strict_collections: true)
+      do: Keyword.merge(opts, collection: allowed, strict_collections: true)
 
     defp maybe_put_evaluate_answers(opts, false, _llm), do: opts
 
@@ -481,7 +481,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp loop_new_opts(repo, :all), do: [repo: repo]
 
     defp loop_new_opts(repo, allowed) when is_list(allowed),
-      do: [repo: repo, collections: allowed]
+      do: [repo: repo, collection: allowed]
 
     defp loop_run_opts(llm, :all), do: [controller_llm: llm]
 

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -806,7 +806,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp entities_view(assigns) do
       ~H"""
       <div class="arcana-entities-view">
-        <form phx-change="filter_entities" class="arcana-filter-bar">
+        <form id="graph-entity-filter-form" phx-change="filter_entities" class="arcana-filter-bar">
           <input
             type="text"
             name="name"
@@ -934,7 +934,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp relationships_view(assigns) do
       ~H"""
       <div class="arcana-relationships-view">
-        <form phx-change="filter_relationships" class="arcana-filter-bar">
+        <form
+          id="graph-relationship-filter-form"
+          phx-change="filter_relationships"
+          class="arcana-filter-bar"
+        >
           <input
             type="text"
             name="search"
@@ -1037,7 +1041,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp communities_view(assigns) do
       ~H"""
       <div class="arcana-communities-view">
-        <form phx-change="filter_communities" class="arcana-filter-bar">
+        <form
+          id="graph-community-filter-form"
+          phx-change="filter_communities"
+          class="arcana-filter-bar"
+        >
           <input
             type="text"
             name="search"

--- a/lib/arcana_web/live/graph_live.ex
+++ b/lib/arcana_web/live/graph_live.ex
@@ -17,7 +17,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     import ArcanaWeb.DashboardComponents
     import Ecto.Query
 
-    alias Arcana.Graph.{Community, Entity, GraphStore, Relationship}
+    alias Arcana.Graph.{Community, Entity, GraphStore}
+    alias Arcana.RetrievalScope
 
     @page_size 50
 
@@ -209,7 +210,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     defp count_entities(repo, collection_id, name_filter, type_filter) do
-      query = from(e in Entity, select: count(e.id))
+      query = from([entity: e] in RetrievalScope.entities(), select: count(e.id))
 
       query =
         if collection_id, do: where(query, [e], e.collection_id == ^collection_id), else: query
@@ -231,7 +232,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_entity_types(repo, collection_id) do
       query =
-        from(e in Entity,
+        from([entity: e] in RetrievalScope.entities(),
           group_by: e.type,
           select: %{type: e.type, count: count(e.id)},
           order_by: [desc: count(e.id), asc: e.type]
@@ -248,7 +249,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp load_relationship_types(repo, collection_id) do
       query =
-        from(r in Relationship,
+        from([relationship: r] in RetrievalScope.relationships(),
           join: source in Entity,
           on: source.id == r.source_id,
           group_by: r.type,
@@ -314,7 +315,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp count_relationships(repo, collection_id, search_filter, type_filter, strength_filter) do
       query =
-        from(r in Relationship,
+        from([relationship: r] in RetrievalScope.relationships(),
           join: source in Entity,
           on: source.id == r.source_id,
           select: count(r.id)

--- a/lib/arcana_web/live/maintenance_live.ex
+++ b/lib/arcana_web/live/maintenance_live.ex
@@ -27,17 +27,21 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
        |> assign(graph_installed: Arcana.Graph.installed?(repo))
        |> assign(
          reembed_running: false,
+         reembed_task: nil,
          reembed_progress: nil,
          reembed_collection: nil,
          embedding_info: get_embedding_info(),
          rebuild_graph_running: false,
+         rebuild_graph_task: nil,
          rebuild_graph_progress: nil,
          rebuild_graph_collection: nil,
          graph_info: get_graph_info(),
          detect_communities_running: false,
+         detect_communities_task: nil,
          detect_communities_progress: nil,
          detect_communities_collection: nil,
          summarize_communities_running: false,
+         summarize_communities_task: nil,
          summarize_communities_progress: nil,
          summarize_communities_collection: nil,
          llm_configured?: not is_nil(Arcana.Config.get_env(:llm)),
@@ -202,6 +206,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       end
     end
 
+    def handle_event("reembed", _params, %{assigns: %{reembed_running: true}} = socket) do
+      {:noreply, socket}
+    end
+
     def handle_event("reembed", _params, socket) do
       case validate_maintenance_collection(socket, socket.assigns.reembed_collection) do
         {:ok, collection} -> {:noreply, start_reembed(socket, collection)}
@@ -216,6 +224,14 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         {:ok, collection} -> {:noreply, assign(socket, rebuild_graph_collection: collection)}
         :error -> {:noreply, socket}
       end
+    end
+
+    def handle_event(
+          "rebuild_graph",
+          _params,
+          %{assigns: %{rebuild_graph_running: true}} = socket
+        ) do
+      {:noreply, socket}
     end
 
     def handle_event("rebuild_graph", _params, socket) do
@@ -239,6 +255,14 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         :error ->
           {:noreply, socket}
       end
+    end
+
+    def handle_event(
+          "detect_communities",
+          _params,
+          %{assigns: %{detect_communities_running: true}} = socket
+        ) do
+      {:noreply, socket}
     end
 
     def handle_event("detect_communities", _params, socket) do
@@ -265,6 +289,14 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         :error ->
           {:noreply, socket}
       end
+    end
+
+    def handle_event(
+          "summarize_communities",
+          _params,
+          %{assigns: %{summarize_communities_running: true}} = socket
+        ) do
+      {:noreply, socket}
     end
 
     def handle_event("summarize_communities", _params, socket) do
@@ -346,25 +378,37 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp start_reembed(socket, collection) do
       repo = socket.assigns.repo
       parent = self()
+      run_ref = make_ref()
 
       socket = assign(socket, reembed_running: true, reembed_progress: %{current: 0, total: 0})
 
-      ArcanaWeb.TaskSupervisor.start_child(fn ->
-        progress_fn = fn current, total ->
-          send(parent, {:reembed_progress, current, total})
-        end
+      case ArcanaWeb.BackgroundTask.start(
+             parent,
+             :reembed_complete,
+             fn ->
+               progress_fn = progress_sender(parent, :reembed_progress, run_ref)
 
-        opts = maintenance_collection_opts([batch_size: 50, progress: progress_fn], collection)
-        result = safely(fn -> Arcana.Maintenance.reembed(repo, opts) end)
-        send(parent, {:reembed_complete, result})
-      end)
+               opts =
+                 maintenance_collection_opts([batch_size: 50, progress: progress_fn], collection)
 
-      socket
+               safely(fn -> Arcana.Maintenance.reembed(repo, opts) end)
+             end,
+             run_ref: run_ref
+           ) do
+        {:ok, task} ->
+          assign(socket, reembed_task: task)
+
+        {:error, reason} ->
+          socket
+          |> assign(reembed_running: false, reembed_task: nil, reembed_progress: nil)
+          |> put_flash(:error, "Could not start re-embedding: #{inspect(reason)}")
+      end
     end
 
     defp start_rebuild_graph(socket, collection) do
       repo = socket.assigns.repo
       parent = self()
+      run_ref = make_ref()
 
       socket =
         assign(socket,
@@ -372,20 +416,35 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           rebuild_graph_progress: %{current: 0, total: 0}
         )
 
-      ArcanaWeb.TaskSupervisor.start_child(fn ->
-        progress_fn = progress_sender(parent, :rebuild_graph_progress)
+      case ArcanaWeb.BackgroundTask.start(
+             parent,
+             :rebuild_graph_complete,
+             fn ->
+               progress_fn = progress_sender(parent, :rebuild_graph_progress, run_ref)
 
-        opts = maintenance_collection_opts([progress: progress_fn], collection)
-        result = safely(fn -> Arcana.Maintenance.rebuild_graph(repo, opts) end)
-        send(parent, {:rebuild_graph_complete, result})
-      end)
+               opts = maintenance_collection_opts([progress: progress_fn], collection)
+               safely(fn -> Arcana.Maintenance.rebuild_graph(repo, opts) end)
+             end,
+             run_ref: run_ref
+           ) do
+        {:ok, task} ->
+          assign(socket, rebuild_graph_task: task)
 
-      socket
+        {:error, reason} ->
+          socket
+          |> assign(
+            rebuild_graph_running: false,
+            rebuild_graph_task: nil,
+            rebuild_graph_progress: nil
+          )
+          |> put_flash(:error, "Could not start graph rebuild: #{inspect(reason)}")
+      end
     end
 
     defp start_detect_communities(socket, collection) do
       repo = socket.assigns.repo
       parent = self()
+      run_ref = make_ref()
 
       socket =
         assign(socket,
@@ -393,15 +452,29 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           detect_communities_progress: %{current: 0, total: 0}
         )
 
-      ArcanaWeb.TaskSupervisor.start_child(fn ->
-        progress_fn = progress_sender(parent, :detect_communities_progress)
+      case ArcanaWeb.BackgroundTask.start(
+             parent,
+             :detect_communities_complete,
+             fn ->
+               progress_fn = progress_sender(parent, :detect_communities_progress, run_ref)
 
-        opts = maintenance_collection_opts([progress: progress_fn], collection)
-        result = safely(fn -> Arcana.Maintenance.detect_communities(repo, opts) end)
-        send(parent, {:detect_communities_complete, result})
-      end)
+               opts = maintenance_collection_opts([progress: progress_fn], collection)
+               safely(fn -> Arcana.Maintenance.detect_communities(repo, opts) end)
+             end,
+             run_ref: run_ref
+           ) do
+        {:ok, task} ->
+          assign(socket, detect_communities_task: task)
 
-      socket
+        {:error, reason} ->
+          socket
+          |> assign(
+            detect_communities_running: false,
+            detect_communities_task: nil,
+            detect_communities_progress: nil
+          )
+          |> put_flash(:error, "Could not start community detection: #{inspect(reason)}")
+      end
     end
 
     # A collection name with no row resolves to "no filter", which silently
@@ -430,31 +503,48 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp start_summarize_communities(socket, collection) do
       repo = socket.assigns.repo
       parent = self()
+      run_ref = make_ref()
 
-      ArcanaWeb.TaskSupervisor.start_child(fn ->
-        progress_fn = progress_sender(parent, :summarize_communities_progress)
+      socket =
+        assign(socket,
+          summarize_communities_running: true,
+          summarize_communities_progress: %{current: 0, total: 0}
+        )
 
-        opts = maintenance_collection_opts([progress: progress_fn], collection)
+      case ArcanaWeb.BackgroundTask.start(
+             parent,
+             :summarize_communities_complete,
+             fn ->
+               progress_fn = progress_sender(parent, :summarize_communities_progress, run_ref)
 
-        result = safely(fn -> Arcana.Maintenance.summarize_communities(repo, opts) end)
+               opts = maintenance_collection_opts([progress: progress_fn], collection)
 
-        send(parent, {:summarize_communities_complete, result})
-      end)
+               safely(fn -> Arcana.Maintenance.summarize_communities(repo, opts) end)
+             end,
+             run_ref: run_ref
+           ) do
+        {:ok, task} ->
+          assign(socket, summarize_communities_task: task)
 
-      assign(socket,
-        summarize_communities_running: true,
-        summarize_communities_progress: %{current: 0, total: 0}
-      )
+        {:error, reason} ->
+          socket
+          |> assign(
+            summarize_communities_running: false,
+            summarize_communities_task: nil,
+            summarize_communities_progress: nil
+          )
+          |> put_flash(:error, "Could not start community summarization: #{inspect(reason)}")
+      end
     end
 
     # Maintenance progress callbacks are called both with numeric
     # `current, total` and with `stage, payload` pairs (`:collection_start`
     # and friends). Only the numeric form drives the progress bar; the
     # stage form is ignored so the callers fall back to numeric progress.
-    defp progress_sender(parent, tag) do
+    defp progress_sender(parent, tag, run_ref) do
       fn
         current, total when is_integer(current) and is_integer(total) ->
-          send(parent, {tag, current, total})
+          send(parent, {tag, run_ref, current, total})
 
         _stage, _payload ->
           :ok
@@ -499,37 +589,59 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     @impl true
-    def handle_info({:reembed_progress, current, total}, socket) do
+    def handle_info(
+          {:reembed_progress, run_ref, current, total},
+          %{assigns: %{reembed_task: %{run_ref: run_ref}}} = socket
+        ) do
       {:noreply, assign(socket, reembed_progress: %{current: current, total: total})}
     end
 
-    def handle_info({:reembed_complete, result}, socket) do
+    def handle_info(
+          {:reembed_complete, run_ref, result},
+          %{assigns: %{reembed_task: %{run_ref: run_ref, monitor_ref: monitor_ref}}} = socket
+        ) do
+      Process.demonitor(monitor_ref, [:flush])
+
       socket =
         case result do
           {:ok, %{reembedded: count}} ->
             socket
-            |> assign(reembed_running: false, reembed_progress: nil)
+            |> assign(reembed_running: false, reembed_task: nil, reembed_progress: nil)
             |> put_flash(:info, "Re-embedded #{count} chunks successfully!")
 
           {:error, reason} ->
             socket
-            |> assign(reembed_running: false, reembed_progress: nil)
+            |> assign(reembed_running: false, reembed_task: nil, reembed_progress: nil)
             |> put_flash(:error, "Re-embedding failed: #{inspect(reason)}")
         end
 
       {:noreply, socket}
     end
 
-    def handle_info({:rebuild_graph_progress, current, total}, socket) do
+    def handle_info(
+          {:rebuild_graph_progress, run_ref, current, total},
+          %{assigns: %{rebuild_graph_task: %{run_ref: run_ref}}} = socket
+        ) do
       {:noreply, assign(socket, rebuild_graph_progress: %{current: current, total: total})}
     end
 
-    def handle_info({:rebuild_graph_complete, result}, socket) do
+    def handle_info(
+          {:rebuild_graph_complete, run_ref, result},
+          %{
+            assigns: %{rebuild_graph_task: %{run_ref: run_ref, monitor_ref: monitor_ref}}
+          } = socket
+        ) do
+      Process.demonitor(monitor_ref, [:flush])
+
       socket =
         case result do
           {:ok, %{entities: entities, relationships: relationships}} ->
             socket
-            |> assign(rebuild_graph_running: false, rebuild_graph_progress: nil)
+            |> assign(
+              rebuild_graph_running: false,
+              rebuild_graph_task: nil,
+              rebuild_graph_progress: nil
+            )
             |> load_data()
             |> put_flash(
               :info,
@@ -538,57 +650,171 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
           {:error, reason} ->
             socket
-            |> assign(rebuild_graph_running: false, rebuild_graph_progress: nil)
+            |> assign(
+              rebuild_graph_running: false,
+              rebuild_graph_task: nil,
+              rebuild_graph_progress: nil
+            )
             |> put_flash(:error, "Rebuild graph failed: #{inspect(reason)}")
         end
 
       {:noreply, socket}
     end
 
-    def handle_info({:detect_communities_progress, current, total}, socket) do
+    def handle_info(
+          {:detect_communities_progress, run_ref, current, total},
+          %{assigns: %{detect_communities_task: %{run_ref: run_ref}}} = socket
+        ) do
       {:noreply, assign(socket, detect_communities_progress: %{current: current, total: total})}
     end
 
-    def handle_info({:detect_communities_complete, result}, socket) do
+    def handle_info(
+          {:detect_communities_complete, run_ref, result},
+          %{
+            assigns: %{
+              detect_communities_task: %{run_ref: run_ref, monitor_ref: monitor_ref}
+            }
+          } = socket
+        ) do
+      Process.demonitor(monitor_ref, [:flush])
+
       socket =
         case result do
           {:ok, %{communities: communities}} ->
             socket
-            |> assign(detect_communities_running: false, detect_communities_progress: nil)
+            |> assign(
+              detect_communities_running: false,
+              detect_communities_task: nil,
+              detect_communities_progress: nil
+            )
             |> load_data()
             |> put_flash(:info, "Detected #{communities} communities successfully!")
 
           {:error, reason} ->
             socket
-            |> assign(detect_communities_running: false, detect_communities_progress: nil)
+            |> assign(
+              detect_communities_running: false,
+              detect_communities_task: nil,
+              detect_communities_progress: nil
+            )
             |> put_flash(:error, "Community detection failed: #{inspect(reason)}")
         end
 
       {:noreply, socket}
     end
 
-    def handle_info({:summarize_communities_progress, current, total}, socket) do
+    def handle_info(
+          {:summarize_communities_progress, run_ref, current, total},
+          %{assigns: %{summarize_communities_task: %{run_ref: run_ref}}} = socket
+        ) do
       {:noreply,
        assign(socket, summarize_communities_progress: %{current: current, total: total})}
     end
 
-    def handle_info({:summarize_communities_complete, result}, socket) do
+    def handle_info(
+          {:summarize_communities_complete, run_ref, result},
+          %{
+            assigns: %{
+              summarize_communities_task: %{run_ref: run_ref, monitor_ref: monitor_ref}
+            }
+          } = socket
+        ) do
+      Process.demonitor(monitor_ref, [:flush])
+
       socket =
         case result do
           {:ok, %{summaries: summaries}} ->
             socket
-            |> assign(summarize_communities_running: false, summarize_communities_progress: nil)
+            |> assign(
+              summarize_communities_running: false,
+              summarize_communities_task: nil,
+              summarize_communities_progress: nil
+            )
             |> load_data()
             |> put_flash(:info, "Summarized #{summaries} communities successfully!")
 
           {:error, reason} ->
             socket
-            |> assign(summarize_communities_running: false, summarize_communities_progress: nil)
+            |> assign(
+              summarize_communities_running: false,
+              summarize_communities_task: nil,
+              summarize_communities_progress: nil
+            )
             |> put_flash(:error, "Community summarization failed: #{inspect(reason)}")
         end
 
       {:noreply, socket}
     end
+
+    def handle_info(
+          {:DOWN, monitor_ref, :process, _pid, reason},
+          %{assigns: %{reembed_task: %{monitor_ref: monitor_ref}}} = socket
+        ) do
+      {:noreply,
+       socket
+       |> assign(reembed_running: false, reembed_task: nil, reembed_progress: nil)
+       |> put_flash(:error, "Re-embedding task stopped: #{inspect(reason)}")}
+    end
+
+    def handle_info(
+          {:DOWN, monitor_ref, :process, _pid, reason},
+          %{assigns: %{rebuild_graph_task: %{monitor_ref: monitor_ref}}} = socket
+        ) do
+      {:noreply,
+       socket
+       |> assign(
+         rebuild_graph_running: false,
+         rebuild_graph_task: nil,
+         rebuild_graph_progress: nil
+       )
+       |> put_flash(:error, "Graph rebuild task stopped: #{inspect(reason)}")}
+    end
+
+    def handle_info(
+          {:DOWN, monitor_ref, :process, _pid, reason},
+          %{assigns: %{detect_communities_task: %{monitor_ref: monitor_ref}}} = socket
+        ) do
+      {:noreply,
+       socket
+       |> assign(
+         detect_communities_running: false,
+         detect_communities_task: nil,
+         detect_communities_progress: nil
+       )
+       |> put_flash(:error, "Community detection task stopped: #{inspect(reason)}")}
+    end
+
+    def handle_info(
+          {:DOWN, monitor_ref, :process, _pid, reason},
+          %{assigns: %{summarize_communities_task: %{monitor_ref: monitor_ref}}} = socket
+        ) do
+      {:noreply,
+       socket
+       |> assign(
+         summarize_communities_running: false,
+         summarize_communities_task: nil,
+         summarize_communities_progress: nil
+       )
+       |> put_flash(:error, "Community summarization task stopped: #{inspect(reason)}")}
+    end
+
+    def handle_info({tag, _run_ref, _result}, socket)
+        when tag in [
+               :reembed_complete,
+               :rebuild_graph_complete,
+               :detect_communities_complete,
+               :summarize_communities_complete
+             ],
+        do: {:noreply, socket}
+
+    def handle_info({tag, _run_ref, _current, _total}, socket)
+        when tag in [
+               :reembed_progress,
+               :rebuild_graph_progress,
+               :detect_communities_progress,
+               :summarize_communities_progress
+             ],
+        do: {:noreply, socket}
 
     @impl true
     def render(assigns) do

--- a/lib/arcana_web/live/search_live.ex
+++ b/lib/arcana_web/live/search_live.ex
@@ -178,27 +178,33 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     defp add_source_id_opt(opts, source_id), do: Keyword.put(opts, :source_id, source_id)
 
     defp requested_collection_scope(nil, allowed),
-      do: {:ok, collection_scope_opts(allowed, :all)}
+      do: {:ok, collection_scope_opts(CollectionScope.normalize!(allowed))}
 
     defp requested_collection_scope(collections, allowed) when is_list(collections) do
       requested = Enum.reject(collections, &(&1 == ""))
-      requested = if requested == [], do: :all, else: requested
-      {:ok, collection_scope_opts(allowed, requested)}
+
+      case requested do
+        [] ->
+          {:ok, collection_scope_opts(CollectionScope.normalize!(allowed))}
+
+        names ->
+          requested_scope = CollectionScope.normalize!(names)
+          allowed_scope = CollectionScope.normalize!(allowed)
+
+          if CollectionScope.subset?(requested_scope, allowed_scope) do
+            {:ok, collection_scope_opts(requested_scope)}
+          else
+            :error
+          end
+      end
     rescue
       ArgumentError -> :error
     end
 
     defp requested_collection_scope(_collections, _allowed), do: :error
 
-    defp collection_scope_opts(allowed, requested) do
-      requested_scope = CollectionScope.normalize!(requested)
-      allowed_scope = CollectionScope.normalize!(allowed)
-
-      case CollectionScope.intersect(requested_scope, allowed_scope) do
-        :all -> [collection: :all]
-        {:only, names} -> [collections: names]
-      end
-    end
+    defp collection_scope_opts(:all), do: [collection: :all]
+    defp collection_scope_opts({:only, names}), do: [collection: names]
 
     @impl true
     def render(assigns) do

--- a/lib/arcana_web/live/search_live.ex
+++ b/lib/arcana_web/live/search_live.ex
@@ -11,7 +11,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     import ArcanaWeb.DashboardComponents
 
-    alias Arcana.Document
+    alias Arcana.{CollectionScope, Document}
+
+    import Ecto.Query
 
     @impl true
     def mount(_params, session, socket) do
@@ -76,50 +78,79 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     defp view_search_document(socket, id) do
       repo = socket.assigns.repo
-      import Ecto.Query
 
-      document_query = from(d in Document, where: d.id == ^id)
-
-      # Forged ids pointing outside the allowed collections resolve to
-      # nothing, same as a missing document.
-      document_query =
-        case socket.assigns.allowed_collections do
-          :all ->
-            document_query
-
-          names when is_list(names) ->
-            from(d in document_query, join: c in assoc(d, :collection), where: c.name in ^names)
-        end
-
-      case repo.one(document_query) do
-        nil ->
-          {:noreply, socket}
-
-        document ->
-          chunks =
-            repo.all(
-              from(c in Arcana.Chunk,
-                where: c.document_id == ^id,
-                order_by: c.chunk_index
-              )
-            )
+      case scoped_published_document(repo, id, socket.assigns.allowed_collections) do
+        {:ok, document} ->
+          chunks = scoped_published_chunks(repo, id, socket.assigns.allowed_collections)
 
           {:noreply, assign(socket, viewing_document: %{document: document, chunks: chunks})}
+
+        _ ->
+          {:noreply, socket}
+      end
+    end
+
+    defp scoped_published_document(repo, id, allowed) do
+      query =
+        Document
+        |> where([document], document.id == ^id and document.status == :completed)
+        |> apply_document_scope(allowed)
+        |> preload([:collection])
+
+      case repo.one(query) do
+        %Document{} = document -> {:ok, document}
+        nil -> {:error, :not_found}
+      end
+    end
+
+    defp scoped_published_chunks(repo, id, allowed) do
+      Arcana.Chunk
+      |> join(:inner, [chunk], document in assoc(chunk, :document))
+      |> where(
+        [chunk, document],
+        chunk.document_id == ^id and document.status == :completed
+      )
+      |> apply_chunk_scope(allowed)
+      |> order_by([chunk], chunk.chunk_index)
+      |> repo.all()
+    end
+
+    defp apply_document_scope(query, allowed) do
+      case CollectionScope.normalize!(allowed) do
+        :all ->
+          query
+
+        {:only, []} ->
+          where(query, [document], is_nil(document.id))
+
+        {:only, names} ->
+          query
+          |> join(:inner, [document], collection in assoc(document, :collection))
+          |> where([_document, collection], collection.name in ^names)
+      end
+    end
+
+    defp apply_chunk_scope(query, allowed) do
+      case CollectionScope.normalize!(allowed) do
+        :all ->
+          query
+
+        {:only, []} ->
+          where(query, [chunk, _document], is_nil(chunk.id))
+
+        {:only, names} ->
+          query
+          |> join(:inner, [_chunk, document], collection in assoc(document, :collection))
+          |> where([_chunk, _document, collection], collection.name in ^names)
       end
     end
 
     defp run_search("", _params, _repo, _allowed), do: []
 
     defp run_search(query, params, repo, allowed) do
-      requested = normalize_collections(params["collections"])
-
-      # Fail closed: a request naming any collection outside the allowed set
-      # refuses the whole search instead of silently narrowing it, and an
-      # empty allowed set never reaches Arcana.search/2 (where an empty
-      # collections option would mean "search everything").
-      case resolve_search_collections(requested, allowed) do
-        {:ok, collections} ->
-          opts = build_search_opts(params, repo, collections, allowed)
+      case requested_collection_scope(params["collections"], allowed) do
+        {:ok, collection_opts} ->
+          opts = build_search_opts(params, repo, collection_opts)
 
           case Arcana.search(query, opts) do
             {:ok, results} -> results
@@ -131,18 +162,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       end
     end
 
-    # Unrestricted: requested collections pass through untouched, [] keeps
-    # today's "search everything" behavior via add_collection_opt/2.
-    defp resolve_search_collections(requested, :all), do: {:ok, requested}
-
-    defp resolve_search_collections([], []), do: :error
-    defp resolve_search_collections([], allowed), do: {:ok, allowed}
-
-    defp resolve_search_collections(requested, allowed) do
-      if Enum.all?(requested, &(&1 in allowed)), do: {:ok, requested}, else: :error
-    end
-
-    defp build_search_opts(params, repo, collections, allowed) do
+    defp build_search_opts(params, repo, collection_opts) do
       [
         repo: repo,
         limit: parse_int(params["limit"], 10),
@@ -150,35 +170,35 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         mode: parse_mode(params["mode"])
       ]
       |> add_source_id_opt(params["source_id"])
-      |> add_collection_opt(collections)
-      |> add_strict_opt(allowed)
+      |> Keyword.merge(collection_opts)
     end
-
-    # Restricted dashboards search strictly. Without it an allowed name with
-    # no collection row (never created, or deleted mid-session) resolves to
-    # "no filter" and the search widens to every collection; strict turns
-    # that into {:error, {:unknown_collection, _}}, which run_search/4
-    # already renders as no results. Unrestricted dashboards keep the
-    # library default.
-    defp add_strict_opt(opts, :all), do: opts
-
-    defp add_strict_opt(opts, allowed) when is_list(allowed),
-      do: Keyword.put(opts, :strict_collections, true)
 
     defp add_source_id_opt(opts, nil), do: opts
     defp add_source_id_opt(opts, ""), do: opts
     defp add_source_id_opt(opts, source_id), do: Keyword.put(opts, :source_id, source_id)
 
-    defp add_collection_opt(opts, []), do: opts
-    defp add_collection_opt(opts, [single]), do: Keyword.put(opts, :collection, single)
-    defp add_collection_opt(opts, multiple), do: Keyword.put(opts, :collections, multiple)
+    defp requested_collection_scope(nil, allowed),
+      do: {:ok, collection_scope_opts(allowed, :all)}
 
-    defp normalize_collections(nil), do: []
+    defp requested_collection_scope(collections, allowed) when is_list(collections) do
+      requested = Enum.reject(collections, &(&1 == ""))
+      requested = if requested == [], do: :all, else: requested
+      {:ok, collection_scope_opts(allowed, requested)}
+    rescue
+      ArgumentError -> :error
+    end
 
-    defp normalize_collections(collections) when is_list(collections),
-      do: Enum.filter(collections, &(&1 != ""))
+    defp requested_collection_scope(_collections, _allowed), do: :error
 
-    defp normalize_collections(collection), do: [collection]
+    defp collection_scope_opts(allowed, requested) do
+      requested_scope = CollectionScope.normalize!(requested)
+      allowed_scope = CollectionScope.normalize!(allowed)
+
+      case CollectionScope.intersect(requested_scope, allowed_scope) do
+        :all -> [collection: :all]
+        {:only, names} -> [collections: names]
+      end
+    end
 
     @impl true
     def render(assigns) do

--- a/lib/arcana_web/router.ex
+++ b/lib/arcana_web/router.ex
@@ -35,10 +35,10 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
         once (say, a superuser dashboard plus a scoped one) needs a distinct
         name for each extra mount.
 
-      * `:collections` - Optional `{module, function}` pair that scopes the
+      * `:collection` - Optional `{module, function}` pair that scopes the
         dashboard to a subset of collections. The function receives the
-        `%Plug.Conn{}` of the page request and must return either `:all` (no
-        restriction) or a list of collection names. Every dashboard surface
+        `%Plug.Conn{}` of the page request and must return `:all`, one collection
+        name, a list of names, or `[]`. Every dashboard surface
         (listings, search, ask, ingest, evaluation, maintenance, stats) is
         limited to those collections, and events naming any other collection
         are rejected server-side. A plain `{module, function}` tuple is
@@ -55,7 +55,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     ## Scoping collections
 
         arcana_dashboard "/arcana",
-          collections: {MyAppWeb.ArcanaAccess, :allowed_collections}
+          collection: {MyAppWeb.ArcanaAccess, :allowed_collections}
 
         defmodule MyAppWeb.ArcanaAccess do
           def allowed_collections(conn) do
@@ -155,11 +155,16 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     def __options__(options, prefix) do
       live_socket_path = Keyword.get(options, :live_socket_path, "/live")
       repo = Keyword.get(options, :repo)
-      collections = options |> Keyword.get(:collections) |> validate_collections_option!()
+      collection = options |> Keyword.get(:collection) |> validate_collection_option!()
 
-      # The collections spec is only appended when given, so dashboards
+      if Keyword.has_key?(options, :collections) do
+        raise ArgumentError,
+              ":collections is not supported, pass the dashboard scope through :collection"
+      end
+
+      # The collection spec is only appended when given, so dashboards
       # without the option keep the exact session MFA they had before.
-      session_args = if collections, do: [repo, prefix, collections], else: [repo, prefix]
+      session_args = if collection, do: [repo, prefix, collection], else: [repo, prefix]
 
       {
         Keyword.get(options, :live_session_name, :arcana_dashboard),
@@ -175,15 +180,15 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       }
     end
 
-    defp validate_collections_option!(nil), do: nil
+    defp validate_collection_option!(nil), do: nil
 
-    defp validate_collections_option!({mod, fun} = spec) when is_atom(mod) and is_atom(fun),
+    defp validate_collection_option!({mod, fun} = spec) when is_atom(mod) and is_atom(fun),
       do: spec
 
-    defp validate_collections_option!(other) do
+    defp validate_collection_option!(other) do
       raise ArgumentError,
-            ":collections must be a {module, function} tuple where the function " <>
-              "accepts a Plug.Conn and returns :all or a list of collection names, " <>
+            ":collection must be a {module, function} tuple where the function " <>
+              "accepts a Plug.Conn and returns a collection scope, " <>
               "got: #{inspect(other)}"
     end
 
@@ -202,30 +207,20 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       |> Map.put("allowed_collections", resolve_allowed_collections(conn, collections_spec))
     end
 
-    # Fail closed: anything other than :all or a list of collection names
-    # raises instead of silently widening access.
     defp resolve_allowed_collections(conn, {mod, fun}) do
-      case apply(mod, fun, [conn]) do
-        :all ->
+      input = apply(mod, fun, [conn])
+
+      case Arcana.CollectionScope.normalize(input) do
+        {:ok, :all} ->
           :all
 
-        names when is_list(names) ->
-          validate_collection_names!(names, {mod, fun})
+        {:ok, {:only, names}} ->
+          names
 
-        other ->
+        {:error, _reason} ->
           raise ArgumentError,
-                "#{inspect(mod)}.#{fun}/1 must return :all or a list of collection " <>
-                  "names, got: #{inspect(other)}"
-      end
-    end
-
-    defp validate_collection_names!(names, {mod, fun}) do
-      if Enum.all?(names, &is_binary/1) do
-        names
-      else
-        raise ArgumentError,
-              "#{inspect(mod)}.#{fun}/1 returned a list with non-string entries: " <>
-                inspect(names)
+                "#{inspect(mod)}.#{fun}/1 must return :all, a collection name, " <>
+                  "or a list of collection names, got: #{inspect(input)}"
       end
     end
   end
@@ -236,7 +231,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     # Assigns the dashboard's mount prefix (e.g. "/admin/arcana") to every
     # dashboard LiveView so links and asset hrefs are built from the actual
     # mount point instead of assuming "/arcana", plus the allowed collections
-    # resolved by the router's :collections MFA (:all when the option is
+    # resolved by the router's :collection MFA (:all when the option is
     # absent). An empty list is a valid restriction and must not collapse to
     # :all, so only a missing session key falls back.
     #

--- a/lib/mix/tasks/arcana.graph.embed_entities.ex
+++ b/lib/mix/tasks/arcana.graph.embed_entities.ex
@@ -62,13 +62,12 @@ defmodule Mix.Tasks.Arcana.Graph.EmbedEntities do
         end
       end
 
-    embed_result =
-      Arcana.Maintenance.embed_entities(repo,
-        collection: collection,
-        batch_size: batch_size,
-        force: force,
-        progress: progress_fn
-      )
+    embed_opts = [batch_size: batch_size, force: force, progress: progress_fn]
+
+    embed_opts =
+      if collection, do: Keyword.put(embed_opts, :collection, collection), else: embed_opts
+
+    embed_result = Arcana.Maintenance.embed_entities(repo, embed_opts)
 
     total =
       case embed_result do

--- a/priv/test_repo/migrations/20260101000002_add_relationship_evidence.exs
+++ b/priv/test_repo/migrations/20260101000002_add_relationship_evidence.exs
@@ -7,6 +7,11 @@ defmodule Arcana.TestRepo.Migrations.AddRelationshipEvidence do
     # repo's upgrade behavior aligned with Arcana.Graph.Migration v2.
     execute("DELETE FROM arcana_graph_relationships")
 
+    execute(
+      "UPDATE arcana_graph_communities " <>
+        "SET dirty = true, summary = NULL, summary_fingerprint = NULL"
+    )
+
     alter table(:arcana_graph_relationships) do
       add(:fingerprint, :string, null: false)
     end

--- a/priv/test_repo/migrations/20260101000002_add_relationship_evidence.exs
+++ b/priv/test_repo/migrations/20260101000002_add_relationship_evidence.exs
@@ -1,7 +1,12 @@
 defmodule Arcana.TestRepo.Migrations.AddRelationshipEvidence do
   use Ecto.Migration
 
-  def change do
+  def up do
+    # v1 relationships have no chunk provenance, so they cannot be backfilled
+    # without making failed or replaced documents visible again. Keep the test
+    # repo's upgrade behavior aligned with Arcana.Graph.Migration v2.
+    execute("DELETE FROM arcana_graph_relationships")
+
     alter table(:arcana_graph_relationships) do
       add(:fingerprint, :string, null: false)
     end
@@ -33,5 +38,14 @@ defmodule Arcana.TestRepo.Migrations.AddRelationshipEvidence do
     )
 
     create(index(:arcana_graph_relationship_evidence, [:chunk_id]))
+  end
+
+  def down do
+    drop(table(:arcana_graph_relationship_evidence))
+    drop(index(:arcana_graph_relationships, [:fingerprint]))
+
+    alter table(:arcana_graph_relationships) do
+      remove(:fingerprint)
+    end
   end
 end

--- a/priv/test_repo/migrations/20260101000002_add_relationship_evidence.exs
+++ b/priv/test_repo/migrations/20260101000002_add_relationship_evidence.exs
@@ -1,0 +1,37 @@
+defmodule Arcana.TestRepo.Migrations.AddRelationshipEvidence do
+  use Ecto.Migration
+
+  def change do
+    alter table(:arcana_graph_relationships) do
+      add(:fingerprint, :string, null: false)
+    end
+
+    create(unique_index(:arcana_graph_relationships, [:fingerprint]))
+
+    create table(:arcana_graph_relationship_evidence, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(
+        :relationship_id,
+        references(:arcana_graph_relationships, type: :binary_id, on_delete: :delete_all),
+        null: false
+      )
+
+      add(
+        :chunk_id,
+        references(:arcana_chunks, type: :binary_id, on_delete: :delete_all),
+        null: false
+      )
+
+      timestamps(updated_at: false)
+    end
+
+    create(
+      unique_index(:arcana_graph_relationship_evidence, [:relationship_id, :chunk_id],
+        name: :arcana_graph_relationship_evidence_rel_chunk_index
+      )
+    )
+
+    create(index(:arcana_graph_relationship_evidence, [:chunk_id]))
+  end
+end

--- a/test/arcana/ask_test.exs
+++ b/test/arcana/ask_test.exs
@@ -71,7 +71,7 @@ defmodule Arcana.AskTest do
                Arcana.ask("What are the Daleks?",
                  repo: Repo,
                  llm: llm,
-                 collections: [],
+                 collection: [],
                  graph: true
                )
     end

--- a/test/arcana/ask_test.exs
+++ b/test/arcana/ask_test.exs
@@ -66,6 +66,16 @@ defmodule Arcana.AskTest do
                )
     end
 
+    test "an empty collection scope returns no context", %{llm: llm} do
+      assert {:ok, _answer, []} =
+               Arcana.ask("What are the Daleks?",
+                 repo: Repo,
+                 llm: llm,
+                 collections: [],
+                 graph: true
+               )
+    end
+
     test "uses custom prompt function", %{llm: llm} do
       custom_prompt = fn _question, _context ->
         "Custom system prompt"

--- a/test/arcana/ask_test.exs
+++ b/test/arcana/ask_test.exs
@@ -1,7 +1,7 @@
 defmodule Arcana.AskTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Graph.{Community, Entity, EntityMention, Relationship}
+  alias Arcana.Graph.{Community, Entity, EntityMention, Relationship, RelationshipEvidence}
 
   setup do
     {:ok, doc} =
@@ -160,6 +160,29 @@ defmodule Arcana.AskTest do
 
       assert system_prompt =~ "Background knowledge:"
       assert system_prompt =~ "greatest enemies"
+    end
+
+    test "does not inject a dirty community summary" do
+      Repo.update_all(Community, set: [dirty: true])
+      received = :ets.new(:received, [:set, :public])
+
+      capturing_llm = fn _prompt, _context, opts ->
+        :ets.insert(received, {:system_prompt, opts[:system_prompt]})
+        {:ok, "answer"}
+      end
+
+      {:ok, _, _} =
+        Arcana.ask("Who are the Daleks?",
+          repo: Repo,
+          llm: capturing_llm,
+          collection: "ask-test",
+          graph: true
+        )
+
+      [{:system_prompt, system_prompt}] = :ets.lookup(received, :system_prompt)
+      :ets.delete(received)
+
+      refute system_prompt =~ "greatest enemies"
     end
   end
 
@@ -355,21 +378,47 @@ defmodule Arcana.AskTest do
         |> Entity.changeset(%{name: "Carol", type: "person", collection_id: collection.id})
         |> Repo.insert!()
 
-      %Relationship{}
-      |> Relationship.changeset(%{
-        source_id: alice.id,
-        target_id: bob.id,
-        type: "knows"
-      })
-      |> Repo.insert!()
+      document =
+        %Arcana.Document{}
+        |> Arcana.Document.changeset(%{
+          content: "Alice evidence",
+          status: :completed,
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
 
-      %Relationship{}
-      |> Relationship.changeset(%{
-        source_id: bob.id,
-        target_id: carol.id,
-        type: "mentors"
-      })
-      |> Repo.insert!()
+      chunk =
+        %Arcana.Chunk{}
+        |> Arcana.Chunk.changeset(%{
+          text: "Alice evidence",
+          document_id: document.id,
+          embedding: embedding
+        })
+        |> Repo.insert!()
+
+      for entity <- [alice, bob, carol] do
+        %EntityMention{}
+        |> EntityMention.changeset(%{entity_id: entity.id, chunk_id: chunk.id})
+        |> Repo.insert!()
+      end
+
+      for {source, target, type} <- [{alice, bob, "knows"}, {bob, carol, "mentors"}] do
+        relationship =
+          %Relationship{}
+          |> Relationship.changeset(%{
+            source_id: source.id,
+            target_id: target.id,
+            type: type
+          })
+          |> Repo.insert!()
+
+        %RelationshipEvidence{}
+        |> RelationshipEvidence.changeset(%{
+          relationship_id: relationship.id,
+          chunk_id: chunk.id
+        })
+        |> Repo.insert!()
+      end
 
       llm = fn _prompt, _context, _opts -> {:ok, "answer"} end
 
@@ -433,6 +482,47 @@ defmodule Arcana.AskTest do
 
       types = graph_context.relationships |> Enum.map(& &1.type) |> Enum.sort()
       assert types == ["knows", "mentors"]
+    end
+
+    test "graph context excludes entities supported only by incomplete documents", %{llm: llm} do
+      collection = Repo.get_by!(Arcana.Collection, name: "ask-graph-depth")
+      {:ok, embedding} = Arcana.Embedder.embed(Arcana.Config.embedder(), "Alice", intent: :query)
+
+      failed =
+        %Entity{}
+        |> Entity.changeset(%{
+          name: "Failed Alice",
+          type: "person",
+          collection_id: collection.id,
+          embedding: embedding
+        })
+        |> Repo.insert!()
+
+      document =
+        %Arcana.Document{}
+        |> Arcana.Document.changeset(%{
+          content: "failed evidence",
+          status: :failed,
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+
+      chunk =
+        %Arcana.Chunk{}
+        |> Arcana.Chunk.changeset(%{
+          text: "failed evidence",
+          document_id: document.id,
+          embedding: embedding
+        })
+        |> Repo.insert!()
+
+      %EntityMention{}
+      |> EntityMention.changeset(%{entity_id: failed.id, chunk_id: chunk.id})
+      |> Repo.insert!()
+
+      graph_context = captured_graph_context(llm, [])
+
+      assert Enum.map(graph_context.entities, & &1.name) == ["Alice"]
     end
   end
 end

--- a/test/arcana/collection_scope_test.exs
+++ b/test/arcana/collection_scope_test.exs
@@ -1,0 +1,96 @@
+defmodule Arcana.CollectionScopeTest do
+  use ExUnit.Case, async: true
+
+  alias Arcana.CollectionScope
+
+  describe "normalize/1" do
+    test "normalizes all, one, many, and no collections" do
+      assert {:ok, :all} = CollectionScope.normalize(:all)
+      assert {:ok, {:only, ["a"]}} = CollectionScope.normalize("a")
+      assert {:ok, {:only, ["a", "b"]}} = CollectionScope.normalize(["a", "b"])
+      assert {:ok, {:only, []}} = CollectionScope.normalize([])
+    end
+
+    test "deduplicates names while preserving their order" do
+      assert {:ok, {:only, ["b", "a", "c"]}} =
+               CollectionScope.normalize(["b", "a", "b", "c", "a"])
+    end
+
+    test "rejects nil, blank names, and mixed lists" do
+      for invalid <- [nil, "", "  ", ["a", nil], ["a", ""], [:all], {:only, ["a"]}] do
+        assert {:error, {:invalid_collection_scope, ^invalid}} =
+                 CollectionScope.normalize(invalid)
+      end
+    end
+  end
+
+  describe "from_opts/2" do
+    test "normalizes singular and plural collection options" do
+      assert {:ok, {:only, ["a"]}} = CollectionScope.from_opts([collection: "a"], :all)
+
+      assert {:ok, {:only, ["a", "b"]}} =
+               CollectionScope.from_opts([collections: ["a", "b"]], :all)
+    end
+
+    test "uses the explicit default when neither option is present" do
+      assert {:ok, :all} = CollectionScope.from_opts([], :all)
+      assert {:ok, {:only, []}} = CollectionScope.from_opts([], [])
+    end
+
+    test "rejects options containing both collection keys" do
+      assert {:error, :conflicting_collection_options} =
+               CollectionScope.from_opts([collection: "a", collections: ["b"]], :all)
+    end
+
+    test "returns validation errors from options and defaults" do
+      assert {:error, {:invalid_collection_scope, nil}} =
+               CollectionScope.from_opts([collection: nil], :all)
+
+      assert {:error, {:invalid_collection_scope, ["a", nil]}} =
+               CollectionScope.from_opts([collections: ["a", nil]], :all)
+
+      assert {:error, {:invalid_collection_scope, nil}} =
+               CollectionScope.from_opts([], nil)
+    end
+  end
+
+  describe "bang variants" do
+    test "return normalized scopes" do
+      assert {:only, ["a"]} = CollectionScope.normalize!("a")
+      assert :all = CollectionScope.from_opts!([], :all)
+    end
+
+    test "raise actionable argument errors" do
+      assert_raise ArgumentError, ~r/collection scope must be/, fn ->
+        CollectionScope.from_opts!([collection: nil], :all)
+      end
+
+      assert_raise ArgumentError, ~r/cannot be used together/, fn ->
+        CollectionScope.from_opts!([collection: "a", collections: ["b"]], :all)
+      end
+    end
+  end
+
+  describe "intersect/2" do
+    test "treats all collections as the identity" do
+      scope = {:only, ["b", "a"]}
+
+      assert scope == CollectionScope.intersect(:all, scope)
+      assert scope == CollectionScope.intersect(scope, :all)
+      assert :all == CollectionScope.intersect(:all, :all)
+    end
+
+    test "preserves the first scope order and never widens it" do
+      assert {:only, ["c", "a"]} =
+               CollectionScope.intersect(
+                 {:only, ["c", "b", "a"]},
+                 {:only, ["a", "c", "outside"]}
+               )
+
+      assert {:only, []} =
+               CollectionScope.intersect({:only, ["a"]}, {:only, ["outside"]})
+
+      assert {:only, []} = CollectionScope.intersect({:only, []}, :all)
+    end
+  end
+end

--- a/test/arcana/collection_scope_test.exs
+++ b/test/arcana/collection_scope_test.exs
@@ -25,11 +25,14 @@ defmodule Arcana.CollectionScopeTest do
   end
 
   describe "from_opts/2" do
-    test "normalizes singular and plural collection options" do
+    test "normalizes every shape through the collection option" do
       assert {:ok, {:only, ["a"]}} = CollectionScope.from_opts([collection: "a"], :all)
 
       assert {:ok, {:only, ["a", "b"]}} =
-               CollectionScope.from_opts([collections: ["a", "b"]], :all)
+               CollectionScope.from_opts([collection: ["a", "b"]], :all)
+
+      assert {:ok, :all} = CollectionScope.from_opts([collection: :all], [])
+      assert {:ok, {:only, []}} = CollectionScope.from_opts([collection: []], :all)
     end
 
     test "uses the explicit default when neither option is present" do
@@ -37,8 +40,11 @@ defmodule Arcana.CollectionScopeTest do
       assert {:ok, {:only, []}} = CollectionScope.from_opts([], [])
     end
 
-    test "rejects options containing both collection keys" do
-      assert {:error, :conflicting_collection_options} =
+    test "rejects the removed plural alias instead of widening to the default" do
+      assert {:error, {:unsupported_collection_option, :collections}} =
+               CollectionScope.from_opts([collections: ["a"]], :all)
+
+      assert {:error, {:unsupported_collection_option, :collections}} =
                CollectionScope.from_opts([collection: "a", collections: ["b"]], :all)
     end
 
@@ -47,7 +53,7 @@ defmodule Arcana.CollectionScopeTest do
                CollectionScope.from_opts([collection: nil], :all)
 
       assert {:error, {:invalid_collection_scope, ["a", nil]}} =
-               CollectionScope.from_opts([collections: ["a", nil]], :all)
+               CollectionScope.from_opts([collection: ["a", nil]], :all)
 
       assert {:error, {:invalid_collection_scope, nil}} =
                CollectionScope.from_opts([], nil)
@@ -65,8 +71,8 @@ defmodule Arcana.CollectionScopeTest do
         CollectionScope.from_opts!([collection: nil], :all)
       end
 
-      assert_raise ArgumentError, ~r/cannot be used together/, fn ->
-        CollectionScope.from_opts!([collection: "a", collections: ["b"]], :all)
+      assert_raise ArgumentError, ~r/:collections is not supported/, fn ->
+        CollectionScope.from_opts!([collections: ["b"]], :all)
       end
     end
   end
@@ -91,6 +97,22 @@ defmodule Arcana.CollectionScopeTest do
                CollectionScope.intersect({:only, ["a"]}, {:only, ["outside"]})
 
       assert {:only, []} = CollectionScope.intersect({:only, []}, :all)
+    end
+  end
+
+  describe "subset?/2" do
+    test "requires every explicitly requested collection to be allowed" do
+      allowed = {:only, ["a", "b"]}
+
+      assert CollectionScope.subset?({:only, ["b", "a"]}, allowed)
+      assert CollectionScope.subset?({:only, []}, allowed)
+      refute CollectionScope.subset?({:only, ["a", "outside"]}, allowed)
+      refute CollectionScope.subset?(:all, allowed)
+    end
+
+    test "allows every scope when collections are unrestricted" do
+      assert CollectionScope.subset?(:all, :all)
+      assert CollectionScope.subset?({:only, ["a"]}, :all)
     end
   end
 end

--- a/test/arcana/delete_contract_test.exs
+++ b/test/arcana/delete_contract_test.exs
@@ -4,7 +4,7 @@ defmodule Arcana.DeleteContractTest do
 
   It used to call `repo.delete!/1`, so a foreign key violation or a
   concurrent delete escaped as an exception from a function documenting
-  `:ok | {:error, :not_found} | {:error, {:sweep_failed, _}}`. The damage was
+  `:ok | {:error, :not_found} | {:error, term()}`. The damage was
   not the exception itself but the sequencing around it: callers remove an
   external artifact and then call this, and a three-clause `case` written
   from the docs gave them no reason to expect control to leave abruptly.
@@ -50,10 +50,7 @@ defmodule Arcana.DeleteContractTest do
   end
 
   describe "inside a caller's own transaction" do
-    test "a failed sweep does not destroy the caller's transaction" do
-      # repo.rollback/1 in a nested Ecto transaction aborts the OUTERMOST one,
-      # so opening a transaction here unconditionally killed the caller's while
-      # handing back a tuple that reads like a recoverable refusal.
+    test "an external graph store refuses deletion it cannot clean after commit" do
       extractor = fn _t, _o -> {:ok, [%{name: "Alpha", type: "concept"}]} end
 
       opts = [
@@ -69,11 +66,13 @@ defmodule Arcana.DeleteContractTest do
         Repo.transaction(fn ->
           deleted = Arcana.delete(doc.id, opts)
 
-          # Still able to work: the point is the caller keeps their transaction.
-          {deleted, Repo.aggregate(Arcana.Document, :count)}
+          {deleted, Repo.get(Arcana.Document, doc.id)}
         end)
 
-      assert {:ok, {{:error, {:sweep_failed, :sweep_boom}}, _count}} = result
+      assert {:ok, {{:error, :external_graph_store_requires_post_commit_delete}, persisted}} =
+               result
+
+      assert persisted.id == doc.id
     end
   end
 
@@ -92,9 +91,7 @@ defmodule Arcana.DeleteContractTest do
       assert chunks.() == 0
     end
 
-    test "a failed sweep puts the chunks back too, not just the document" do
-      # A rollback restoring the document without its chunks would be worse
-      # than the old behaviour, which at least left nothing half-deleted.
+    test "an external cleanup failure is reported after the database delete commits" do
       extractor = fn _t, _o -> {:ok, [%{name: "Beta", type: "concept"}]} end
 
       opts = [
@@ -114,13 +111,13 @@ defmodule Arcana.DeleteContractTest do
         Repo.aggregate(from(c in Arcana.Chunk, where: c.document_id == ^doc.id), :count)
       end
 
-      before = chunks.()
-      assert before > 0
+      assert chunks.() > 0
 
-      assert {:error, {:sweep_failed, :sweep_boom}} = Arcana.delete(doc.id, opts)
+      assert {:error, {:post_commit_graph_cleanup_failed, {:sweep_failed, :sweep_boom}}} =
+               Arcana.delete(doc.id, opts)
 
-      assert Repo.get(Arcana.Document, doc.id), "the document comes back"
-      assert chunks.() == before, "and so do its chunks"
+      refute Repo.get(Arcana.Document, doc.id)
+      assert chunks.() == 0
     end
   end
 end

--- a/test/arcana/delete_contract_test.exs
+++ b/test/arcana/delete_contract_test.exs
@@ -16,6 +16,8 @@ defmodule Arcana.DeleteContractTest do
   """
   use Arcana.DataCase, async: true
 
+  alias Arcana.Graph.GraphStore
+
   defp ingest_doc(text \\ "Elixir runs on the BEAM.") do
     {:ok, doc} = Arcana.ingest(text, repo: Repo)
     doc
@@ -113,11 +115,103 @@ defmodule Arcana.DeleteContractTest do
 
       assert chunks.() > 0
 
-      assert {:error, {:post_commit_graph_cleanup_failed, {:sweep_failed, :sweep_boom}}} =
-               Arcana.delete(doc.id, opts)
+      chunk_ids = Repo.all(from(c in Arcana.Chunk, where: c.document_id == ^doc.id, select: c.id))
+
+      assert {:error,
+              {:post_commit_graph_cleanup_failed,
+               %{
+                 reason: {:sweep_failed, :sweep_boom},
+                 chunk_ids: ^chunk_ids,
+                 published_chunk_ids: ^chunk_ids,
+                 collection_id: collection_id
+               }}} = Arcana.delete(doc.id, opts)
+
+      assert collection_id == doc.collection_id
 
       refute Repo.get(Arcana.Document, doc.id)
       assert chunks.() == 0
+    end
+
+    test "an external cleanup exception is not misreported as a concurrent delete" do
+      doc = ingest_doc("external cleanup raises after the delete commits")
+
+      assert {:error,
+              {:post_commit_graph_cleanup_failed,
+               %{
+                 reason: %Ecto.StaleEntryError{message: "external graph cleanup failed"},
+                 chunk_ids: chunk_ids,
+                 published_chunk_ids: chunk_ids,
+                 collection_id: collection_id
+               }}} =
+               Arcana.delete(doc.id,
+                 repo: Repo,
+                 graph: true,
+                 graph_store: Arcana.RaisingDeleteGraphStore
+               )
+
+      assert chunk_ids != []
+      assert collection_id == doc.collection_id
+      refute Repo.get(Arcana.Document, doc.id)
+    end
+
+    test "post-commit context can replay graph deletion after the document is gone" do
+      doc = ingest_doc("retry external graph cleanup")
+
+      assert {:error,
+              {:post_commit_graph_cleanup_failed,
+               %{
+                 reason: :delete_boom,
+                 chunk_ids: chunk_ids,
+                 published_chunk_ids: published_chunk_ids,
+                 collection_id: collection_id
+               }}} =
+               Arcana.delete(doc.id,
+                 repo: Repo,
+                 graph: true,
+                 graph_store: Arcana.FailingDeleteGraphStore
+               )
+
+      refute Repo.get(Arcana.Document, doc.id)
+
+      assert :ok =
+               GraphStore.delete_by_chunks(chunk_ids,
+                 repo: Repo,
+                 graph_store: {Arcana.FailingDeleteGraphStore, delete_failure: :ok},
+                 published_chunk_ids: published_chunk_ids
+               )
+
+      assert :ok =
+               GraphStore.sweep_orphans(collection_id,
+                 repo: Repo,
+                 graph_store: {Arcana.FailingDeleteGraphStore, delete_failure: :ok}
+               )
+    end
+
+    test "external cleanup exits and throws retain post-commit recovery context" do
+      for {failure, expected_reason} <- [
+            exit: :external_cleanup_exit,
+            throw: {:throw, :external_cleanup_throw}
+          ] do
+        doc = ingest_doc("external cleanup #{failure}")
+
+        assert {:error,
+                {:post_commit_graph_cleanup_failed,
+                 %{
+                   reason: ^expected_reason,
+                   chunk_ids: chunk_ids,
+                   published_chunk_ids: chunk_ids,
+                   collection_id: collection_id
+                 }}} =
+                 Arcana.delete(doc.id,
+                   repo: Repo,
+                   graph: true,
+                   graph_store: {Arcana.RaisingDeleteGraphStore, cleanup_failure: failure}
+                 )
+
+        assert chunk_ids != []
+        assert collection_id == doc.collection_id
+        refute Repo.get(Arcana.Document, doc.id)
+      end
     end
   end
 end

--- a/test/arcana/documents_test.exs
+++ b/test/arcana/documents_test.exs
@@ -1,7 +1,18 @@
 defmodule Arcana.DocumentsTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Document
+  alias Arcana.{Document, DocumentMetadata, TestRepo}
+  alias Ecto.Adapters.SQL
+
+  defmodule QueryCapturingRepo do
+    @moduledoc false
+
+    def all(query) do
+      {sql, _params} = SQL.to_sql(:all, TestRepo, query)
+      send(self(), {:documents_query, sql})
+      TestRepo.all(query)
+    end
+  end
 
   describe "list_documents/1" do
     test "lists documents newest first with collection preloaded" do
@@ -24,6 +35,28 @@ defmodule Arcana.DocumentsTest do
       assert [%Document{}] = docs
 
       assert {:ok, []} = Arcana.list_documents(repo: Repo, collection: "docs-nope")
+    end
+
+    test "supports all, none, one, and many collection scopes" do
+      {:ok, first} = Arcana.ingest("In scope A", repo: Repo, collection: "scope-a")
+      {:ok, second} = Arcana.ingest("In scope B", repo: Repo, collection: "scope-b")
+      {:ok, outside} = Arcana.ingest("Outside", repo: Repo, collection: "scope-c")
+
+      assert {:ok, one} = Arcana.list_documents(repo: Repo, collection: "scope-a")
+      assert [%Document{id: first_id}] = one
+      assert first_id == first.id
+
+      assert {:ok, many} =
+               Arcana.list_documents(repo: Repo, collections: ["scope-a", "scope-b"])
+
+      assert MapSet.new(Enum.map(many, & &1.id)) == MapSet.new([first.id, second.id])
+      refute Enum.any?(many, &(&1.id == outside.id))
+
+      assert {:ok, []} = Arcana.list_documents(repo: Repo, collections: [])
+      assert {:ok, 0} = Arcana.count_documents(repo: Repo, collections: [])
+
+      assert {:ok, all} = Arcana.list_documents(repo: Repo, collection: :all)
+      assert Enum.all?([first, second, outside], fn doc -> Enum.any?(all, &(&1.id == doc.id)) end)
     end
 
     test "filters by status" do
@@ -82,6 +115,121 @@ defmodule Arcana.DocumentsTest do
 
     test "returns not_found for a malformed id instead of raising" do
       assert {:error, :not_found} = Arcana.get_document("not-a-uuid", repo: Repo)
+    end
+
+    test "applies collection scope in the document lookup" do
+      {:ok, doc} = Arcana.ingest("Scoped fetch", repo: Repo, collection: "get-scope")
+
+      assert {:ok, %Document{id: id}} =
+               Arcana.get_document(doc.id, repo: Repo, collection: "get-scope")
+
+      assert id == doc.id
+
+      assert {:error, :not_found} =
+               Arcana.get_document(doc.id, repo: Repo, collections: ["somewhere-else"])
+
+      assert {:error, :not_found} = Arcana.get_document(doc.id, repo: Repo, collections: [])
+    end
+  end
+
+  describe "get_document_metadata/2" do
+    test "returns a sparse ID-keyed projection in one query and deduplicates IDs" do
+      {:ok, doc} =
+        Arcana.ingest("Large original content that must stay out of the select",
+          repo: Repo,
+          collection: "metadata-api",
+          source_id: "guide-7",
+          metadata: %{"title" => "Guide"}
+        )
+
+      id = doc.id
+
+      assert {:ok, %{^id => metadata}} =
+               Arcana.get_document_metadata([doc.id, doc.id],
+                 repo: QueryCapturingRepo,
+                 collection: "metadata-api"
+               )
+
+      assert %DocumentMetadata{
+               id: doc.id,
+               source_id: "guide-7",
+               metadata: %{"title" => "Guide"}
+             } == metadata
+
+      assert %{id: doc.id, source_id: "guide-7", metadata: %{"title" => "Guide"}} ==
+               DocumentMetadata.to_map(metadata)
+
+      assert_receive {:documents_query, sql}
+      refute_receive {:documents_query, _sql}
+      assert sql =~ ~s("source_id")
+      assert sql =~ ~s("metadata")
+      refute sql =~ ~s(."content")
+    end
+
+    test "returns only completed documents inside the explicit scope" do
+      {:ok, included} =
+        Arcana.ingest("Included", repo: Repo, collection: "metadata-in", source_id: "in")
+
+      {:ok, outside} =
+        Arcana.ingest("Outside", repo: Repo, collection: "metadata-out", source_id: "out")
+
+      {:ok, collection} = Arcana.Collection.get_or_create("metadata-in", Repo)
+
+      {:ok, pending} =
+        %Document{}
+        |> Document.changeset(%{
+          content: "Pending",
+          status: :pending,
+          source_id: "pending",
+          collection_id: collection.id
+        })
+        |> Repo.insert()
+
+      missing = Ecto.UUID.generate()
+
+      assert {:ok, result} =
+               Arcana.get_document_metadata([included.id, outside.id, pending.id, missing],
+                 repo: Repo,
+                 collections: ["metadata-in"]
+               )
+
+      included_id = included.id
+      assert %{^included_id => %DocumentMetadata{source_id: "in"}} = result
+      refute Map.has_key?(result, outside.id)
+      refute Map.has_key?(result, pending.id)
+      refute Map.has_key?(result, missing)
+    end
+
+    test "requires an explicit scope and accepts explicit all or none" do
+      {:ok, doc} = Arcana.ingest("All scope", repo: Repo, collection: "metadata-all")
+      id = doc.id
+
+      assert_raise ArgumentError, ~r/requires an explicit/, fn ->
+        Arcana.get_document_metadata([doc.id], repo: Repo)
+      end
+
+      assert {:ok, %{^id => %DocumentMetadata{}}} =
+               Arcana.get_document_metadata([doc.id], repo: Repo, collection: :all)
+
+      assert {:ok, %{}} =
+               Arcana.get_document_metadata([doc.id], repo: Repo, collections: [])
+    end
+
+    test "does not query for an empty ID list" do
+      assert {:ok, %{}} =
+               Arcana.get_document_metadata([], repo: QueryCapturingRepo, collection: :all)
+
+      refute_receive {:documents_query, _sql}
+    end
+
+    test "rejects malformed IDs before querying" do
+      assert {:error, {:invalid_document_id, "not-a-uuid"}} =
+               Arcana.get_document_metadata([Ecto.UUID.generate(), "not-a-uuid"],
+                 repo: QueryCapturingRepo,
+                 collection: :all
+               )
+
+      refute_receive {:documents_query, _sql}
     end
   end
 

--- a/test/arcana/documents_test.exs
+++ b/test/arcana/documents_test.exs
@@ -47,13 +47,13 @@ defmodule Arcana.DocumentsTest do
       assert first_id == first.id
 
       assert {:ok, many} =
-               Arcana.list_documents(repo: Repo, collections: ["scope-a", "scope-b"])
+               Arcana.list_documents(repo: Repo, collection: ["scope-a", "scope-b"])
 
       assert MapSet.new(Enum.map(many, & &1.id)) == MapSet.new([first.id, second.id])
       refute Enum.any?(many, &(&1.id == outside.id))
 
-      assert {:ok, []} = Arcana.list_documents(repo: Repo, collections: [])
-      assert {:ok, 0} = Arcana.count_documents(repo: Repo, collections: [])
+      assert {:ok, []} = Arcana.list_documents(repo: Repo, collection: [])
+      assert {:ok, 0} = Arcana.count_documents(repo: Repo, collection: [])
 
       assert {:ok, all} = Arcana.list_documents(repo: Repo, collection: :all)
       assert Enum.all?([first, second, outside], fn doc -> Enum.any?(all, &(&1.id == doc.id)) end)
@@ -126,9 +126,9 @@ defmodule Arcana.DocumentsTest do
       assert id == doc.id
 
       assert {:error, :not_found} =
-               Arcana.get_document(doc.id, repo: Repo, collections: ["somewhere-else"])
+               Arcana.get_document(doc.id, repo: Repo, collection: ["somewhere-else"])
 
-      assert {:error, :not_found} = Arcana.get_document(doc.id, repo: Repo, collections: [])
+      assert {:error, :not_found} = Arcana.get_document(doc.id, repo: Repo, collection: [])
     end
   end
 
@@ -190,7 +190,7 @@ defmodule Arcana.DocumentsTest do
       assert {:ok, result} =
                Arcana.get_document_metadata([included.id, outside.id, pending.id, missing],
                  repo: Repo,
-                 collections: ["metadata-in"]
+                 collection: ["metadata-in"]
                )
 
       included_id = included.id
@@ -212,7 +212,7 @@ defmodule Arcana.DocumentsTest do
                Arcana.get_document_metadata([doc.id], repo: Repo, collection: :all)
 
       assert {:ok, %{}} =
-               Arcana.get_document_metadata([doc.id], repo: Repo, collections: [])
+               Arcana.get_document_metadata([doc.id], repo: Repo, collection: [])
     end
 
     test "does not query for an empty ID list" do

--- a/test/arcana/evaluation_test.exs
+++ b/test/arcana/evaluation_test.exs
@@ -106,7 +106,7 @@ defmodule Arcana.EvaluationTest do
                  repo: Repo,
                  llm: llm,
                  sample_size: 10,
-                 collections: ["generator-a", "generator-b", "missing"]
+                 collection: ["generator-a", "generator-b", "missing"]
                )
 
       assert length(test_cases) == 2
@@ -116,7 +116,7 @@ defmodule Arcana.EvaluationTest do
                  repo: Repo,
                  llm: llm,
                  sample_size: 10,
-                 collections: []
+                 collection: []
                )
     end
 
@@ -217,7 +217,7 @@ defmodule Arcana.EvaluationTest do
       assert {:ok, run} = Evaluation.run(repo: Repo, collection: "default")
       assert run.config.collections == ["default"]
 
-      assert {:error, :no_test_cases} = Evaluation.run(repo: Repo, collections: [])
+      assert {:error, :no_test_cases} = Evaluation.run(repo: Repo, collection: [])
       assert {:error, :no_test_cases} = Evaluation.run(repo: Repo, collection: "missing")
     end
 
@@ -310,6 +310,36 @@ defmodule Arcana.EvaluationTest do
       result = run.results[python_tc.id]
       assert result.hit[1] == false
       assert result.reciprocal_rank == 0.0
+    end
+
+    test "forwards scoped runs through the singular collection option" do
+      test_pid = self()
+
+      retriever = fn _question, opts ->
+        send(test_pid, {:retriever_opts, opts})
+        {:ok, []}
+      end
+
+      assert {:ok, _run} =
+               Evaluation.run(repo: Repo, collection: "default", retriever: retriever)
+
+      assert_received {:retriever_opts, opts}
+      assert opts[:collection] == ["default"]
+      assert opts[:strict_collections] == true
+      refute Keyword.has_key?(opts, :collections)
+    end
+
+    test "forwards all explicitly so search defaults cannot narrow the run" do
+      test_pid = self()
+
+      retriever = fn _question, opts ->
+        send(test_pid, {:retriever_opts, opts})
+        {:ok, []}
+      end
+
+      assert {:ok, _run} = Evaluation.run(repo: Repo, collection: :all, retriever: retriever)
+      assert_received {:retriever_opts, opts}
+      assert opts[:collection] == :all
     end
 
     test "without evaluate_answers does not include answer metrics", %{test_cases: _test_cases} do
@@ -459,26 +489,23 @@ defmodule Arcana.EvaluationTest do
       assert [%{question: "Alpha?"}] =
                Evaluation.list_test_cases(repo: Repo, collection: "evaluation-a")
 
-      assert [%{question: "Alpha?"}] =
-               Evaluation.list_test_cases(repo: Repo, collections: "evaluation-a")
-
       assert 2 ==
                Evaluation.count_test_cases(
                  repo: Repo,
                  collection: ["evaluation-a", "evaluation-b", "missing"]
                )
 
-      assert [] == Evaluation.list_test_cases(repo: Repo, collections: [])
+      assert [] == Evaluation.list_test_cases(repo: Repo, collection: [])
       assert 2 == Evaluation.count_test_cases(repo: Repo, collection: :all)
     end
 
-    test "rejects conflicting and malformed collection scopes" do
-      assert_raise ArgumentError, ~r/cannot be used together/, fn ->
-        Evaluation.list_test_cases(repo: Repo, collection: "a", collections: ["b"])
+    test "rejects malformed and removed collection scopes" do
+      assert_raise ArgumentError, ~r/collection scope must be/, fn ->
+        Evaluation.list_test_cases(repo: Repo, collection: ["a", nil])
       end
 
-      assert_raise ArgumentError, ~r/collection scope must be/, fn ->
-        Evaluation.list_test_cases(repo: Repo, collections: ["a", nil])
+      assert_raise ArgumentError, ~r/:collections is not supported/, fn ->
+        Evaluation.list_test_cases(repo: Repo, collections: ["a"])
       end
     end
   end
@@ -523,6 +550,14 @@ defmodule Arcana.EvaluationTest do
       assert {:error, :not_found} =
                Evaluation.delete_test_case(Ecto.UUID.generate(), repo: Repo)
     end
+
+    test "validates collection scope before rejecting malformed IDs" do
+      for operation <- [&Evaluation.get_test_case/2, &Evaluation.delete_test_case/2] do
+        assert_raise ArgumentError, ~r/collection scope must be/, fn ->
+          operation.("not-a-uuid", repo: Repo, collection: ["a", nil])
+        end
+      end
+    end
   end
 
   describe "list_runs/1" do
@@ -565,6 +600,14 @@ defmodule Arcana.EvaluationTest do
       {:ok, _deleted} = Evaluation.delete_run(run.id, repo: Repo)
 
       assert Evaluation.get_run(run.id, repo: Repo) == nil
+    end
+
+    test "run reads and deletes validate scope before malformed IDs" do
+      for operation <- [&Evaluation.get_run/2, &Evaluation.delete_run/2] do
+        assert_raise ArgumentError, ~r/collection scope must be/, fn ->
+          operation.("not-a-uuid", repo: Repo, collection: ["a", nil])
+        end
+      end
     end
   end
 end

--- a/test/arcana/evaluation_test.exs
+++ b/test/arcana/evaluation_test.exs
@@ -1,7 +1,7 @@
 defmodule Arcana.EvaluationTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Evaluation
+  alias Arcana.{Chunk, Collection, Document, Evaluation}
   alias Arcana.Evaluation.TestCase
 
   describe "generate_test_cases/1" do
@@ -88,6 +88,42 @@ defmodule Arcana.EvaluationTest do
         )
 
       assert test_cases == []
+    end
+
+    test "samples only chunks from completed documents" do
+      {:ok, collection} = Collection.get_or_create("evaluation-published-only", Repo)
+
+      for status <- [:completed, :processing, :failed] do
+        document =
+          %Document{}
+          |> Document.changeset(%{
+            content: "#{status} evaluation content",
+            status: status,
+            collection_id: collection.id
+          })
+          |> Repo.insert!()
+
+        %Chunk{}
+        |> Chunk.changeset(%{
+          text: "#{status} evaluation content",
+          embedding: List.duplicate(0.1, 384),
+          document_id: document.id
+        })
+        |> Repo.insert!()
+      end
+
+      llm = fn prompt, _context -> {:ok, "Question from #{prompt}"} end
+
+      assert {:ok, [test_case]} =
+               Evaluation.generate_test_cases(
+                 repo: Repo,
+                 llm: llm,
+                 sample_size: 10,
+                 collection: collection.name
+               )
+
+      [chunk] = test_case.relevant_chunks
+      assert Repo.get!(Document, chunk.document_id).status == :completed
     end
   end
 

--- a/test/arcana/evaluation_test.exs
+++ b/test/arcana/evaluation_test.exs
@@ -90,6 +90,36 @@ defmodule Arcana.EvaluationTest do
       assert test_cases == []
     end
 
+    test "accepts many collections and treats an empty list as no chunks" do
+      for {collection, content} <- [
+            {"generator-a", "alpha generator content"},
+            {"generator-b", "bravo generator content"},
+            {"generator-outside", "outside generator content"}
+          ] do
+        {:ok, _document} = Arcana.ingest(content, repo: Repo, collection: collection)
+      end
+
+      llm = fn _prompt, _context -> {:ok, "Generated question?"} end
+
+      assert {:ok, test_cases} =
+               Evaluation.generate_test_cases(
+                 repo: Repo,
+                 llm: llm,
+                 sample_size: 10,
+                 collections: ["generator-a", "generator-b", "missing"]
+               )
+
+      assert length(test_cases) == 2
+
+      assert {:ok, []} =
+               Evaluation.generate_test_cases(
+                 repo: Repo,
+                 llm: llm,
+                 sample_size: 10,
+                 collections: []
+               )
+    end
+
     test "samples only chunks from completed documents" do
       {:ok, collection} = Collection.get_or_create("evaluation-published-only", Repo)
 
@@ -181,6 +211,14 @@ defmodule Arcana.EvaluationTest do
       Repo.delete_all(TestCase)
 
       assert {:error, :no_test_cases} = Evaluation.run(repo: Repo)
+    end
+
+    test "normalizes one and no-collection run scopes", %{test_cases: _test_cases} do
+      assert {:ok, run} = Evaluation.run(repo: Repo, collection: "default")
+      assert run.config.collections == ["default"]
+
+      assert {:error, :no_test_cases} = Evaluation.run(repo: Repo, collections: [])
+      assert {:error, :no_test_cases} = Evaluation.run(repo: Repo, collection: "missing")
     end
 
     test "saves full Arcana config in run", %{test_cases: _test_cases} do
@@ -400,6 +438,48 @@ defmodule Arcana.EvaluationTest do
 
       assert length(test_cases) == 1
       assert hd(test_cases).question == "Test question?"
+    end
+
+    test "accepts all public collection scope shapes" do
+      for {collection, content, question} <- [
+            {"evaluation-a", "alpha evaluation content", "Alpha?"},
+            {"evaluation-b", "bravo evaluation content", "Bravo?"}
+          ] do
+        {:ok, document} = Arcana.ingest(content, repo: Repo, collection: collection)
+        chunk = Repo.get_by!(Chunk, document_id: document.id)
+
+        {:ok, _test_case} =
+          Evaluation.create_test_case(
+            repo: Repo,
+            question: question,
+            relevant_chunk_ids: [chunk.id]
+          )
+      end
+
+      assert [%{question: "Alpha?"}] =
+               Evaluation.list_test_cases(repo: Repo, collection: "evaluation-a")
+
+      assert [%{question: "Alpha?"}] =
+               Evaluation.list_test_cases(repo: Repo, collections: "evaluation-a")
+
+      assert 2 ==
+               Evaluation.count_test_cases(
+                 repo: Repo,
+                 collection: ["evaluation-a", "evaluation-b", "missing"]
+               )
+
+      assert [] == Evaluation.list_test_cases(repo: Repo, collections: [])
+      assert 2 == Evaluation.count_test_cases(repo: Repo, collection: :all)
+    end
+
+    test "rejects conflicting and malformed collection scopes" do
+      assert_raise ArgumentError, ~r/cannot be used together/, fn ->
+        Evaluation.list_test_cases(repo: Repo, collection: "a", collections: ["b"])
+      end
+
+      assert_raise ArgumentError, ~r/collection scope must be/, fn ->
+        Evaluation.list_test_cases(repo: Repo, collections: ["a", nil])
+      end
     end
   end
 

--- a/test/arcana/graph/entity_matcher_test.exs
+++ b/test/arcana/graph/entity_matcher_test.exs
@@ -1,8 +1,8 @@
 defmodule Arcana.Graph.EntityMatcherTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Collection
-  alias Arcana.Graph.Entity
+  alias Arcana.{Chunk, Collection, Document}
+  alias Arcana.Graph.{Entity, EntityMention}
   alias Arcana.Graph.EntityMatcher
 
   describe "behaviour" do
@@ -112,6 +112,49 @@ defmodule Arcana.Graph.EntityMatcherTest do
       assert ids == [alice.id]
     end
 
+    test "does not match an entity supported only by a failed document" do
+      collection = create_collection("ner-failed-#{System.unique_integer([:positive])}")
+
+      failed_entity =
+        %Entity{}
+        |> Entity.changeset(%{
+          name: "Failed Entity",
+          type: "person",
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+
+      failed_document =
+        %Document{}
+        |> Document.changeset(%{
+          content: "failed evidence",
+          status: :failed,
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+
+      failed_chunk =
+        %Chunk{}
+        |> Chunk.changeset(%{
+          text: "failed evidence",
+          embedding: List.duplicate(0.1, 384),
+          document_id: failed_document.id
+        })
+        |> Repo.insert!()
+
+      %EntityMention{}
+      |> EntityMention.changeset(%{entity_id: failed_entity.id, chunk_id: failed_chunk.id})
+      |> Repo.insert!()
+
+      extractor = fn _text, _opts -> {:ok, [%{name: "Failed Entity", type: "person"}]} end
+
+      assert {:ok, []} =
+               NER.match("Failed Entity", [collection.id],
+                 repo: Repo,
+                 entity_extractor: extractor
+               )
+    end
+
     test "scopes lookups to the given collection_ids" do
       target = create_collection("ner-target-#{System.unique_integer([:positive])}")
       other = create_collection("ner-other-#{System.unique_integer([:positive])}")
@@ -187,20 +230,41 @@ defmodule Arcana.Graph.EntityMatcherTest do
   end
 
   defp create_entity(collection, name, type) do
-    %Entity{}
-    |> Entity.changeset(%{name: name, type: type, collection_id: collection.id})
+    entity =
+      %Entity{}
+      |> Entity.changeset(%{name: name, type: type, collection_id: collection.id})
+      |> Repo.insert!()
+
+    document =
+      %Document{}
+      |> Document.changeset(%{
+        content: "evidence for #{name}",
+        status: :completed,
+        collection_id: collection.id
+      })
+      |> Repo.insert!()
+
+    chunk =
+      %Chunk{}
+      |> Chunk.changeset(%{
+        text: "evidence for #{name}",
+        embedding: List.duplicate(0.1, 384),
+        document_id: document.id
+      })
+      |> Repo.insert!()
+
+    %EntityMention{}
+    |> EntityMention.changeset(%{entity_id: entity.id, chunk_id: chunk.id})
     |> Repo.insert!()
+
+    entity
   end
 
   defp create_entity_with_embedding(collection, name, embedding) do
-    %Entity{}
-    |> Entity.changeset(%{
-      name: name,
-      type: "concept",
-      collection_id: collection.id,
-      embedding: embedding
-    })
-    |> Repo.insert!()
+    collection
+    |> create_entity(name, "concept")
+    |> Ecto.Changeset.change(embedding: embedding)
+    |> Repo.update!()
   end
 
   defp random_unit_vector(dims \\ 384) do

--- a/test/arcana/graph/graph_store/ecto_test.exs
+++ b/test/arcana/graph/graph_store/ecto_test.exs
@@ -215,6 +215,16 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
 
       assert Repo.get(Entity, entity.id)
     end
+
+    test "an empty list still sweeps an explicitly known collection" do
+      collection = create_collection("dbc-known-empty-#{System.unique_integer([:positive])}")
+      orphan = create_entity(collection, "Orphan")
+
+      assert :ok =
+               EctoStore.delete_by_chunks([], repo: Repo, collection_id: collection.id)
+
+      refute Repo.get(Entity, orphan.id)
+    end
   end
 
   describe "persist_entities/3" do

--- a/test/arcana/graph/graph_store/ecto_test.exs
+++ b/test/arcana/graph/graph_store/ecto_test.exs
@@ -582,6 +582,26 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
       assert Repo.get(Entity, bob.id)
     end
 
+    test "looks up the fingerprint produced from cast relationship values" do
+      collection = create_collection("relationship-cast-fingerprint")
+      document = create_document(collection)
+      chunk = create_chunk(document)
+      alice = create_entity(collection, "Alice")
+      bob = create_entity(collection, "Bob")
+      id_map = %{"alice" => alice.id, "bob" => bob.id}
+
+      fact = [%{source: "Alice", target: "Bob", type: "knows", strength: "5"}]
+
+      assert :ok = EctoStore.persist_relationships(chunk.id, fact, id_map, repo: Repo)
+
+      assert %Relationship{strength: 5} = relationship = Repo.one!(Relationship)
+
+      assert %RelationshipEvidence{relationship_id: relationship_id} =
+               Repo.one!(RelationshipEvidence)
+
+      assert relationship_id == relationship.id
+    end
+
     test "publishes a fact only while it has completed-document evidence" do
       collection = create_collection("relationship-publication")
       completed_document = create_document(collection)

--- a/test/arcana/graph/graph_store/ecto_test.exs
+++ b/test/arcana/graph/graph_store/ecto_test.exs
@@ -2,7 +2,16 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
   use Arcana.DataCase, async: true
 
   alias Arcana.{Chunk, Collection, Document}
-  alias Arcana.Graph.{Community, Entity, EntityMention, EntityName, Relationship}
+
+  alias Arcana.Graph.{
+    Community,
+    Entity,
+    EntityMention,
+    EntityName,
+    Relationship,
+    RelationshipEvidence
+  }
+
   alias Arcana.Graph.GraphStore.Ecto, as: EctoStore
 
   defp create_collection(name \\ "test-collection") do
@@ -427,8 +436,11 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
           repo: Repo
         )
 
+      chunk = collection |> create_document() |> create_chunk()
+
       :ok =
         EctoStore.persist_relationships(
+          chunk.id,
           [%{source: "İstanbul", target: decomposed, type: "spelled_as"}],
           id_map,
           repo: Repo
@@ -481,13 +493,15 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
       collection = create_collection()
       alice = create_entity(collection, "Alice")
       bob = create_entity(collection, "Bob")
+      chunk = collection |> create_document() |> create_chunk()
       entity_id_map = %{"alice" => alice.id, "bob" => bob.id}
 
       relationships = [
         %{source: "Alice", target: "Bob", type: "knows"}
       ]
 
-      assert :ok = EctoStore.persist_relationships(relationships, entity_id_map, repo: Repo)
+      assert :ok =
+               EctoStore.persist_relationships(chunk.id, relationships, entity_id_map, repo: Repo)
 
       rel = Repo.get_by(Relationship, source_id: alice.id, target_id: bob.id)
       assert rel.type == "knows"
@@ -497,6 +511,7 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
       collection = create_collection()
       alice = create_entity(collection, "Alice")
       bob = create_entity(collection, "Bob")
+      chunk = collection |> create_document() |> create_chunk()
       entity_id_map = %{"alice" => alice.id, "bob" => bob.id}
 
       relationships = [
@@ -509,7 +524,8 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
         }
       ]
 
-      assert :ok = EctoStore.persist_relationships(relationships, entity_id_map, repo: Repo)
+      assert :ok =
+               EctoStore.persist_relationships(chunk.id, relationships, entity_id_map, repo: Repo)
 
       rel = Repo.get_by(Relationship, source_id: alice.id, target_id: bob.id)
       assert rel.type == "knows"
@@ -524,8 +540,78 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
         %{source: "Alice", target: "Unknown", type: "knows"}
       ]
 
-      assert :ok = EctoStore.persist_relationships(relationships, entity_id_map, repo: Repo)
+      assert :ok =
+               EctoStore.persist_relationships(
+                 Ecto.UUID.generate(),
+                 relationships,
+                 entity_id_map,
+                 repo: Repo
+               )
+
       assert Repo.aggregate(Relationship, :count) == 0
+    end
+
+    test "canonicalizes facts and removes them only after their final evidence is deleted" do
+      collection = create_collection("relationship-evidence")
+      document = create_document(collection)
+      anchor = create_chunk(document, "anchor")
+      edge_a = create_chunk(document, "edge a")
+      edge_b = create_chunk(document, "edge b")
+      alice = create_entity(collection, "Alice")
+      bob = create_entity(collection, "Bob")
+      create_mention(alice, anchor)
+      create_mention(bob, anchor)
+      id_map = %{"alice" => alice.id, "bob" => bob.id}
+      fact = [%{source: "Alice", target: "Bob", type: "knows"}]
+
+      assert :ok = EctoStore.persist_relationships(edge_a.id, fact, id_map, repo: Repo)
+      assert :ok = EctoStore.persist_relationships(edge_a.id, fact, id_map, repo: Repo)
+      assert :ok = EctoStore.persist_relationships(edge_b.id, fact, id_map, repo: Repo)
+
+      assert Repo.aggregate(Relationship, :count) == 1
+      assert Repo.aggregate(RelationshipEvidence, :count) == 2
+
+      assert :ok = EctoStore.delete_by_chunks([edge_a.id], repo: Repo)
+      assert Repo.aggregate(Relationship, :count) == 1
+      assert Repo.aggregate(RelationshipEvidence, :count) == 1
+
+      assert :ok = EctoStore.delete_by_chunks([edge_b.id], repo: Repo)
+      assert Repo.aggregate(Relationship, :count) == 0
+      assert Repo.aggregate(RelationshipEvidence, :count) == 0
+      assert Repo.get(Entity, alice.id)
+      assert Repo.get(Entity, bob.id)
+    end
+
+    test "publishes a fact only while it has completed-document evidence" do
+      collection = create_collection("relationship-publication")
+      completed_document = create_document(collection)
+
+      failed_document =
+        %Document{}
+        |> Document.changeset(%{
+          content: "failed",
+          status: :failed,
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+
+      completed_chunk = create_chunk(completed_document, "completed edge")
+      failed_chunk = create_chunk(failed_document, "failed edge")
+      alice = create_entity(collection, "Alice")
+      bob = create_entity(collection, "Bob")
+      id_map = %{"alice" => alice.id, "bob" => bob.id}
+      fact = [%{source: "Alice", target: "Bob", type: "knows"}]
+
+      assert :ok = EctoStore.persist_relationships(failed_chunk.id, fact, id_map, repo: Repo)
+      assert EctoStore.get_relationships(alice.id, repo: Repo) == []
+
+      assert :ok = EctoStore.persist_relationships(completed_chunk.id, fact, id_map, repo: Repo)
+      assert [%{type: "knows"}] = EctoStore.get_relationships(alice.id, repo: Repo)
+
+      assert :ok = EctoStore.delete_by_chunks([completed_chunk.id], repo: Repo)
+      assert EctoStore.get_relationships(alice.id, repo: Repo) == []
+      assert Repo.aggregate(Relationship, :count) == 1
+      assert Repo.aggregate(RelationshipEvidence, :count) == 1
     end
   end
 
@@ -633,12 +719,40 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
       assert EctoStore.search(["Alice"], nil, repo: Repo) != []
       assert EctoStore.search(["Alice"], [], repo: Repo) == []
     end
+
+    test "ignores mentions from documents that have not completed" do
+      collection = create_collection("graph-published-only")
+      entity = create_entity(collection, "Visible")
+
+      chunks =
+        for status <- [:completed, :processing, :failed], into: %{} do
+          document =
+            %Document{}
+            |> Document.changeset(%{
+              content: "#{status}",
+              status: status,
+              collection_id: collection.id
+            })
+            |> Repo.insert!()
+
+          chunk = create_chunk(document, "#{status} graph evidence")
+          create_mention(entity, chunk)
+          {status, chunk}
+        end
+
+      assert [%{chunk_id: chunk_id}] =
+               EctoStore.search(["Visible"], [collection.id], repo: Repo)
+
+      assert chunk_id == chunks.completed.id
+    end
   end
 
   describe "search_by_embedding/3" do
     test "empty collection_ids matches nothing instead of searching globally" do
       collection = create_collection()
       entity = create_entity(collection, "Alice")
+      chunk = collection |> create_document() |> create_chunk()
+      create_mention(entity, chunk)
 
       entity
       |> Ecto.Changeset.change(embedding: Enum.map(1..384, fn _ -> 0.1 end))
@@ -648,6 +762,43 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
 
       refute EctoStore.search_by_embedding(query_embedding, nil, repo: Repo, threshold: 0.1) == []
       assert EctoStore.search_by_embedding(query_embedding, [], repo: Repo, threshold: 0.1) == []
+    end
+
+    test "ignores entities supported only by documents that have not completed" do
+      collection = create_collection("embedding-published-only")
+      embedding = Enum.map(1..384, fn _ -> 0.1 end)
+
+      entities =
+        for status <- [:completed, :processing, :failed], into: %{} do
+          document =
+            %Document{}
+            |> Document.changeset(%{
+              content: "#{status}",
+              status: status,
+              collection_id: collection.id
+            })
+            |> Repo.insert!()
+
+          chunk = create_chunk(document, "#{status} embedding evidence")
+
+          entity =
+            collection
+            |> create_entity("#{status}")
+            |> Ecto.Changeset.change(embedding: embedding)
+            |> Repo.update!()
+
+          create_mention(entity, chunk)
+          {status, entity}
+        end
+
+      assert [%{id: entity_id}] =
+               EctoStore.search_by_embedding(embedding, [collection.id],
+                 repo: Repo,
+                 threshold: 0.1,
+                 limit: 10
+               )
+
+      assert entity_id == entities.completed.id
     end
   end
 
@@ -722,13 +873,18 @@ defmodule Arcana.Graph.GraphStore.EctoTest do
   end
 
   describe "find_entities/2" do
-    test "returns all entities in collection" do
+    test "returns completed-document entities in collection" do
       collection = create_collection("test-find")
       other_collection = create_collection("other")
+      chunk = collection |> create_document() |> create_chunk()
+      other_chunk = other_collection |> create_document() |> create_chunk()
 
-      create_entity(collection, "Alice", "person")
-      create_entity(collection, "Bob", "person")
-      create_entity(other_collection, "Other", "person")
+      alice = create_entity(collection, "Alice", "person")
+      bob = create_entity(collection, "Bob", "person")
+      other = create_entity(other_collection, "Other", "person")
+      create_mention(alice, chunk)
+      create_mention(bob, chunk)
+      create_mention(other, other_chunk)
 
       entities = EctoStore.find_entities(collection.id, repo: Repo)
 

--- a/test/arcana/graph/graph_store/memory_publication_test.exs
+++ b/test/arcana/graph/graph_store/memory_publication_test.exs
@@ -1,0 +1,108 @@
+defmodule Arcana.Graph.GraphStore.MemoryPublicationTest do
+  use Arcana.DataCase, async: true
+
+  alias Arcana.{Chunk, Collection, Document}
+  alias Arcana.Graph.GraphStore.Memory
+
+  setup do
+    {:ok, pid} = Memory.start_link([])
+
+    {:ok, collection} =
+      Collection.get_or_create("memory-publication-#{System.unique_integer()}", Repo)
+
+    completed = create_document(collection, :completed)
+    failed = create_document(collection, :failed)
+
+    %{
+      pid: pid,
+      collection: collection,
+      anchor: create_chunk(completed, "published anchors"),
+      edge: create_chunk(completed, "published edge"),
+      failed: create_chunk(failed, "failed edge")
+    }
+  end
+
+  test "publication-facing reads expose only completed chunk evidence", ctx do
+    entities = [
+      %{name: "Alice", type: "person"},
+      %{name: "Bob", type: "person"},
+      %{name: "Charlie", type: "person"}
+    ]
+
+    {:ok, ids} = Memory.persist_entities(ctx.collection.id, entities, pid: ctx.pid)
+
+    :ok =
+      Memory.persist_mentions(
+        [
+          %{entity_name: "Alice", chunk_id: ctx.anchor.id},
+          %{entity_name: "Bob", chunk_id: ctx.anchor.id},
+          %{entity_name: "Alice", chunk_id: ctx.failed.id},
+          %{entity_name: "Charlie", chunk_id: ctx.failed.id}
+        ],
+        ids,
+        pid: ctx.pid
+      )
+
+    fact = [%{source: "Alice", target: "Bob", type: "knows"}]
+    :ok = Memory.persist_relationships(ctx.failed.id, fact, ids, pid: ctx.pid)
+
+    opts = [pid: ctx.pid, repo: Repo]
+
+    assert [%{chunk_id: chunk_id}] = Memory.search(["Alice"], [ctx.collection.id], opts)
+    assert chunk_id == ctx.anchor.id
+
+    assert Enum.map(Memory.find_entities(ctx.collection.id, opts), & &1.name) |> Enum.sort() ==
+             ["Alice", "Bob"]
+
+    assert {:error, :not_found} = Memory.get_entity(ids["charlie"], opts)
+    assert [%{chunk_id: anchor_id}] = Memory.get_mentions(ids["alice"], opts)
+    assert anchor_id == ctx.anchor.id
+    assert Memory.get_relationships(ids["alice"], opts) == []
+
+    :ok = Memory.persist_relationships(ctx.edge.id, fact, ids, pid: ctx.pid)
+    assert [relationship] = Memory.get_relationships(ids["alice"], opts)
+
+    :ok =
+      Memory.persist_communities(
+        ctx.collection.id,
+        [
+          %{
+            id: "community",
+            level: 0,
+            summary: "Alice knows Bob",
+            entity_ids: [ids["alice"], ids["bob"]],
+            dirty: false
+          }
+        ],
+        pid: ctx.pid
+      )
+
+    :ok = Memory.delete_by_chunks([ctx.edge.id], opts)
+
+    assert {:error, :not_found} = Memory.get_relationship(relationship.id, opts)
+    assert {:ok, community} = Memory.get_community("community", opts)
+    assert community.dirty
+    assert community.entity_ids == [ids["alice"], ids["bob"]]
+    assert Memory.get_community_summaries(ctx.collection.id, opts) == []
+  end
+
+  defp create_document(collection, status) do
+    %Document{}
+    |> Document.changeset(%{
+      content: "#{status} document",
+      collection_id: collection.id,
+      status: status
+    })
+    |> Repo.insert!()
+  end
+
+  defp create_chunk(document, text) do
+    %Chunk{}
+    |> Chunk.changeset(%{
+      text: text,
+      document_id: document.id,
+      embedding: Enum.map(1..384, fn _ -> 0.0 end)
+    })
+    |> Repo.insert!()
+  end
+end

--- a/test/arcana/graph/graph_store/memory_publication_test.exs
+++ b/test/arcana/graph/graph_store/memory_publication_test.exs
@@ -86,6 +86,108 @@ defmodule Arcana.Graph.GraphStore.MemoryPublicationTest do
     assert Memory.get_community_summaries(ctx.collection.id, opts) == []
   end
 
+  test "deleting failed-only relationship evidence keeps communities clean", ctx do
+    entities = [%{name: "Alice", type: "person"}, %{name: "Bob", type: "person"}]
+    {:ok, ids} = Memory.persist_entities(ctx.collection.id, entities, pid: ctx.pid)
+
+    :ok =
+      Memory.persist_mentions(
+        [
+          %{entity_name: "Alice", chunk_id: ctx.anchor.id},
+          %{entity_name: "Bob", chunk_id: ctx.anchor.id}
+        ],
+        ids,
+        pid: ctx.pid
+      )
+
+    :ok =
+      Memory.persist_relationships(
+        ctx.failed.id,
+        [%{source: "Alice", target: "Bob", type: "knows"}],
+        ids,
+        pid: ctx.pid
+      )
+
+    :ok =
+      Memory.persist_communities(
+        ctx.collection.id,
+        [
+          %{
+            id: "community",
+            level: 0,
+            summary: "Alice and Bob",
+            entity_ids: [ids["alice"], ids["bob"]],
+            dirty: false
+          }
+        ],
+        pid: ctx.pid
+      )
+
+    :ok = Memory.delete_by_chunks([ctx.failed.id], pid: ctx.pid, repo: Repo)
+
+    assert {:ok, community} = Memory.get_community("community", pid: ctx.pid)
+    refute community.dirty
+  end
+
+  test "Arcana.delete preserves removed publication evidence for external memory cleanup", ctx do
+    entity_extractor = fn _text, _opts ->
+      {:ok, [%{name: "Alice", type: "person"}, %{name: "Bob", type: "person"}]}
+    end
+
+    relationship_extractor = fn text, _entities, _opts ->
+      if text =~ "edge" do
+        {:ok, [%{source: "Alice", target: "Bob", type: "knows"}]}
+      else
+        {:ok, []}
+      end
+    end
+
+    opts = [
+      repo: Repo,
+      graph: true,
+      graph_store: {Memory, pid: ctx.pid},
+      entity_extractor: entity_extractor,
+      relationship_extractor: relationship_extractor,
+      collection: ctx.collection.name
+    ]
+
+    {:ok, edge_document} = Arcana.ingest("published edge", opts)
+    {:ok, _anchor_document} = Arcana.ingest("published anchor", opts)
+
+    [alice, bob] =
+      ctx.collection.id
+      |> Memory.find_entities(pid: ctx.pid, repo: Repo)
+      |> Enum.sort_by(& &1.name)
+
+    :ok =
+      Memory.persist_communities(
+        ctx.collection.id,
+        [
+          %{
+            id: "delete-community",
+            level: 0,
+            summary: "Alice knows Bob",
+            entity_ids: [alice.id, bob.id],
+            dirty: false
+          }
+        ],
+        pid: ctx.pid
+      )
+
+    # The wrapper returns a stale :processing copy from Arcana.delete/2's
+    # initial lookup while the locked transaction reload sees the real
+    # :completed row. This deterministically models completion winning the
+    # race immediately before deletion acquires its row lock.
+    delete_opts = Keyword.put(opts, :repo, Arcana.StaleDocumentStatusRepo)
+    assert :ok = Arcana.delete(edge_document.id, delete_opts)
+
+    assert Enum.map(Memory.find_entities(ctx.collection.id, pid: ctx.pid, repo: Repo), & &1.name)
+           |> Enum.sort() == ["Alice", "Bob"]
+
+    assert {:ok, community} = Memory.get_community("delete-community", pid: ctx.pid)
+    assert community.dirty
+  end
+
   defp create_document(collection, status) do
     %Document{}
     |> Document.changeset(%{

--- a/test/arcana/graph/graph_store/memory_test.exs
+++ b/test/arcana/graph/graph_store/memory_test.exs
@@ -457,4 +457,68 @@ defmodule Arcana.Graph.GraphStore.MemoryTest do
       assert comm2.entity_ids == [id_map["kept"]]
     end
   end
+
+  test "with_write_lock serializes the full function per collection", %{pid: pid} do
+    parent = self()
+    collection_id = Ecto.UUID.generate()
+
+    first =
+      Task.async(fn ->
+        Memory.with_write_lock(collection_id, [pid: pid], fn ->
+          send(parent, :first_entered)
+
+          receive do
+            :release_first -> :ok
+          end
+        end)
+      end)
+
+    assert_receive :first_entered
+
+    second =
+      Task.async(fn ->
+        Memory.with_write_lock(collection_id, [pid: pid], fn ->
+          send(parent, :second_entered)
+        end)
+      end)
+
+    refute_receive :second_entered, 50
+    send(first.pid, :release_first)
+    assert :ok = Task.await(first)
+    assert_receive :second_entered, 1_000
+    assert :second_entered = Task.await(second)
+  end
+
+  test "with_write_lock canonicalizes named and pid references" do
+    parent = self()
+    collection_id = Ecto.UUID.generate()
+    name = {:global, {__MODULE__, make_ref()}}
+    pid = start_supervised!({Memory, name: name})
+
+    first =
+      Task.async(fn ->
+        Memory.with_write_lock(collection_id, [name: name], fn ->
+          send(parent, :named_entered)
+
+          receive do
+            :release_named -> :ok
+          end
+        end)
+      end)
+
+    assert_receive :named_entered
+
+    second =
+      Task.async(fn ->
+        Memory.with_write_lock(collection_id, [pid: pid], fn ->
+          send(parent, :pid_entered)
+        end)
+      end)
+
+    refute_receive :pid_entered, 50
+    send(first.pid, :release_named)
+    assert :ok = Task.await(first)
+    assert_receive :pid_entered, 1_000
+    assert :pid_entered = Task.await(second)
+  end
 end

--- a/test/arcana/graph/graph_store/memory_test.exs
+++ b/test/arcana/graph/graph_store/memory_test.exs
@@ -143,14 +143,51 @@ defmodule Arcana.Graph.GraphStore.MemoryTest do
         %{source: "Alice", target: "Bob", type: "knows"}
       ]
 
-      assert :ok = Memory.persist_relationships(relationships, id_map, pid: pid)
+      assert :ok = Memory.persist_relationships("chunk-1", relationships, id_map, pid: pid)
     end
 
     test "skips relationships with missing entities", %{pid: pid} do
       id_map = %{"Alice" => Ecto.UUID.generate()}
       relationships = [%{source: "Alice", target: "Unknown", type: "knows"}]
 
-      assert :ok = Memory.persist_relationships(relationships, id_map, pid: pid)
+      assert :ok = Memory.persist_relationships("chunk-1", relationships, id_map, pid: pid)
+    end
+
+    test "canonicalizes facts and removes them only after their final evidence is deleted", %{
+      pid: pid
+    } do
+      {:ok, id_map} =
+        Memory.persist_entities(
+          "col-1",
+          [%{name: "Alice", type: "person"}, %{name: "Bob", type: "person"}],
+          pid: pid
+        )
+
+      :ok =
+        Memory.persist_mentions(
+          [
+            %{entity_name: "Alice", chunk_id: "anchor"},
+            %{entity_name: "Bob", chunk_id: "anchor"}
+          ],
+          id_map,
+          pid: pid
+        )
+
+      fact = [%{source: "Alice", target: "Bob", type: "knows"}]
+
+      assert :ok = Memory.persist_relationships("edge-a", fact, id_map, pid: pid)
+      assert :ok = Memory.persist_relationships("edge-a", fact, id_map, pid: pid)
+      assert :ok = Memory.persist_relationships("edge-b", fact, id_map, pid: pid)
+
+      assert [_] = Memory.get_relationships(id_map["alice"], pid: pid)
+
+      assert :ok = Memory.delete_by_chunks(["edge-a"], pid: pid)
+      assert [_] = Memory.get_relationships(id_map["alice"], pid: pid)
+
+      assert :ok = Memory.delete_by_chunks(["edge-b"], pid: pid)
+      assert Memory.get_relationships(id_map["alice"], pid: pid) == []
+      assert {:ok, _} = Memory.get_entity(id_map["alice"], pid: pid)
+      assert {:ok, _} = Memory.get_entity(id_map["bob"], pid: pid)
     end
   end
 
@@ -267,7 +304,7 @@ defmodule Arcana.Graph.GraphStore.MemoryTest do
         %{source: "Bob", target: "Charlie", type: "knows"}
       ]
 
-      :ok = Memory.persist_relationships(relationships, id_map, pid: pid)
+      :ok = Memory.persist_relationships("chunk-1", relationships, id_map, pid: pid)
 
       # From Alice, depth 1 should find Bob
       alice_id = id_map["alice"]
@@ -326,6 +363,7 @@ defmodule Arcana.Graph.GraphStore.MemoryTest do
 
       :ok =
         Memory.persist_relationships(
+          "chunk-orphan",
           [%{source: "Orphan", target: "Kept", type: "RELATED"}],
           id_map,
           pid: pid

--- a/test/arcana/graph/graph_store_test.exs
+++ b/test/arcana/graph/graph_store_test.exs
@@ -11,7 +11,7 @@ defmodule Arcana.Graph.GraphStoreTest do
 
     test "defines persist_relationships callback" do
       callbacks = GraphStore.behaviour_info(:callbacks)
-      assert {:persist_relationships, 3} in callbacks
+      assert {:persist_relationships, 4} in callbacks
     end
 
     test "defines persist_mentions callback" do

--- a/test/arcana/graph/relationship_test.exs
+++ b/test/arcana/graph/relationship_test.exs
@@ -80,6 +80,25 @@ defmodule Arcana.Graph.RelationshipTest do
       changeset = Relationship.changeset(%Relationship{}, Map.put(base_attrs, :strength, 5))
       assert changeset.valid?
     end
+
+    test "canonicalizes metadata before fingerprinting" do
+      attrs = %{
+        type: "WORKS_FOR",
+        source_id: Ecto.UUID.generate(),
+        target_id: Ecto.UUID.generate()
+      }
+
+      atom_keys =
+        Relationship.changeset(%Relationship{}, Map.put(attrs, :metadata, %{role: "ceo"}))
+
+      string_keys =
+        Relationship.changeset(%Relationship{}, Map.put(attrs, :metadata, %{"role" => "ceo"}))
+
+      assert Ecto.Changeset.get_field(atom_keys, :metadata) == %{"role" => "ceo"}
+
+      assert Ecto.Changeset.get_field(atom_keys, :fingerprint) ==
+               Ecto.Changeset.get_field(string_keys, :fingerprint)
+    end
   end
 
   describe "database operations" do

--- a/test/arcana/graph/relationship_test.exs
+++ b/test/arcana/graph/relationship_test.exs
@@ -99,6 +99,12 @@ defmodule Arcana.Graph.RelationshipTest do
       assert Ecto.Changeset.get_field(atom_keys, :fingerprint) ==
                Ecto.Changeset.get_field(string_keys, :fingerprint)
     end
+
+    test "keeps metadata whose JSON encoder returns invalid iodata" do
+      metadata = %Arcana.InvalidJSONMetadata{value: "kept"}
+
+      assert Relationship.normalized_metadata(metadata) == metadata
+    end
   end
 
   describe "database operations" do

--- a/test/arcana/graph_expand_test.exs
+++ b/test/arcana/graph_expand_test.exs
@@ -1,9 +1,9 @@
 defmodule Arcana.GraphExpandTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Collection
+  alias Arcana.{Chunk, Collection, Document}
   alias Arcana.Graph
-  alias Arcana.Graph.{Entity, Relationship}
+  alias Arcana.Graph.{Entity, EntityMention, Relationship, RelationshipEvidence}
 
   defp create_collection(name) do
     %Collection{}
@@ -12,15 +12,60 @@ defmodule Arcana.GraphExpandTest do
   end
 
   defp create_entity(collection, name, type \\ "person") do
-    %Entity{}
-    |> Entity.changeset(%{name: name, type: type, collection_id: collection.id})
+    entity =
+      %Entity{}
+      |> Entity.changeset(%{name: name, type: type, collection_id: collection.id})
+      |> Repo.insert!()
+
+    add_evidence(entity, collection, :completed)
+    entity
+  end
+
+  defp add_evidence(entity, collection, status) do
+    document =
+      %Document{}
+      |> Document.changeset(%{
+        content: "#{status} evidence",
+        status: status,
+        collection_id: collection.id
+      })
+      |> Repo.insert!()
+
+    chunk =
+      %Chunk{}
+      |> Chunk.changeset(%{
+        text: "#{status} evidence",
+        embedding: List.duplicate(0.1, 384),
+        document_id: document.id
+      })
+      |> Repo.insert!()
+
+    %EntityMention{}
+    |> EntityMention.changeset(%{entity_id: entity.id, chunk_id: chunk.id})
     |> Repo.insert!()
   end
 
   defp create_relationship(source, target, type \\ "knows") do
-    %Relationship{}
-    |> Relationship.changeset(%{source_id: source.id, target_id: target.id, type: type})
+    relationship =
+      %Relationship{}
+      |> Relationship.changeset(%{source_id: source.id, target_id: target.id, type: type})
+      |> Repo.insert!()
+
+    chunk_id =
+      Repo.one!(
+        from(m in EntityMention,
+          where: m.entity_id == ^source.id,
+          order_by: m.inserted_at,
+          limit: 1,
+          select: m.chunk_id
+        )
+      )
+
+    %RelationshipEvidence{}
+    |> RelationshipEvidence.changeset(%{relationship_id: relationship.id, chunk_id: chunk_id})
     |> Repo.insert!()
+
+    relationship
   end
 
   describe "query_depth/1" do
@@ -122,6 +167,29 @@ defmodule Arcana.GraphExpandTest do
 
     test "empty input returns empty map" do
       assert Graph.expand_entity_ids([], 2, nil, repo: Repo) == %{}
+    end
+
+    test "does not traverse through an entity supported only by a failed document", ctx do
+      %{collection: collection, alice: alice} = ctx
+      published_target = create_entity(collection, "Published target")
+
+      failed_bridge =
+        %Entity{}
+        |> Entity.changeset(%{
+          name: "Failed bridge",
+          type: "person",
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+
+      add_evidence(failed_bridge, collection, :failed)
+      create_relationship(alice, failed_bridge)
+      create_relationship(failed_bridge, published_target)
+
+      expanded = Graph.expand_entity_ids([alice.id], 2, nil, repo: Repo)
+
+      refute failed_bridge.id in Map.get(expanded, 1, [])
+      refute published_target.id in Map.get(expanded, 2, [])
     end
   end
 end

--- a/test/arcana/graph_integration_test.exs
+++ b/test/arcana/graph_integration_test.exs
@@ -791,7 +791,8 @@ defmodule Arcana.GraphIntegrationTest do
           collection: "sweep-fails"
         )
 
-      assert {:error, {:post_commit_graph_cleanup_failed, {:sweep_failed, :sweep_boom}}} =
+      assert {:error,
+              {:post_commit_graph_cleanup_failed, %{reason: {:sweep_failed, :sweep_boom}}}} =
                Arcana.delete(doc.id,
                  repo: Repo,
                  graph: true,
@@ -802,6 +803,57 @@ defmodule Arcana.GraphIntegrationTest do
       # first so a later caller rollback can never restore published DB data
       # after the external graph has already been removed.
       assert Repo.get(Arcana.Document, doc.id) == nil
+    end
+
+    test "replace reports an external predecessor cleanup failure after committing the swap" do
+      extractor = fn _text, _opts -> {:ok, [%{name: "Theta", type: "concept"}]} end
+      collection = "replace-cleanup-fails-#{System.unique_integer()}"
+
+      opts = [
+        repo: Repo,
+        graph: true,
+        entity_extractor: extractor,
+        graph_store: Arcana.FailingDeleteGraphStore,
+        collection: collection,
+        source_id: "doc-1",
+        replace: true
+      ]
+
+      {:ok, old} = Arcana.ingest("v1", opts)
+
+      assert {:error,
+              {:post_commit_graph_cleanup_failed,
+               %{
+                 reason: :delete_boom,
+                 chunk_ids: chunk_ids,
+                 published_chunk_ids: chunk_ids,
+                 collection_id: collection_id
+               } = cleanup}} = Arcana.ingest("v2", opts)
+
+      assert [%{id: replacement_id, content: "v2", status: :completed}] =
+               documents_in(collection)
+
+      refute replacement_id == old.id
+      assert collection_id == old.collection_id
+      assert chunk_ids != []
+
+      assert :ok =
+               GraphStore.delete_by_chunks(chunk_ids,
+                 repo: Repo,
+                 graph_store: {Arcana.FailingDeleteGraphStore, delete_failure: :ok},
+                 published_chunk_ids: cleanup.published_chunk_ids
+               )
+
+      assert :ok =
+               GraphStore.sweep_orphans(collection_id,
+                 repo: Repo,
+                 graph_store: {Arcana.FailingDeleteGraphStore, delete_failure: :ok}
+               )
+    end
+
+    test "replace wraps external predecessor cleanup exceptions and exits after committing" do
+      assert %RuntimeError{message: "delete_boom"} = replace_cleanup_failure(:raise)
+      assert :delete_boom = replace_cleanup_failure(:exit)
     end
 
     test "build and sweep use the same per-call graph store" do
@@ -872,6 +924,40 @@ defmodule Arcana.GraphIntegrationTest do
       # Entity survives (stranded, but sweeping requires graph enabled)
       assert Repo.get(Entity, gamma.id)
     end
+  end
+
+  defp replace_cleanup_failure(failure) do
+    extractor = fn _text, _opts -> {:ok, [%{name: "Iota", type: "concept"}]} end
+    collection = "replace-cleanup-#{failure}-#{System.unique_integer()}"
+
+    opts = [
+      repo: Repo,
+      graph: true,
+      entity_extractor: extractor,
+      graph_store: {Arcana.FailingDeleteGraphStore, delete_failure: failure},
+      collection: collection,
+      source_id: "doc-1",
+      replace: true
+    ]
+
+    {:ok, old} = Arcana.ingest("v1", opts)
+
+    assert {:error,
+            {:post_commit_graph_cleanup_failed,
+             %{
+               reason: reason,
+               chunk_ids: chunk_ids,
+               published_chunk_ids: chunk_ids,
+               collection_id: collection_id
+             }}} = Arcana.ingest("v2", opts)
+
+    assert [%{id: replacement_id, content: "v2", status: :completed}] =
+             documents_in(collection)
+
+    refute replacement_id == old.id
+    assert collection_id == old.collection_id
+    assert chunk_ids != []
+    reason
   end
 
   describe "config/0" do

--- a/test/arcana/graph_integration_test.exs
+++ b/test/arcana/graph_integration_test.exs
@@ -1,7 +1,15 @@
 defmodule Arcana.GraphIntegrationTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Graph.{Community, Entity, EntityMention, Relationship}
+  alias Arcana.Graph.{
+    Community,
+    Entity,
+    EntityMention,
+    GraphStore,
+    Relationship,
+    RelationshipEvidence
+  }
+
   alias Ecto.Adapters.SQL.Sandbox
 
   # Scoped to the collection under test: the documents table is shared with
@@ -62,10 +70,17 @@ defmodule Arcana.GraphIntegrationTest do
     |> Repo.insert!()
   end
 
-  defp create_relationship(source, target, type \\ "knows") do
-    %Relationship{}
-    |> Relationship.changeset(%{source_id: source.id, target_id: target.id, type: type})
+  defp create_relationship(source, target, chunk, type \\ "knows") do
+    relationship =
+      %Relationship{}
+      |> Relationship.changeset(%{source_id: source.id, target_id: target.id, type: type})
+      |> Repo.insert!()
+
+    %RelationshipEvidence{}
+    |> RelationshipEvidence.changeset(%{relationship_id: relationship.id, chunk_id: chunk.id})
     |> Repo.insert!()
+
+    relationship
   end
 
   describe "graph_enabled?/1" do
@@ -483,9 +498,9 @@ defmodule Arcana.GraphIntegrationTest do
       create_mention(carol, chunk_c)
       create_mention(dave, chunk_d)
 
-      create_relationship(alice, bob)
-      create_relationship(bob, carol)
-      create_relationship(alice, dave)
+      create_relationship(alice, bob, chunk_a)
+      create_relationship(bob, carol, chunk_b)
+      create_relationship(alice, dave, chunk_a)
 
       opts = [
         repo: Repo,
@@ -579,6 +594,32 @@ defmodule Arcana.GraphIntegrationTest do
   end
 
   describe "delete/2 with graph enabled" do
+    test "removes a fact's last evidence without deleting surviving community members" do
+      collection = create_collection("edge-delete-#{System.unique_integer()}")
+      edge_document = create_document(collection, %{content: "edge evidence"})
+      anchor_document = create_document(collection, %{content: "entity anchors"})
+      edge_chunk = create_chunk(edge_document, "Alice knows Bob")
+      anchor_chunk = create_chunk(anchor_document, "Alice and Bob")
+      alice = create_entity(collection, "Alice")
+      bob = create_entity(collection, "Bob")
+      create_mention(alice, anchor_chunk)
+      create_mention(bob, anchor_chunk)
+      relationship = create_relationship(alice, bob, edge_chunk)
+      community = insert_community(collection.id, [alice.id, bob.id])
+
+      assert :ok = Arcana.delete(edge_document.id, repo: Repo, graph: true)
+
+      assert Repo.get(Relationship, relationship.id) == nil
+      assert Repo.get(Entity, alice.id)
+      assert Repo.get(Entity, bob.id)
+
+      community = Repo.get!(Community, community.id)
+      assert community.dirty
+      assert community.entity_ids == [alice.id, bob.id]
+
+      assert GraphStore.get_community_summaries(collection.id, repo: Repo) == []
+    end
+
     test "sweeps zero-mention entities in the document's collection and dirties overlapping communities" do
       extractor = fn text, _opts ->
         cond do
@@ -662,7 +703,83 @@ defmodule Arcana.GraphIntegrationTest do
       refute "OldEntity" in names
     end
 
-    test "a failing sweep rolls the delete back rather than half-finishing" do
+    test "replace: true removes predecessor-only relationship evidence" do
+      entity_extractor = fn _text, _opts ->
+        {:ok, [%{name: "Alice", type: "person"}, %{name: "Bob", type: "person"}]}
+      end
+
+      relationship_extractor = fn text, _entities, _opts ->
+        if text =~ "v1" do
+          {:ok, [%{source: "Alice", target: "Bob", type: "knows"}]}
+        else
+          {:ok, []}
+        end
+      end
+
+      opts = [
+        repo: Repo,
+        graph: true,
+        entity_extractor: entity_extractor,
+        relationship_extractor: relationship_extractor,
+        collection: "replace-edge-#{System.unique_integer()}",
+        source_id: "doc-1",
+        replace: true
+      ]
+
+      {:ok, _v1} = Arcana.ingest("v1 relationship", opts)
+      relationship = Repo.one!(Relationship)
+      alice = Repo.one!(from(e in Entity, where: e.name == "Alice"))
+      bob = Repo.one!(from(e in Entity, where: e.name == "Bob"))
+      community = insert_community(alice.collection_id, [alice.id, bob.id])
+
+      {:ok, _v2} = Arcana.ingest("v2 without the relationship", opts)
+
+      assert Repo.get(Relationship, relationship.id) == nil
+      assert Repo.get(Entity, alice.id)
+      assert Repo.get(Entity, bob.id)
+
+      community = Repo.get!(Community, community.id)
+      assert community.dirty
+      assert community.entity_ids == [alice.id, bob.id]
+    end
+
+    test "replace: true keeps an identical relationship's community clean" do
+      entity_extractor = fn _text, _opts ->
+        {:ok, [%{name: "Alice", type: "person"}, %{name: "Bob", type: "person"}]}
+      end
+
+      relationship_extractor = fn _text, _entities, _opts ->
+        {:ok, [%{source: "Alice", target: "Bob", type: "knows"}]}
+      end
+
+      opts = [
+        repo: Repo,
+        graph: true,
+        entity_extractor: entity_extractor,
+        relationship_extractor: relationship_extractor,
+        collection: "replace-same-edge-#{System.unique_integer()}",
+        source_id: "doc-1",
+        replace: true
+      ]
+
+      {:ok, _v1} = Arcana.ingest("v1 relationship", opts)
+      relationship = Repo.one!(Relationship)
+      alice = Repo.one!(from(e in Entity, where: e.name == "Alice"))
+      bob = Repo.one!(from(e in Entity, where: e.name == "Bob"))
+      community = insert_community(alice.collection_id, [alice.id, bob.id])
+
+      {:ok, _v2} = Arcana.ingest("v2 same relationship", opts)
+
+      assert Repo.get(Relationship, relationship.id)
+      refute Repo.get!(Community, community.id).dirty
+
+      assert [%{id: community_id}] =
+               GraphStore.get_community_summaries(alice.collection_id, repo: Repo)
+
+      assert community_id == community.id
+    end
+
+    test "a failing external sweep reports post-commit cleanup failure" do
       extractor = fn _text, _opts -> {:ok, [%{name: "Delta", type: "concept"}]} end
 
       {:ok, doc} =
@@ -674,18 +791,17 @@ defmodule Arcana.GraphIntegrationTest do
           collection: "sweep-fails"
         )
 
-      assert {:error, {:sweep_failed, :sweep_boom}} =
+      assert {:error, {:post_commit_graph_cleanup_failed, {:sweep_failed, :sweep_boom}}} =
                Arcana.delete(doc.id,
                  repo: Repo,
                  graph: true,
                  graph_store: Arcana.FailingSweepGraphStore
                )
 
-      # The sweep shares the delete's transaction, so a failed cleanup takes
-      # the delete with it. This used to report the failure *after* deleting
-      # the document, which left the caller an error it could not retry.
-      assert Repo.get(Arcana.Document, doc.id),
-             "a failed sweep must leave the document in place"
+      # External stores cannot join the Ecto transaction. The document commits
+      # first so a later caller rollback can never restore published DB data
+      # after the external graph has already been removed.
+      assert Repo.get(Arcana.Document, doc.id) == nil
     end
 
     test "build and sweep use the same per-call graph store" do

--- a/test/arcana/graph_integration_test.exs
+++ b/test/arcana/graph_integration_test.exs
@@ -594,6 +594,17 @@ defmodule Arcana.GraphIntegrationTest do
   end
 
   describe "delete/2 with graph enabled" do
+    test "sweeps the document collection when its chunks have no graph mentions" do
+      collection = create_collection("mentionless-delete-#{System.unique_integer()}")
+      document = create_document(collection)
+      _chunk = create_chunk(document, "no extracted entities")
+      orphan = create_entity(collection, "AlreadyOrphaned")
+
+      assert :ok = Arcana.delete(document.id, repo: Repo, graph: true)
+
+      refute Repo.get(Entity, orphan.id)
+    end
+
     test "removes a fact's last evidence without deleting surviving community members" do
       collection = create_collection("edge-delete-#{System.unique_integer()}")
       edge_document = create_document(collection, %{content: "edge evidence"})

--- a/test/arcana/graph_lifecycle_race_test.exs
+++ b/test/arcana/graph_lifecycle_race_test.exs
@@ -1,0 +1,140 @@
+defmodule Arcana.GraphLifecycleRaceTest do
+  use Arcana.DataCase, async: true
+
+  alias Ecto.Adapters.SQL.Sandbox
+
+  alias Arcana.{Chunk, Collection, Document}
+
+  test "external delete retires the chunk before queued graph persistence can write" do
+    collection = create_collection("delete-race")
+    document = create_document(collection, :processing, "delete-race")
+    chunk = create_chunk(document, "Alice knows Bob")
+    chunk_id = chunk.id
+    opts = lifecycle_opts(collection)
+    collection_id = collection.id
+
+    delete_task = async_with_repo(fn -> Arcana.delete(document.id, opts) end)
+    {delete_ref, ^collection_id} = await_lock(delete_task.pid)
+
+    persist_task = async_with_repo(fn -> persist_chunk(chunk, collection, opts) end)
+    {persist_ref, ^collection_id} = await_lock(persist_task.pid)
+
+    grant_lock(delete_task.pid, delete_ref)
+    assert :ok = Task.await(delete_task)
+    assert_receive {:graph_lock_released, _, ^delete_ref, _}
+
+    grant_lock(persist_task.pid, persist_ref)
+
+    assert {:ok, %{entity_count: 0, relationship_count: 0}} = Task.await(persist_task)
+    assert_receive {:graph_lock_released, _, ^persist_ref, _}
+    refute_received {:controlled_graph_store, {:persist_relationships, ^chunk_id, _}}
+  end
+
+  test "external replace retires predecessor chunks before queued persistence can write" do
+    collection = create_collection("replace-race")
+    predecessor = create_document(collection, :processing, "same-source")
+    predecessor_chunk = create_chunk(predecessor, "Alice knows Bob")
+    predecessor_chunk_id = predecessor_chunk.id
+    opts = lifecycle_opts(collection, source_id: "same-source", replace: true)
+    collection_id = collection.id
+
+    replace_task =
+      async_with_repo(fn ->
+        Arcana.ingest("replacement", opts)
+      end)
+
+    {build_ref, ^collection_id} = await_lock(replace_task.pid)
+    grant_lock(replace_task.pid, build_ref)
+    assert_receive {:graph_lock_released, _, ^build_ref, _}
+
+    {replace_ref, ^collection_id} = await_lock(replace_task.pid)
+
+    persist_task =
+      async_with_repo(fn -> persist_chunk(predecessor_chunk, collection, opts) end)
+
+    {persist_ref, ^collection_id} = await_lock(persist_task.pid)
+
+    grant_lock(replace_task.pid, replace_ref)
+    assert {:ok, replacement} = Task.await(replace_task)
+    assert replacement.source_id == "same-source"
+    assert_receive {:graph_lock_released, _, ^replace_ref, _}
+
+    grant_lock(persist_task.pid, persist_ref)
+
+    assert {:ok, %{entity_count: 0, relationship_count: 0}} = Task.await(persist_task)
+    assert_receive {:graph_lock_released, _, ^persist_ref, _}
+
+    refute Repo.get(Document, predecessor.id)
+
+    refute_received {:controlled_graph_store, {:persist_relationships, ^predecessor_chunk_id, _}}
+  end
+
+  defp lifecycle_opts(collection, extra \\ []) do
+    Keyword.merge(
+      [
+        repo: Repo,
+        graph: true,
+        graph_store: {Arcana.ControlledGraphStore, coordinator: self(), notify: self()},
+        entity_extractor: fn _text, _opts ->
+          {:ok, [%{name: "Alice", type: "person"}, %{name: "Bob", type: "person"}]}
+        end,
+        relationship_extractor: fn _text, _entities, _opts ->
+          {:ok, [%{source: "Alice", target: "Bob", type: "knows"}]}
+        end,
+        collection: collection.name
+      ],
+      extra
+    )
+  end
+
+  defp persist_chunk(chunk, collection, opts) do
+    Arcana.Graph.build_and_persist([chunk], collection, Repo, opts)
+  end
+
+  defp async_with_repo(fun) do
+    task =
+      Task.async(fn ->
+        receive do
+          :run -> fun.()
+        end
+      end)
+
+    Sandbox.allow(Repo, self(), task.pid)
+    send(task.pid, :run)
+    task
+  end
+
+  defp await_lock(pid) do
+    assert_receive {:graph_lock_waiting, ^pid, ref, collection_id}, 1_000
+    {ref, collection_id}
+  end
+
+  defp grant_lock(pid, ref), do: send(pid, {:grant_graph_lock, ref})
+
+  defp create_collection(prefix) do
+    %Collection{}
+    |> Collection.changeset(%{name: "#{prefix}-#{System.unique_integer([:positive])}"})
+    |> Repo.insert!()
+  end
+
+  defp create_document(collection, status, source_id) do
+    %Document{}
+    |> Document.changeset(%{
+      content: "predecessor",
+      collection_id: collection.id,
+      source_id: source_id,
+      status: status
+    })
+    |> Repo.insert!()
+  end
+
+  defp create_chunk(document, text) do
+    %Chunk{}
+    |> Chunk.changeset(%{
+      text: text,
+      document_id: document.id,
+      embedding: Enum.map(1..384, fn _ -> 0.0 end)
+    })
+    |> Repo.insert!()
+  end
+end

--- a/test/arcana/llm_test.exs
+++ b/test/arcana/llm_test.exs
@@ -60,7 +60,7 @@ defmodule Arcana.LLMTest do
     end
 
     test "model string with opts still dispatches through the tuple impl" do
-      assert LLM.impl_for({"openai:gpt-4o-mini", api_key: "k"}) != nil
+      assert LLM.impl_for({"openai:gpt-4o-mini", api_key: "k"}) == Arcana.LLM.Tuple
     end
   end
 
@@ -70,13 +70,13 @@ defmodule Arcana.LLMTest do
       model = "openai:gpt-4o-mini"
 
       # The protocol should be implemented for BitString
-      assert LLM.impl_for(model) != nil
+      assert LLM.impl_for(model) == Arcana.LLM.BitString
     end
 
     test "works with Anthropic model string" do
       model = "anthropic:claude-sonnet-4-20250514"
 
-      assert LLM.impl_for(model) != nil
+      assert LLM.impl_for(model) == Arcana.LLM.BitString
     end
   end
 end

--- a/test/arcana/loop_test.exs
+++ b/test/arcana/loop_test.exs
@@ -141,6 +141,15 @@ defmodule Arcana.LoopTest do
       refute :collection in param_names
     end
 
+    test "canonical public inputs build the expected search tool" do
+      for scope <- [:all, "docs", []] do
+        search = Enum.find(Tools.default(scope), &(&1.name == "search"))
+        param_names = Enum.map(search.parameter_schema, &elem(&1, 0))
+
+        refute :collection in param_names
+      end
+    end
+
     test "multi-collection context: search tool gains :collection param listing choices" do
       tools = Tools.default(["docs", "wiki", "changelog"])
       search = Enum.find(tools, &(&1.name == "search"))
@@ -162,6 +171,66 @@ defmodule Arcana.LoopTest do
   end
 
   describe "Tools.execute search collection arg" do
+    test ":all context explicitly searches every collection" do
+      search_fn = fn _q, opts ->
+        send(self(), {:search_opts, opts})
+        {:ok, []}
+      end
+
+      ctx = %Context{repo: nil, collections: :all}
+
+      Tools.execute(ctx, "search", %{query: "q"}, search_fn: search_fn)
+
+      assert_received {:search_opts, opts}
+      assert opts[:collection] == :all
+    end
+
+    test "legacy [nil] context still searches every collection" do
+      search_fn = fn _q, opts ->
+        send(self(), {:search_opts, opts})
+        {:ok, []}
+      end
+
+      ctx = %Context{repo: nil, collections: [nil]}
+
+      Tools.execute(ctx, "search", %{query: "q"}, search_fn: search_fn)
+
+      assert_received {:search_opts, opts}
+      assert opts[:collection] == :all
+    end
+
+    test "extra search options cannot override the context scope" do
+      search_fn = fn _q, opts ->
+        send(self(), {:search_opts, opts})
+        {:ok, []}
+      end
+
+      ctx = %Context{repo: nil, collections: ["allowed"]}
+
+      Tools.execute(ctx, "search", %{query: "q"},
+        search_fn: search_fn,
+        search_opts: [collection: :all, tenant_id: "tenant-a"]
+      )
+
+      assert_received {:search_opts, opts}
+      assert opts[:collection] == "allowed"
+      assert opts[:tenant_id] == "tenant-a"
+    end
+
+    test "empty context preserves the match-nothing scope" do
+      search_fn = fn _q, opts ->
+        send(self(), {:search_opts, opts})
+        {:ok, []}
+      end
+
+      ctx = %Context{repo: nil, collections: []}
+
+      Tools.execute(ctx, "search", %{query: "q"}, search_fn: search_fn)
+
+      assert_received {:search_opts, opts}
+      assert opts[:collections] == []
+    end
+
     test "multi-collection ctx + no collection arg → searches across all" do
       search_fn = fn _q, opts ->
         send(self(), {:search_opts, opts})
@@ -227,6 +296,20 @@ defmodule Arcana.LoopTest do
       assert_received {:search_opts, opts}
       assert opts[:collection] == "locked"
     end
+
+    test "a context carrying the public string shape locks that collection" do
+      search_fn = fn _q, opts ->
+        send(self(), {:search_opts, opts})
+        {:ok, []}
+      end
+
+      ctx = %Context{repo: nil, collections: "locked"}
+
+      Tools.execute(ctx, "search", %{query: "q"}, search_fn: search_fn)
+
+      assert_received {:search_opts, opts}
+      assert opts[:collection] == "locked"
+    end
   end
 
   describe "SystemPrompt.default/1 collections section" do
@@ -252,6 +335,11 @@ defmodule Arcana.LoopTest do
 
       refute prompt =~ "# Collections"
     end
+
+    test "canonical unrestricted and empty scopes omit the Collections section" do
+      refute SystemPrompt.default(collections: :all) =~ "# Collections"
+      refute SystemPrompt.default(collections: []) =~ "# Collections"
+    end
   end
 
   describe "new/2" do
@@ -268,6 +356,24 @@ defmodule Arcana.LoopTest do
     test "stores collections list when given" do
       ctx = Loop.new("question", collections: ["a", "b"])
       assert ctx.collections == ["a", "b"]
+    end
+
+    test "normalizes every public collection scope shape" do
+      assert Loop.new("question").collections == :all
+      assert Loop.new("question", collection: :all).collections == :all
+      assert Loop.new("question", collection: "a").collections == ["a"]
+      assert Loop.new("question", collection: ["a", "b"]).collections == ["a", "b"]
+      assert Loop.new("question", collections: []).collections == []
+      assert Loop.new("question", collections: [nil]).collections == :all
+      assert Loop.new("question", collection: [nil]).collections == :all
+    end
+
+    test "rejects conflicting or invalid collection scopes" do
+      assert_raise ArgumentError, fn ->
+        Loop.new("question", collection: "a", collections: ["b"])
+      end
+
+      assert_raise ArgumentError, fn -> Loop.new("question", collection: nil) end
     end
   end
 
@@ -373,6 +479,28 @@ defmodule Arcana.LoopTest do
   end
 
   describe "run/2 search tool" do
+    test "an unrestricted loop forwards the explicit all scope" do
+      test_pid = self()
+
+      search_fn = fn "anything", opts ->
+        send(test_pid, {:unrestricted_search_opts, opts})
+        {:ok, []}
+      end
+
+      controller =
+        scripted_controller([
+          tool_call_response([tool_call("search", %{"query" => "anything"}, "c1")]),
+          tool_call_response([tool_call("answer", %{"text" => "done"}, "c2")])
+        ])
+
+      {:ok, _ctx} =
+        Loop.new("question")
+        |> Loop.run(controller_llm: controller, search_fn: search_fn)
+
+      assert_received {:unrestricted_search_opts, opts}
+      assert opts[:collection] == :all
+    end
+
     test "search tool calls a stub search_fn and accumulates chunks" do
       search_fn = fn "ren and stimpy", _opts ->
         {:ok,

--- a/test/arcana/loop_test.exs
+++ b/test/arcana/loop_test.exs
@@ -209,11 +209,12 @@ defmodule Arcana.LoopTest do
 
       Tools.execute(ctx, "search", %{query: "q"},
         search_fn: search_fn,
-        search_opts: [collection: :all, tenant_id: "tenant-a"]
+        search_opts: [collection: :all, collections: ["outside"], tenant_id: "tenant-a"]
       )
 
       assert_received {:search_opts, opts}
       assert opts[:collection] == "allowed"
+      refute Keyword.has_key?(opts, :collections)
       assert opts[:tenant_id] == "tenant-a"
     end
 
@@ -228,7 +229,7 @@ defmodule Arcana.LoopTest do
       Tools.execute(ctx, "search", %{query: "q"}, search_fn: search_fn)
 
       assert_received {:search_opts, opts}
-      assert opts[:collections] == []
+      assert opts[:collection] == []
     end
 
     test "multi-collection ctx + no collection arg → searches across all" do
@@ -243,8 +244,8 @@ defmodule Arcana.LoopTest do
         Tools.execute(ctx, "search", %{query: "q"}, search_fn: search_fn)
 
       assert_received {:search_opts, opts}
-      assert opts[:collections] == ["a", "b"]
-      refute opts[:collection]
+      assert opts[:collection] == ["a", "b"]
+      refute Keyword.has_key?(opts, :collections)
     end
 
     test "multi-collection ctx + valid collection arg → narrows to that one" do
@@ -353,8 +354,8 @@ defmodule Arcana.LoopTest do
       assert ctx.collections == ["doctor-who"]
     end
 
-    test "stores collections list when given" do
-      ctx = Loop.new("question", collections: ["a", "b"])
+    test "stores a collection list when given" do
+      ctx = Loop.new("question", collection: ["a", "b"])
       assert ctx.collections == ["a", "b"]
     end
 
@@ -363,17 +364,16 @@ defmodule Arcana.LoopTest do
       assert Loop.new("question", collection: :all).collections == :all
       assert Loop.new("question", collection: "a").collections == ["a"]
       assert Loop.new("question", collection: ["a", "b"]).collections == ["a", "b"]
-      assert Loop.new("question", collections: []).collections == []
-      assert Loop.new("question", collections: [nil]).collections == :all
-      assert Loop.new("question", collection: [nil]).collections == :all
+      assert Loop.new("question", collection: []).collections == []
     end
 
-    test "rejects conflicting or invalid collection scopes" do
-      assert_raise ArgumentError, fn ->
-        Loop.new("question", collection: "a", collections: ["b"])
-      end
-
+    test "rejects invalid and removed collection scopes" do
       assert_raise ArgumentError, fn -> Loop.new("question", collection: nil) end
+      assert_raise ArgumentError, fn -> Loop.new("question", collection: [nil]) end
+
+      assert_raise ArgumentError, ~r/:collections is not supported/, fn ->
+        Loop.new("question", collections: ["a"])
+      end
     end
   end
 

--- a/test/arcana/maintenance_communities_test.exs
+++ b/test/arcana/maintenance_communities_test.exs
@@ -1,8 +1,17 @@
 defmodule Arcana.MaintenanceCommunitiesTest do
   use Arcana.DataCase, async: true
 
-  alias Arcana.Collection
-  alias Arcana.Graph.{Community, CommunitySummarizer, Entity, Relationship}
+  alias Arcana.{Chunk, Collection, Document}
+
+  alias Arcana.Graph.{
+    Community,
+    CommunitySummarizer,
+    Entity,
+    EntityMention,
+    Relationship,
+    RelationshipEvidence
+  }
+
   alias Arcana.Maintenance
 
   defmodule TwoLevelDetector do
@@ -31,6 +40,24 @@ defmodule Arcana.MaintenanceCommunitiesTest do
     name = "communities-#{System.unique_integer([:positive])}"
     {:ok, collection} = Collection.get_or_create(name, Repo)
 
+    document =
+      %Document{}
+      |> Document.changeset(%{
+        content: "community evidence",
+        collection_id: collection.id,
+        status: :completed
+      })
+      |> Repo.insert!()
+
+    chunk =
+      %Chunk{}
+      |> Chunk.changeset(%{
+        text: "community evidence",
+        embedding: Enum.map(1..384, fn _ -> 0.0 end),
+        document_id: document.id
+      })
+      |> Repo.insert!()
+
     # Two tight clusters joined by a weak bridge.
     entities =
       for entity_name <- ~w(a b c d e f) do
@@ -45,6 +72,12 @@ defmodule Arcana.MaintenanceCommunitiesTest do
 
     [a, b, c, d, e, f] = entities
 
+    for entity <- entities do
+      %EntityMention{}
+      |> EntityMention.changeset(%{entity_id: entity.id, chunk_id: chunk.id})
+      |> Repo.insert!()
+    end
+
     for {source, target, strength} <- [
           {a, b, 10},
           {b, c, 10},
@@ -54,17 +87,31 @@ defmodule Arcana.MaintenanceCommunitiesTest do
           {d, f, 10},
           {c, d, 1}
         ] do
+      persist_relationship(source, target, chunk, "RELATED", strength)
+    end
+
+    %{collection: collection, entities: entities, chunk: chunk}
+  end
+
+  defp persist_relationship(source, target, chunk, type, strength) do
+    relationship =
       %Relationship{}
       |> Relationship.changeset(%{
-        type: "RELATED",
+        type: type,
         source_id: source.id,
         target_id: target.id,
         strength: strength
       })
       |> Repo.insert!()
-    end
 
-    %{collection: collection, entities: entities}
+    %RelationshipEvidence{}
+    |> RelationshipEvidence.changeset(%{
+      relationship_id: relationship.id,
+      chunk_id: chunk.id
+    })
+    |> Repo.insert!()
+
+    relationship
   end
 
   defp summarized_as_a_real_run_would(community, summary) do
@@ -280,7 +327,8 @@ defmodule Arcana.MaintenanceCommunitiesTest do
 
     test "a relationship added between existing members invalidates the summary", %{
       collection: collection,
-      entities: entities
+      entities: entities,
+      chunk: chunk
     } do
       # The case membership can't see: ingesting another document adds
       # relationships between entities that are already in the community, so
@@ -295,14 +343,7 @@ defmodule Arcana.MaintenanceCommunitiesTest do
 
       [a, b | _] = entities
 
-      %Relationship{}
-      |> Relationship.changeset(%{
-        source_id: a.id,
-        target_id: b.id,
-        type: "newly-discovered",
-        strength: 1
-      })
-      |> Repo.insert!()
+      persist_relationship(a, b, chunk, "newly-discovered", 1)
 
       assert {:ok, _} =
                Maintenance.detect_communities(Repo, collection: collection.name, seed: 42)
@@ -319,7 +360,10 @@ defmodule Arcana.MaintenanceCommunitiesTest do
       end
     end
 
-    test "new memberships come back dirty with no summary", %{collection: collection} do
+    test "new memberships come back dirty with no summary", %{
+      collection: collection,
+      chunk: chunk
+    } do
       assert {:ok, _} =
                Maintenance.detect_communities(Repo, collection: collection.name, seed: 42)
 
@@ -327,12 +371,17 @@ defmodule Arcana.MaintenanceCommunitiesTest do
         summarized_as_a_real_run_would(community, "old")
       end
 
-      %Entity{}
-      |> Entity.changeset(%{
-        name: "loner-#{collection.name}",
-        type: "thing",
-        collection_id: collection.id
-      })
+      entity =
+        %Entity{}
+        |> Entity.changeset(%{
+          name: "loner-#{collection.name}",
+          type: "thing",
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+
+      %EntityMention{}
+      |> EntityMention.changeset(%{entity_id: entity.id, chunk_id: chunk.id})
       |> Repo.insert!()
 
       assert {:ok, _} =

--- a/test/arcana/maintenance_test.exs
+++ b/test/arcana/maintenance_test.exs
@@ -97,4 +97,54 @@ defmodule Arcana.MaintenanceTest do
       assert {:ok, %{collections: 0}} = Maintenance.rebuild_graph(Repo, collection: "nope")
     end
   end
+
+  describe "collection scopes" do
+    test "graph maintenance accepts one or many collection names" do
+      {:ok, _} = Collection.get_or_create("maintenance-a", Repo)
+      {:ok, _} = Collection.get_or_create("maintenance-b", Repo)
+      {:ok, _} = Collection.get_or_create("maintenance-outside", Repo)
+
+      assert {:ok, %{collections: 1}} =
+               Maintenance.rebuild_graph(Repo, collection: "maintenance-a")
+
+      assert {:ok, %{collections: 1}} =
+               Maintenance.rebuild_graph(Repo, collections: "maintenance-a")
+
+      assert {:ok, %{collections: 2}} =
+               Maintenance.rebuild_graph(Repo,
+                 collection: ["maintenance-a", "maintenance-b", "missing"]
+               )
+    end
+
+    test "empty and unknown scopes never widen re-embedding to every collection" do
+      {:ok, collection} = Collection.get_or_create("maintenance-existing", Repo)
+
+      document =
+        %Document{}
+        |> Document.changeset(%{
+          content: "must remain untouched",
+          status: :pending,
+          chunk_count: 0,
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+
+      assert {:ok, %{rechunked_documents: 0, total_chunks: 0}} =
+               Maintenance.reembed(Repo, collections: [])
+
+      assert {:ok, %{rechunked_documents: 0, total_chunks: 0}} =
+               Maintenance.reembed(Repo, collection: "missing")
+
+      assert Repo.get!(Document, document.id).chunk_count == 0
+      assert Repo.aggregate(Chunk, :count) == 0
+    end
+
+    test "conflicting and malformed collection options are rejected" do
+      assert {:error, :conflicting_collection_options} =
+               Maintenance.rebuild_graph(Repo, collection: "a", collections: ["b"])
+
+      assert {:error, {:invalid_collection_scope, ["a", nil]}} =
+               Maintenance.rebuild_graph(Repo, collections: ["a", nil])
+    end
+  end
 end

--- a/test/arcana/maintenance_test.exs
+++ b/test/arcana/maintenance_test.exs
@@ -107,9 +107,6 @@ defmodule Arcana.MaintenanceTest do
       assert {:ok, %{collections: 1}} =
                Maintenance.rebuild_graph(Repo, collection: "maintenance-a")
 
-      assert {:ok, %{collections: 1}} =
-               Maintenance.rebuild_graph(Repo, collections: "maintenance-a")
-
       assert {:ok, %{collections: 2}} =
                Maintenance.rebuild_graph(Repo,
                  collection: ["maintenance-a", "maintenance-b", "missing"]
@@ -130,7 +127,7 @@ defmodule Arcana.MaintenanceTest do
         |> Repo.insert!()
 
       assert {:ok, %{rechunked_documents: 0, total_chunks: 0}} =
-               Maintenance.reembed(Repo, collections: [])
+               Maintenance.reembed(Repo, collection: [])
 
       assert {:ok, %{rechunked_documents: 0, total_chunks: 0}} =
                Maintenance.reembed(Repo, collection: "missing")
@@ -139,12 +136,12 @@ defmodule Arcana.MaintenanceTest do
       assert Repo.aggregate(Chunk, :count) == 0
     end
 
-    test "conflicting and malformed collection options are rejected" do
-      assert {:error, :conflicting_collection_options} =
-               Maintenance.rebuild_graph(Repo, collection: "a", collections: ["b"])
-
+    test "malformed and removed collection scopes are rejected" do
       assert {:error, {:invalid_collection_scope, ["a", nil]}} =
-               Maintenance.rebuild_graph(Repo, collections: ["a", nil])
+               Maintenance.rebuild_graph(Repo, collection: ["a", nil])
+
+      assert {:error, {:unsupported_collection_option, :collections}} =
+               Maintenance.rebuild_graph(Repo, collections: ["a"])
     end
   end
 end

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -80,7 +80,7 @@ defmodule Arcana.MigrationTest do
   # through Migrator.up/4: `down` here means "the thing this migration
   # does is call Arcana.Migration.down/1", not a rollback of it.
   defp run(module, direction, opts) do
-    name = :"Elixir.MigTest#{System.unique_integer([:positive])}"
+    name = :"Elixir.MigTest#{migration_version()}"
 
     body =
       quote do
@@ -90,8 +90,25 @@ defmodule Arcana.MigrationTest do
       end
 
     Module.create(name, body, Macro.Env.location(__ENV__))
-    Ecto.Migrator.up(Repo, System.unique_integer([:positive]), name, log: false)
+    Ecto.Migrator.up(Repo, migration_version(), name, log: false)
   end
+
+  defp run_nontransactional(module, direction, opts) do
+    name = :"Elixir.MigTest#{migration_version()}"
+
+    body =
+      quote do
+        use Ecto.Migration
+
+        @disable_ddl_transaction true
+        def up, do: unquote(module).unquote(direction)(unquote(Macro.escape(opts)))
+      end
+
+    Module.create(name, body, Macro.Env.location(__ENV__))
+    Ecto.Migrator.up(Repo, migration_version(), name, log: false)
+  end
+
+  defp migration_version, do: System.unique_integer([:positive, :monotonic])
 
   # 'n' = SET NULL (what :nilify_all produces), 'r' = RESTRICT.
   defp collection_fk_rule do
@@ -380,7 +397,7 @@ defmodule Arcana.MigrationTest do
       assert Arcana.Migration.recorded_version(Repo) == 0
       refute "reference_answer" in columns("arcana_evaluation_test_cases")
 
-      migrate(Arcana.Migration)
+      migrate(Arcana.Migration, prefix: "public")
 
       assert "reference_answer" in columns("arcana_evaluation_test_cases")
       assert Arcana.Migration.recorded_version(Repo) == Arcana.Migration.current_version()
@@ -445,7 +462,7 @@ defmodule Arcana.MigrationTest do
         []
       )
 
-      migrate(Arcana.Migration)
+      migrate(Arcana.Migration, prefix: "public")
 
       assert collection_fk_rule() == "r",
              "adoption must swap the collection FK to RESTRICT"
@@ -516,7 +533,7 @@ defmodule Arcana.MigrationTest do
 
       err =
         assert_raise RuntimeError, ~r/can't tell which version is applied/, fn ->
-          migrate_down(Arcana.Migration, [])
+          migrate_down(Arcana.Migration, prefix: "public")
         end
 
       # It can't offer the COMMENT recovery, because the table to comment on
@@ -660,7 +677,7 @@ defmodule Arcana.MigrationTest do
 
       refute unique_index?("arcana_collections_name_index"), "precondition: not unique"
 
-      migrate(Arcana.Migration)
+      migrate(Arcana.Migration, prefix: "public")
 
       assert unique_index?("arcana_collections_name_index"),
              "converge kept a non-unique index that shares the name"
@@ -724,7 +741,7 @@ defmodule Arcana.MigrationTest do
       assert index_columns("arcana_collections_name_index") == ["description"],
              "precondition: the index covers the wrong column"
 
-      migrate(Arcana.Migration)
+      migrate(Arcana.Migration, prefix: "public")
 
       assert index_columns("arcana_collections_name_index") == ["name"],
              "an index on the wrong column kept its name and was left in place"
@@ -745,7 +762,8 @@ defmodule Arcana.MigrationTest do
       SQL.query!(Repo, "INSERT INTO arcana_collections (name) VALUES ('dup'), ('dup')", [])
       assert Arcana.Migration.recorded_version(Repo) == 0
 
-      err = assert_raise RuntimeError, fn -> migrate(Arcana.Migration) end
+      err =
+        assert_raise RuntimeError, fn -> migrate(Arcana.Migration, prefix: "public") end
 
       assert err.message =~ "can't add the unique index arcana_collections_name_index"
       assert err.message =~ ~s(["dup"])
@@ -795,7 +813,7 @@ defmodule Arcana.MigrationTest do
       )
 
       migrate(Arcana.Migration)
-      assert :ok = migrate(Arcana.Graph.Migration)
+      assert :ok = migrate(Arcana.Graph.Migration, prefix: "public")
 
       assert index_identity("arcana_graph_entities_name_collection_id_index").unique,
              "NULL collection_id rows were treated as duplicates and blocked the rebuild"
@@ -875,7 +893,7 @@ defmodule Arcana.MigrationTest do
         []
       )
 
-      migrate(Arcana.Migration)
+      migrate(Arcana.Migration, prefix: "public")
 
       identity = index_identity("arcana_collections_name_index")
       assert identity.unique
@@ -897,7 +915,7 @@ defmodule Arcana.MigrationTest do
         []
       )
 
-      migrate(Arcana.Migration)
+      migrate(Arcana.Migration, prefix: "public")
 
       identity = index_identity("arcana_collections_name_index")
       refute identity.expression, "an expression index does not constrain the raw column"
@@ -924,7 +942,7 @@ defmodule Arcana.MigrationTest do
 
       err =
         assert_raise RuntimeError, ~r/can't add the unique index/, fn ->
-          migrate(Arcana.Migration)
+          migrate(Arcana.Migration, prefix: "public")
         end
 
       assert err.message =~ ~s(["same"])
@@ -1180,8 +1198,51 @@ defmodule Arcana.MigrationTest do
 
       assert with_tenant_first(fn -> Registry.present(Repo, :graph, "public") end)
              |> Enum.sort() == Enum.sort(Registry.owned_tables(:graph))
+    end
 
-      assert scalar(~s|SELECT count(*) FROM "tenant_first"."arcana_graph_communities"|) == 0
+    test "an unmarked shadow of the marker table does not hide a marked install" do
+      migrate(Arcana.Migration)
+      migrate(Arcana.Graph.Migration)
+
+      SQL.query!(
+        Repo,
+        ~s|CREATE TABLE "tenant_first"."arcana_graph_entities" (sentinel text)|,
+        []
+      )
+
+      assert with_tenant_first(fn -> SchemaScope.resolve(Repo, :graph, nil) end) == "public"
+    end
+
+    test "an unmarked marker-name collision cannot select a fresh install schema" do
+      SQL.query!(
+        Repo,
+        ~s|CREATE TABLE "tenant_first"."arcana_graph_entities" (id uuid, name text, type text)|,
+        []
+      )
+
+      error =
+        assert_raise RuntimeError, fn ->
+          with_tenant_first(fn -> SchemaScope.resolve(Repo, :graph, nil) end)
+        end
+
+      assert error.message =~ "unmarked table named like its graph migration marker"
+      assert error.message =~ "Pass an explicit :prefix"
+    end
+
+    test "an unmarked non-marker collision cannot select a fresh install schema" do
+      SQL.query!(
+        Repo,
+        ~s|CREATE TABLE "tenant_first"."arcana_graph_communities" (sentinel text)|,
+        []
+      )
+
+      error =
+        assert_raise RuntimeError, fn ->
+          with_tenant_first(fn -> SchemaScope.resolve(Repo, :graph, nil) end)
+        end
+
+      assert error.message =~ "unmarked partial graph migration install"
+      assert error.message =~ "Pass an explicit :prefix"
     end
   end
 
@@ -1258,6 +1319,123 @@ defmodule Arcana.MigrationTest do
 
       assert scalar("SELECT count(*) FROM arcana_graph_entities") == 2
       assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+    end
+
+    test "a nontransactional host migration preserves v1 data when v2 fails" do
+      migrate(Arcana.Graph.Migration, version: 1)
+      {source, target} = seed_graph_entities()
+
+      SQL.query!(Repo, "DROP INDEX arcana_graph_entities_name_collection_id_index", [])
+
+      SQL.query!(
+        Repo,
+        "CREATE INDEX arcana_graph_entities_name_collection_id_index " <>
+          "ON arcana_graph_entities (name)",
+        []
+      )
+
+      entity_index = index_identity("arcana_graph_entities_name_collection_id_index")
+
+      SQL.query!(
+        Repo,
+        "INSERT INTO arcana_graph_relationships " <>
+          "(id, type, source_id, target_id, inserted_at, updated_at) " <>
+          "VALUES (gen_random_uuid(), 'knows', $1, $2, now(), now())",
+        [source, target]
+      )
+
+      SQL.query!(Repo, "ALTER TABLE arcana_graph_communities DROP COLUMN dirty", [])
+
+      assert_raise Postgrex.Error, fn ->
+        run_nontransactional(Arcana.Graph.Migration, :up, dimensions: 384)
+      end
+
+      assert scalar("SELECT count(*) FROM arcana_graph_relationships") == 1
+      refute "fingerprint" in columns("arcana_graph_relationships")
+      refute table_exists?("arcana_graph_relationship_evidence")
+      assert index_identity("arcana_graph_entities_name_collection_id_index") == entity_index
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 1
+    end
+
+    test "refuses a v2 evidence table missing runtime-required columns" do
+      migrate(Arcana.Graph.Migration, version: 1)
+
+      SQL.query!(
+        Repo,
+        "ALTER TABLE arcana_graph_relationships " <>
+          "ADD COLUMN fingerprint varchar(64) NOT NULL",
+        []
+      )
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE arcana_graph_relationship_evidence (" <>
+          "relationship_id uuid NOT NULL REFERENCES arcana_graph_relationships(id) " <>
+          "ON DELETE CASCADE, " <>
+          "chunk_id uuid NOT NULL REFERENCES arcana_chunks(id) ON DELETE CASCADE)",
+        []
+      )
+
+      error = assert_raise RuntimeError, fn -> migrate(Arcana.Graph.Migration) end
+
+      assert error.message =~ "evidence columns have the wrong shape"
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 1
+
+      refute index_identity("arcana_graph_relationship_evidence_rel_chunk_index")
+    end
+
+    test "refuses a v2 evidence table without its id primary key" do
+      migrate(Arcana.Graph.Migration, version: 1)
+
+      SQL.query!(
+        Repo,
+        "ALTER TABLE arcana_graph_relationships " <>
+          "ADD COLUMN fingerprint varchar(64) NOT NULL",
+        []
+      )
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE arcana_graph_relationship_evidence (" <>
+          "id uuid NOT NULL, " <>
+          "relationship_id uuid NOT NULL REFERENCES arcana_graph_relationships(id) " <>
+          "ON DELETE CASCADE, " <>
+          "chunk_id uuid NOT NULL REFERENCES arcana_chunks(id) ON DELETE CASCADE, " <>
+          "inserted_at timestamp(0) without time zone NOT NULL)",
+        []
+      )
+
+      error = assert_raise RuntimeError, fn -> migrate(Arcana.Graph.Migration) end
+
+      assert error.message =~ "evidence primary key has the wrong shape"
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 1
+    end
+
+    test "refuses evidence foreign keys that do not reference target ids" do
+      migrate(Arcana.Graph.Migration)
+
+      SQL.query!(
+        Repo,
+        "ALTER TABLE arcana_chunks ADD COLUMN alternate_id uuid UNIQUE " <>
+          "DEFAULT gen_random_uuid()",
+        []
+      )
+
+      SQL.query!(
+        Repo,
+        "ALTER TABLE arcana_graph_relationship_evidence " <>
+          "DROP CONSTRAINT arcana_graph_relationship_evidence_chunk_id_fkey, " <>
+          "ADD CONSTRAINT arcana_graph_relationship_evidence_chunk_id_fkey " <>
+          "FOREIGN KEY (chunk_id) REFERENCES arcana_chunks(alternate_id) ON DELETE CASCADE",
+        []
+      )
+
+      SQL.query!(Repo, "COMMENT ON TABLE arcana_graph_entities IS 'arcana_graph:1'", [])
+
+      error = assert_raise RuntimeError, fn -> migrate(Arcana.Graph.Migration) end
+
+      assert error.message =~ "evidence foreign keys have the wrong shape"
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 1
     end
 
     test "a damaged marker preserves a complete v2 graph" do
@@ -1361,6 +1539,27 @@ defmodule Arcana.MigrationTest do
       assert :ok = migrate_down(Arcana.Graph.Migration, [])
       assert Enum.all?(Registry.owned_tables(:graph), &(&1 not in tables()))
       assert Enum.all?(Registry.owned_tables(:core), &(&1 in tables()))
+    end
+
+    test "graph uninstall refuses a host sequence owned by an Arcana column" do
+      migrate(Arcana.Graph.Migration)
+      SQL.query!(Repo, "CREATE SEQUENCE host_entity_sequence", [])
+
+      SQL.query!(
+        Repo,
+        "ALTER SEQUENCE host_entity_sequence OWNED BY arcana_graph_entities.inserted_at",
+        []
+      )
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~ "host_entity_sequence"
+      assert error.message =~ "objects Arcana does not own depend on it"
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+      assert Enum.all?(Registry.owned_tables(:graph), &(&1 in tables()))
     end
 
     test "graph uninstall finds a cross-schema view and leaves every graph table intact" do

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -10,6 +10,9 @@ defmodule Arcana.MigrationTest do
 
   doctest Arcana.Migration.Dimensions
 
+  alias Arcana.Migration.Dimensions
+  alias Arcana.Migration.Registry
+  alias Arcana.Migration.SchemaScope
   alias Arcana.MigrationRepo, as: Repo
   alias Ecto.Adapters.Postgres
   alias Ecto.Adapters.SQL
@@ -49,7 +52,10 @@ defmodule Arcana.MigrationTest do
   setup do
     # Each test starts from nothing, so version detection is real rather
     # than inherited from whatever ran before.
-    for table <- ~w(arcana_graph_communities arcana_graph_entity_mentions
+    for table <- ~w(host_audit host_checks host_chunks host_entity_snapshots host_graph_entities
+                    host_graph_links
+                    arcana_graph_communities arcana_graph_relationship_evidence
+                    arcana_graph_entity_mentions
                     arcana_graph_relationships arcana_graph_entities
                     arcana_evaluation_runs arcana_evaluation_test_case_chunks
                     arcana_evaluation_test_cases arcana_chunks
@@ -109,12 +115,16 @@ defmodule Arcana.MigrationTest do
   end
 
   defp tables do
+    tables(nil)
+  end
+
+  defp tables(prefix) do
     %{rows: rows} =
       SQL.query!(
         Repo,
         "SELECT table_name FROM information_schema.tables " <>
-          "WHERE table_schema = current_schema()",
-        []
+          "WHERE table_schema = COALESCE($1, current_schema())",
+        [prefix]
       )
 
     List.flatten(rows)
@@ -301,12 +311,16 @@ defmodule Arcana.MigrationTest do
 
   describe "Arcana.Migration" do
     test "creates the core schema and records a version" do
+      before = MapSet.new(tables())
       migrate(Arcana.Migration)
 
-      for table <- ~w(arcana_collections arcana_documents arcana_chunks
-                      arcana_evaluation_test_cases arcana_evaluation_runs) do
-        assert table_exists?(table), "#{table} was not created"
-      end
+      created =
+        tables()
+        |> MapSet.new()
+        |> MapSet.difference(before)
+        |> MapSet.delete("schema_migrations")
+
+      assert created == MapSet.new(Registry.owned_tables(:core))
 
       assert Arcana.Migration.recorded_version(Repo) == Arcana.Migration.current_version()
     end
@@ -545,6 +559,48 @@ defmodule Arcana.MigrationTest do
 
       assert :ok = migrate_down(Arcana.Migration, [])
       refute "arcana_documents" in tables()
+    end
+
+    test "core uninstall refuses same-prefix graph dependencies before changing anything" do
+      migrate(Arcana.Migration)
+      migrate(Arcana.Graph.Migration)
+      before = MapSet.new(tables())
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Migration, [])
+        end
+
+      assert error.message =~ "GraphRAG is installed in the same prefix"
+      assert error.message =~ "Arcana.Graph.Migration.down(prefix: \"public\")"
+      assert error.message =~ "Nothing was changed"
+      assert MapSet.new(tables()) == before
+      assert Arcana.Migration.recorded_version(Repo) == 1
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+    end
+
+    test "core uninstall refuses a host foreign key before changing anything" do
+      migrate(Arcana.Migration)
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE host_chunks (chunk_id uuid REFERENCES arcana_chunks(id))",
+        []
+      )
+
+      before = MapSet.new(tables())
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Migration, [])
+        end
+
+      assert error.message =~
+               ~s(foreign key "public"."host_chunks"."host_chunks_chunk_id_fkey")
+
+      assert error.message =~ "Nothing was changed"
+      assert MapSet.new(tables()) == before
+      assert Arcana.Migration.recorded_version(Repo) == 1
     end
 
     test "up/1 requires :dimensions" do
@@ -1023,7 +1079,7 @@ defmodule Arcana.MigrationTest do
       migrate(Arcana.Migration, prefix: "tenant_b")
       migrate(Arcana.Graph.Migration, prefix: "tenant_b")
 
-      assert Arcana.Graph.Migration.recorded_version(Repo, prefix: "tenant_b") == 1
+      assert Arcana.Graph.Migration.recorded_version(Repo, prefix: "tenant_b") == 2
       assert Arcana.Graph.Migration.recorded_version(Repo) == 0
 
       # The raw SQL in converge_v1 has to be qualified as well, or it edits
@@ -1039,6 +1095,94 @@ defmodule Arcana.MigrationTest do
 
       assert count == 1
     end
+
+    test "graph in another prefix does not block core uninstall" do
+      prefix = "tenant_graph_only"
+      SQL.query!(Repo, ~s(DROP SCHEMA IF EXISTS "tenant_graph_only" CASCADE), [])
+
+      on_exit(fn ->
+        SQL.query!(Repo, ~s(DROP SCHEMA IF EXISTS "tenant_graph_only" CASCADE), [])
+      end)
+
+      migrate(Arcana.Migration)
+      migrate(Arcana.Migration, prefix: prefix)
+      migrate(Arcana.Graph.Migration, prefix: prefix)
+
+      assert :ok = migrate_down(Arcana.Migration, [])
+      assert Arcana.Migration.recorded_version(Repo) == 0
+      assert Arcana.Graph.Migration.recorded_version(Repo, prefix: prefix) == 2
+
+      assert MapSet.new(Registry.owned_tables(:graph))
+             |> MapSet.subset?(MapSet.new(tables(prefix)))
+    end
+  end
+
+  describe "unprefixed search_path resolution" do
+    setup do
+      SQL.query!(Repo, ~s(CREATE SCHEMA IF NOT EXISTS "tenant_first"), [])
+
+      on_exit(fn ->
+        SQL.query!(Repo, ~s(DROP SCHEMA IF EXISTS "tenant_first" CASCADE), [])
+      end)
+
+      :ok
+    end
+
+    defp with_tenant_first(fun) do
+      Repo.checkout(fn ->
+        SQL.query!(Repo, ~s(SET search_path TO "tenant_first", public), [])
+
+        try do
+          fun.()
+        after
+          SQL.query!(Repo, "SET search_path TO public", [])
+        end
+      end)
+    end
+
+    test "version markers follow the visible relation instead of current_schema" do
+      migrate(Arcana.Migration)
+      migrate(Arcana.Graph.Migration)
+
+      assert with_tenant_first(fn -> Arcana.Migration.recorded_version(Repo) end) == 1
+      assert with_tenant_first(fn -> Arcana.Graph.Migration.recorded_version(Repo) end) == 2
+    end
+
+    test "dimension validation follows the visible relation" do
+      migrate(Arcana.Migration)
+
+      assert_raise ArgumentError, ~r/already vector\(384\)/, fn ->
+        with_tenant_first(fn ->
+          Dimensions.verify!(Repo, 512, Arcana.Migration, "arcana_chunks", nil, "remedy")
+        end)
+      end
+    end
+
+    test "an explicit prefix still means exactly that schema" do
+      migrate(Arcana.Migration)
+
+      assert with_tenant_first(fn ->
+               Arcana.Migration.recorded_version(Repo, prefix: "tenant_first")
+             end) == 0
+    end
+
+    test "the marker schema anchors the whole stream despite a shadow table" do
+      migrate(Arcana.Migration)
+      migrate(Arcana.Graph.Migration)
+
+      SQL.query!(
+        Repo,
+        ~s|CREATE TABLE "tenant_first"."arcana_graph_communities" (sentinel text)|,
+        []
+      )
+
+      assert with_tenant_first(fn -> SchemaScope.resolve(Repo, :graph, nil) end) == "public"
+
+      assert with_tenant_first(fn -> Registry.present(Repo, :graph, "public") end)
+             |> Enum.sort() == Enum.sort(Registry.owned_tables(:graph))
+
+      assert scalar(~s|SELECT count(*) FROM "tenant_first"."arcana_graph_communities"|) == 0
+    end
   end
 
   describe "Arcana.Graph.Migration" do
@@ -1048,12 +1192,12 @@ defmodule Arcana.MigrationTest do
     end
 
     test "creates the graph schema and records its own version" do
+      before = MapSet.new(tables())
       migrate(Arcana.Graph.Migration)
 
-      for table <- ~w(arcana_graph_entities arcana_graph_relationships
-                      arcana_graph_entity_mentions arcana_graph_communities) do
-        assert table_exists?(table), "#{table} was not created"
-      end
+      created = MapSet.difference(MapSet.new(tables()), before)
+
+      assert created == MapSet.new(Registry.owned_tables(:graph))
 
       assert Arcana.Graph.Migration.recorded_version(Repo) ==
                Arcana.Graph.Migration.current_version()
@@ -1066,6 +1210,8 @@ defmodule Arcana.MigrationTest do
       migrate(Arcana.Graph.Migration)
 
       assert "summary_fingerprint" in columns("arcana_graph_communities")
+      assert "fingerprint" in columns("arcana_graph_relationships")
+      assert table_exists?("arcana_graph_relationship_evidence")
 
       %{rows: rows} =
         SQL.query!(
@@ -1077,6 +1223,297 @@ defmodule Arcana.MigrationTest do
 
       assert Enum.any?(List.flatten(rows), &String.contains?(&1, "entity_id_chunk_id")),
              "the entity mention unique index should come with v1"
+    end
+
+    test "v1 to v2 clears unattributable facts and invalidates summaries" do
+      migrate(Arcana.Graph.Migration, version: 1)
+      {source, target} = seed_graph_entities()
+
+      SQL.query!(
+        Repo,
+        "INSERT INTO arcana_graph_relationships " <>
+          "(id, type, source_id, target_id, inserted_at, updated_at) " <>
+          "VALUES (gen_random_uuid(), 'knows', $1, $2, now(), now())",
+        [source, target]
+      )
+
+      SQL.query!(
+        Repo,
+        "INSERT INTO arcana_graph_communities " <>
+          "(id, level, entity_ids, dirty, summary, summary_fingerprint, inserted_at, updated_at) " <>
+          "VALUES (gen_random_uuid(), 0, $1, false, 'legacy summary', 'legacy', now(), now())",
+        [[source, target]]
+      )
+
+      migrate(Arcana.Graph.Migration)
+
+      assert scalar("SELECT count(*) FROM arcana_graph_relationships") == 0
+
+      assert [[true, nil, nil]] =
+               SQL.query!(
+                 Repo,
+                 "SELECT dirty, summary, summary_fingerprint FROM arcana_graph_communities",
+                 []
+               ).rows
+
+      assert scalar("SELECT count(*) FROM arcana_graph_entities") == 2
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+    end
+
+    test "a damaged marker preserves a complete v2 graph" do
+      migrate(Arcana.Graph.Migration)
+      {source, target} = seed_graph_entities()
+      chunk = seed_completed_chunk()
+      relationship = uuid()
+      fingerprint = String.duplicate("a", 64)
+
+      SQL.query!(
+        Repo,
+        "INSERT INTO arcana_graph_relationships " <>
+          "(id, type, source_id, target_id, fingerprint, inserted_at, updated_at) " <>
+          "VALUES ($1, 'knows', $2, $3, $4, now(), now())",
+        [relationship, source, target, fingerprint]
+      )
+
+      SQL.query!(
+        Repo,
+        "INSERT INTO arcana_graph_relationship_evidence " <>
+          "(id, relationship_id, chunk_id, inserted_at) VALUES " <>
+          "(gen_random_uuid(), $1, $2, now())",
+        [relationship, chunk]
+      )
+
+      SQL.query!(Repo, "COMMENT ON TABLE arcana_graph_entities IS NULL", [])
+      migrate(Arcana.Graph.Migration)
+
+      assert scalar("SELECT count(*) FROM arcana_graph_relationships") == 1
+      assert scalar("SELECT count(*) FROM arcana_graph_relationship_evidence") == 1
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+    end
+
+    test "refuses a partial v2 schema before changing data" do
+      migrate(Arcana.Graph.Migration, version: 1)
+      {source, target} = seed_graph_entities()
+
+      SQL.query!(
+        Repo,
+        "INSERT INTO arcana_graph_relationships " <>
+          "(id, type, source_id, target_id, inserted_at, updated_at) " <>
+          "VALUES (gen_random_uuid(), 'knows', $1, $2, now(), now())",
+        [source, target]
+      )
+
+      SQL.query!(
+        Repo,
+        "ALTER TABLE arcana_graph_relationships ADD COLUMN fingerprint varchar(64)",
+        []
+      )
+
+      error = assert_raise RuntimeError, fn -> migrate(Arcana.Graph.Migration) end
+
+      assert error.message =~ "partial graph migration v2 install"
+      assert scalar("SELECT count(*) FROM arcana_graph_relationships") == 1
+      refute table_exists?("arcana_graph_relationship_evidence")
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 1
+    end
+
+    test "refuses the provenance-losing v2 to v1 rollback" do
+      migrate(Arcana.Graph.Migration)
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, version: 1)
+        end
+
+      assert error.message =~ "cannot be rolled back to v1 safely"
+      assert table_exists?("arcana_graph_relationship_evidence")
+      assert "fingerprint" in columns("arcana_graph_relationships")
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+    end
+
+    test "graph uninstall refuses a host foreign key before changing v2" do
+      migrate(Arcana.Graph.Migration)
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE host_graph_links (entity_id uuid REFERENCES arcana_graph_entities(id))",
+        []
+      )
+
+      before = MapSet.new(tables())
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~ "objects Arcana does not own depend on it"
+
+      assert error.message =~
+               ~s(foreign key "public"."host_graph_links"."host_graph_links_entity_id_fkey")
+
+      assert error.message =~ "Nothing was changed"
+      assert MapSet.new(tables()) == before
+      assert "fingerprint" in columns("arcana_graph_relationships")
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+
+      SQL.query!(Repo, "DROP TABLE host_graph_links", [])
+      assert :ok = migrate_down(Arcana.Graph.Migration, [])
+      assert Enum.all?(Registry.owned_tables(:graph), &(&1 not in tables()))
+      assert Enum.all?(Registry.owned_tables(:core), &(&1 in tables()))
+    end
+
+    test "graph uninstall finds a cross-schema view and leaves every graph table intact" do
+      migrate(Arcana.Graph.Migration)
+      SQL.query!(Repo, ~s(CREATE SCHEMA "reporting"), [])
+
+      on_exit(fn -> SQL.query!(Repo, ~s(DROP SCHEMA IF EXISTS "reporting" CASCADE), []) end)
+
+      SQL.query!(
+        Repo,
+        ~s(CREATE VIEW "reporting"."graph_entities" AS SELECT id FROM arcana_graph_entities),
+        []
+      )
+
+      before = MapSet.new(tables())
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~ ~s(view "reporting"."graph_entities")
+      assert MapSet.new(tables()) == before
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+    end
+
+    test "graph uninstall refuses a host column using an owned composite row type" do
+      migrate(Arcana.Graph.Migration)
+      SQL.query!(Repo, "CREATE TABLE host_entity_snapshots (entity arcana_graph_entities)", [])
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~
+               ~s(column "public"."host_entity_snapshots"."entity" uses row type "public"."arcana_graph_entities")
+
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+      assert Enum.all?(Registry.owned_tables(:graph), &(&1 in tables()))
+    end
+
+    test "graph uninstall refuses a host table inheriting from an owned table" do
+      migrate(Arcana.Graph.Migration)
+      SQL.query!(Repo, "CREATE TABLE host_graph_entities () INHERITS (arcana_graph_entities)", [])
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~
+               ~s(inherited table "public"."host_graph_entities" -> "public"."arcana_graph_entities")
+
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+    end
+
+    test "graph uninstall refuses a host function using an owned row type" do
+      migrate(Arcana.Graph.Migration)
+
+      SQL.query!(
+        Repo,
+        "CREATE FUNCTION host_entity() RETURNS arcana_graph_entities " <>
+          "LANGUAGE SQL AS 'SELECT NULL::arcana_graph_entities'",
+        []
+      )
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~ "host_entity"
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+      assert table_exists?("arcana_graph_relationship_evidence")
+      assert "fingerprint" in columns("arcana_graph_relationships")
+    end
+
+    test "graph uninstall refuses a host rewrite rule using an owned table" do
+      migrate(Arcana.Graph.Migration)
+      SQL.query!(Repo, "CREATE TABLE host_audit (id uuid)", [])
+
+      SQL.query!(
+        Repo,
+        "CREATE RULE delete_graph_entity AS ON DELETE TO host_audit " <>
+          "DO ALSO DELETE FROM arcana_graph_entities WHERE id = OLD.id",
+        []
+      )
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~ "delete_graph_entity"
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+      assert table_exists?("arcana_graph_relationship_evidence")
+      assert "fingerprint" in columns("arcana_graph_relationships")
+    end
+
+    test "graph uninstall refuses a host check constraint using an owned row type" do
+      migrate(Arcana.Graph.Migration)
+
+      SQL.query!(
+        Repo,
+        "CREATE TABLE host_checks (value integer, " <>
+          "CONSTRAINT graph_row_type_check CHECK (NULL::arcana_graph_entities IS NULL))",
+        []
+      )
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~ "graph_row_type_check"
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+      assert table_exists?("arcana_graph_relationship_evidence")
+    end
+
+    test "graph uninstall refuses an owned table added to a host extension" do
+      migrate(Arcana.Graph.Migration)
+
+      SQL.query!(Repo, "ALTER EXTENSION vector ADD TABLE arcana_graph_entities", [])
+
+      on_exit(fn ->
+        SQL.query!(Repo, "ALTER EXTENSION vector DROP TABLE arcana_graph_entities", [])
+      end)
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~ ~s(extension "vector" requires "public"."arcana_graph_entities")
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+      assert Enum.all?(Registry.owned_tables(:graph), &(&1 in tables()))
+    end
+
+    test "graph uninstall refuses a host domain over an owned row type" do
+      migrate(Arcana.Graph.Migration)
+      SQL.query!(Repo, "CREATE DOMAIN host_entity AS arcana_graph_entities", [])
+
+      on_exit(fn -> SQL.query!(Repo, "DROP DOMAIN host_entity", []) end)
+
+      error =
+        assert_raise RuntimeError, fn ->
+          migrate_down(Arcana.Graph.Migration, [])
+        end
+
+      assert error.message =~ "host_entity"
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+      assert Enum.all?(Registry.owned_tables(:graph), &(&1 in tables()))
     end
 
     test "converges a graph install that predates both upgrade migrations" do
@@ -1101,7 +1538,7 @@ defmodule Arcana.MigrationTest do
       migrate(Arcana.Graph.Migration)
 
       assert "summary_fingerprint" in columns("arcana_graph_communities")
-      assert Arcana.Graph.Migration.recorded_version(Repo) == 1
+      assert Arcana.Graph.Migration.recorded_version(Repo) == 2
     end
 
     test "adoption dedups mentions before converging their unique index" do
@@ -1150,6 +1587,49 @@ defmodule Arcana.MigrationTest do
       assert mention_contexts() == ["older"]
     end
   end
+
+  defp seed_graph_entities do
+    source = uuid()
+    target = uuid()
+
+    SQL.query!(
+      Repo,
+      "INSERT INTO arcana_graph_entities " <>
+        "(id, name, type, inserted_at, updated_at) VALUES " <>
+        "($1, 'Alice', 'person', now(), now()), ($2, 'Bob', 'person', now(), now())",
+      [source, target]
+    )
+
+    {source, target}
+  end
+
+  defp seed_completed_chunk do
+    document = uuid()
+    chunk = uuid()
+
+    SQL.query!(
+      Repo,
+      "INSERT INTO arcana_documents (id, content, status, inserted_at, updated_at) " <>
+        "VALUES ($1, 'evidence', 'completed', now(), now())",
+      [document]
+    )
+
+    SQL.query!(
+      Repo,
+      "INSERT INTO arcana_chunks (id, text, embedding, document_id, inserted_at, updated_at) " <>
+        "VALUES ($1, 'evidence', array_fill(0.0::real, ARRAY[384])::vector, $2, now(), now())",
+      [chunk, document]
+    )
+
+    chunk
+  end
+
+  defp scalar(sql) do
+    %{rows: [[value]]} = SQL.query!(Repo, sql, [])
+    value
+  end
+
+  defp uuid, do: Ecto.UUID.generate() |> Ecto.UUID.dump!()
 
   describe "converge under a prefix" do
     test "rebuilds inside the prefixed schema and leaves the default one alone" do

--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -1229,6 +1229,24 @@ defmodule Arcana.MigrationTest do
       assert error.message =~ "Pass an explicit :prefix"
     end
 
+    test "an unmarked temporary marker collision cannot select a fresh install schema" do
+      Repo.checkout(fn ->
+        SQL.query!(Repo, "CREATE TEMP TABLE arcana_graph_entities (sentinel text)", [])
+
+        try do
+          error =
+            assert_raise RuntimeError, fn ->
+              SchemaScope.resolve(Repo, :graph, nil)
+            end
+
+          assert error.message =~ "unmarked table named like its graph migration marker"
+          assert error.message =~ "Pass an explicit :prefix"
+        after
+          SQL.query!(Repo, "DROP TABLE pg_temp.arcana_graph_entities", [])
+        end
+      end)
+    end
+
     test "an unmarked non-marker collision cannot select a fresh install schema" do
       SQL.query!(
         Repo,
@@ -1319,6 +1337,48 @@ defmodule Arcana.MigrationTest do
 
       assert scalar("SELECT count(*) FROM arcana_graph_entities") == 2
       assert Arcana.Graph.Migration.recorded_version(Repo) == 2
+    end
+
+    test "the test repo v2 migration invalidates summaries for discarded relationships" do
+      migrate(Arcana.Graph.Migration, version: 1)
+      {source, target} = seed_graph_entities()
+
+      SQL.query!(
+        Repo,
+        "INSERT INTO arcana_graph_relationships " <>
+          "(id, type, source_id, target_id, inserted_at, updated_at) " <>
+          "VALUES (gen_random_uuid(), 'knows', $1, $2, now(), now())",
+        [source, target]
+      )
+
+      SQL.query!(
+        Repo,
+        "INSERT INTO arcana_graph_communities " <>
+          "(id, level, entity_ids, dirty, summary, summary_fingerprint, inserted_at, updated_at) " <>
+          "VALUES (gen_random_uuid(), 0, $1, false, 'legacy summary', 'legacy', now(), now())",
+        [[source, target]]
+      )
+
+      Code.require_file(
+        "20260101000002_add_relationship_evidence.exs",
+        Path.expand("../../priv/test_repo/migrations", __DIR__)
+      )
+
+      Ecto.Migrator.up(
+        Repo,
+        migration_version(),
+        Arcana.TestRepo.Migrations.AddRelationshipEvidence,
+        log: false
+      )
+
+      assert scalar("SELECT count(*) FROM arcana_graph_relationships") == 0
+
+      assert [[true, nil, nil]] =
+               SQL.query!(
+                 Repo,
+                 "SELECT dirty, summary, summary_fingerprint FROM arcana_graph_communities",
+                 []
+               ).rows
     end
 
     test "a nontransactional host migration preserves v1 data when v2 fails" do

--- a/test/arcana/pipeline/reason_test.exs
+++ b/test/arcana/pipeline/reason_test.exs
@@ -400,7 +400,7 @@ defmodule Arcana.Pipeline.ReasonTest do
       ctx =
         "What is the tenant policy?"
         |> Pipeline.new(repo: Arcana.TestRepo, llm: llm)
-        |> Pipeline.search(searcher: searcher, collections: ["tenant-a"])
+        |> Pipeline.search(searcher: searcher, collection: ["tenant-a"])
         |> Pipeline.reason()
 
       assert ctx.reason_iterations == 2
@@ -423,7 +423,7 @@ defmodule Arcana.Pipeline.ReasonTest do
       ctx =
         "What is the Zorblax blueprint?"
         |> Pipeline.new(repo: Arcana.TestRepo, llm: llm, threshold: 0.1)
-        |> Pipeline.search(collections: ["probe-tenant-a"])
+        |> Pipeline.search(collection: ["probe-tenant-a"])
         |> Pipeline.reason()
 
       assert Enum.all?(ctx.results, &(&1.collection == "probe-tenant-a"))

--- a/test/arcana/pipeline/reason_test.exs
+++ b/test/arcana/pipeline/reason_test.exs
@@ -317,6 +317,37 @@ defmodule Arcana.Pipeline.ReasonTest do
       assert_received {:searched, "Elixir concurrency actors"}
     end
 
+    test "inherits arbitrary backend and auth options from search/2" do
+      test_pid = self()
+
+      searcher = fn question, _collection, opts ->
+        send(test_pid, {:searched_with_opts, question, opts})
+        {:ok, [%{id: question, text: "scoped chunk", score: 0.9}]}
+      end
+
+      ctx =
+        "How does Elixir handle concurrency?"
+        |> Pipeline.new(repo: Arcana.TestRepo, llm: insufficient_then_sufficient_llm())
+        |> Pipeline.search(
+          searcher: searcher,
+          collection: "tenant-a",
+          tenant_id: "tenant-a",
+          auth_token: "signed-token",
+          backend_timeout: 321
+        )
+        |> Pipeline.reason()
+
+      assert ctx.reason_iterations == 1
+
+      assert_received {:searched_with_opts, "Elixir concurrency actors", opts}
+      assert opts[:tenant_id] == "tenant-a"
+      assert opts[:auth_token] == "signed-token"
+      assert opts[:backend_timeout] == 321
+      assert opts[:repo] == Arcana.TestRepo
+      assert opts[:limit] == 5
+      assert opts[:threshold] == 0.5
+    end
+
     test "an explicit searcher on reason/2 beats the inherited one" do
       test_pid = self()
 
@@ -324,19 +355,29 @@ defmodule Arcana.Pipeline.ReasonTest do
         {:ok, [%{id: "1", text: "from search", score: 0.9}]}
       end
 
-      reason_searcher = fn question, _collection, _opts ->
-        send(test_pid, {:reason_searched, question})
+      reason_searcher = fn question, _collection, opts ->
+        send(test_pid, {:reason_searched, question, opts})
         {:ok, [%{id: "2", text: "from reason", score: 0.9}]}
       end
 
       ctx =
         "How does Elixir handle concurrency?"
         |> Pipeline.new(repo: Arcana.TestRepo, llm: insufficient_then_sufficient_llm())
-        |> Pipeline.search(searcher: search_searcher, collection: "explicit-searcher-test")
-        |> Pipeline.reason(searcher: reason_searcher)
+        |> Pipeline.search(
+          searcher: search_searcher,
+          collection: "explicit-searcher-test",
+          original_backend_token: "do-not-forward"
+        )
+        |> Pipeline.reason(
+          searcher: reason_searcher,
+          searcher_opts: [replacement_backend_token: "forward-this"]
+        )
 
       assert ctx.reason_iterations == 1
-      assert_received {:reason_searched, "Elixir concurrency actors"}
+
+      assert_received {:reason_searched, "Elixir concurrency actors", opts}
+      assert opts[:replacement_backend_token] == "forward-this"
+      refute Keyword.has_key?(opts, :original_backend_token)
     end
 
     # search/2 resolved ["tenant-a"], so every follow-up has to stay there.

--- a/test/arcana/pipeline/search_test.exs
+++ b/test/arcana/pipeline/search_test.exs
@@ -97,7 +97,7 @@ defmodule Arcana.Pipeline.SearchTest do
       assert result.collection == "ruby-docs"
     end
 
-    test "uses :collections option to search multiple collections" do
+    test "uses :collection option to search multiple collections" do
       {:ok, _} =
         Arcana.ingest("Go is a systems language.",
           repo: Arcana.TestRepo,
@@ -112,7 +112,7 @@ defmodule Arcana.Pipeline.SearchTest do
 
       ctx =
         Pipeline.new("language", repo: Arcana.TestRepo, llm: &mock_llm/1)
-        |> Pipeline.search(collections: ["go-docs", "rust-docs"])
+        |> Pipeline.search(collection: ["go-docs", "rust-docs"])
 
       # Should search both collections
       collections = Enum.map(ctx.results, & &1.collection)
@@ -132,7 +132,7 @@ defmodule Arcana.Pipeline.SearchTest do
         Pipeline.new("anything", repo: Arcana.TestRepo, llm: &mock_llm/1)
         |> Pipeline.search(
           searcher: searcher,
-          collections: :all,
+          collection: :all,
           strict_collections: true,
           hnsw_ef_search: 123
         )
@@ -147,7 +147,7 @@ defmodule Arcana.Pipeline.SearchTest do
 
       none_ctx =
         Pipeline.new("anything", repo: Arcana.TestRepo, llm: &mock_llm/1)
-        |> Pipeline.search(searcher: searcher, collections: [])
+        |> Pipeline.search(searcher: searcher, collection: [])
 
       assert none_ctx.collections == []
       assert none_ctx.results == []
@@ -177,6 +177,13 @@ defmodule Arcana.Pipeline.SearchTest do
       assert length(ctx.results) == 1
       [result] = ctx.results
       assert result.collection == "haskell-docs"
+    end
+
+    test "rejects the removed collections option" do
+      assert_raise ArgumentError, ~r/:collections is not supported/, fn ->
+        Pipeline.new("anything", repo: Arcana.TestRepo, llm: &mock_llm/1)
+        |> Pipeline.search(collections: ["default"])
+      end
     end
 
     test "skips search when skip_retrieval is true" do

--- a/test/arcana/pipeline/search_test.exs
+++ b/test/arcana/pipeline/search_test.exs
@@ -120,6 +120,41 @@ defmodule Arcana.Pipeline.SearchTest do
       assert "rust-docs" in collections
     end
 
+    test "supports all and none while forwarding retrieval options" do
+      test_pid = self()
+
+      searcher = fn _question, collection, opts ->
+        send(test_pid, {:search_call, collection, opts})
+        {:ok, []}
+      end
+
+      all_ctx =
+        Pipeline.new("anything", repo: Arcana.TestRepo, llm: &mock_llm/1)
+        |> Pipeline.search(
+          searcher: searcher,
+          collections: :all,
+          strict_collections: true,
+          hnsw_ef_search: 123
+        )
+
+      assert all_ctx.collections == :all
+      assert all_ctx.searcher_opts[:strict_collections] == true
+      assert all_ctx.searcher_opts[:hnsw_ef_search] == 123
+
+      assert_received {:search_call, :all, opts}
+      assert opts[:strict_collections] == true
+      assert opts[:hnsw_ef_search] == 123
+
+      none_ctx =
+        Pipeline.new("anything", repo: Arcana.TestRepo, llm: &mock_llm/1)
+        |> Pipeline.search(searcher: searcher, collections: [])
+
+      assert none_ctx.collections == []
+      assert none_ctx.results == []
+      assert is_list(none_ctx.searcher_opts)
+      refute_received {:search_call, _, _}
+    end
+
     test "option takes priority over ctx.collections" do
       {:ok, _} =
         Arcana.ingest("Haskell is purely functional.",

--- a/test/arcana/rewriters_test.exs
+++ b/test/arcana/rewriters_test.exs
@@ -133,7 +133,7 @@ defmodule Arcana.RewritersTest do
       # Verify the protocol is implemented for model strings
       model = "openai:gpt-4o-mini"
 
-      assert Arcana.LLM.impl_for(model) != nil
+      assert Arcana.LLM.impl_for(model) == Arcana.LLM.BitString
     end
   end
 end

--- a/test/arcana/search_test.exs
+++ b/test/arcana/search_test.exs
@@ -157,6 +157,36 @@ defmodule Arcana.SearchTest do
       assert Enum.any?(texts, &String.contains?(&1, "Rust"))
       refute Enum.any?(texts, &String.contains?(&1, "JavaScript"))
     end
+
+    test "accepts a single name through :collections" do
+      {:ok, _} =
+        Arcana.ingest("Ruby belongs in the selected collection",
+          repo: Repo,
+          collection: "single-scope"
+        )
+
+      {:ok, _} =
+        Arcana.ingest("Python belongs elsewhere", repo: Repo, collection: "other-scope")
+
+      assert {:ok, [%{text: text}]} =
+               Arcana.search("belongs", repo: Repo, mode: :keyword, collections: "single-scope")
+
+      assert text =~ "Ruby"
+    end
+
+    test ":all is unscoped and an empty list matches nothing" do
+      {:ok, _} = Arcana.ingest("Alpha scope marker", repo: Repo, collection: "scope-alpha")
+      {:ok, _} = Arcana.ingest("Beta scope marker", repo: Repo, collection: "scope-beta")
+
+      assert {:ok, all_results} =
+               Arcana.search("scope marker", repo: Repo, mode: :keyword, collections: :all)
+
+      assert Enum.sort(Enum.map(all_results, & &1.text)) ==
+               ["Alpha scope marker", "Beta scope marker"]
+
+      assert {:ok, []} =
+               Arcana.search("scope marker", repo: Repo, mode: :keyword, collections: [])
+    end
   end
 
   describe "search/2 result shape" do
@@ -206,10 +236,10 @@ defmodule Arcana.SearchTest do
       end
     end
 
-    test "unknown collection still searches unscoped when strict is off" do
+    test "unknown collection matches nothing when strict is off" do
       {:ok, results} = Arcana.search("Elixir", repo: Repo, collection: "strict-nope")
 
-      refute Enum.empty?(results)
+      assert results == []
     end
 
     test "a single unknown name in a collections list fails the whole search" do

--- a/test/arcana/search_test.exs
+++ b/test/arcana/search_test.exs
@@ -1,6 +1,8 @@
 defmodule Arcana.SearchTest do
   use Arcana.DataCase, async: true
 
+  alias Arcana.Searcher.Arcana, as: ArcanaSearcher
+
   describe "search/2" do
     setup do
       # Ingest some documents for searching
@@ -147,7 +149,7 @@ defmodule Arcana.SearchTest do
 
       # Search only in collections a and b
       {:ok, results} =
-        Arcana.search("language", repo: Repo, collections: ["search-coll-a", "search-coll-b"])
+        Arcana.search("language", repo: Repo, collection: ["search-coll-a", "search-coll-b"])
 
       refute Enum.empty?(results)
       texts = Enum.map(results, & &1.text)
@@ -158,7 +160,7 @@ defmodule Arcana.SearchTest do
       refute Enum.any?(texts, &String.contains?(&1, "JavaScript"))
     end
 
-    test "accepts a single name through :collections" do
+    test "accepts a single collection name" do
       {:ok, _} =
         Arcana.ingest("Ruby belongs in the selected collection",
           repo: Repo,
@@ -169,7 +171,7 @@ defmodule Arcana.SearchTest do
         Arcana.ingest("Python belongs elsewhere", repo: Repo, collection: "other-scope")
 
       assert {:ok, [%{text: text}]} =
-               Arcana.search("belongs", repo: Repo, mode: :keyword, collections: "single-scope")
+               Arcana.search("belongs", repo: Repo, mode: :keyword, collection: "single-scope")
 
       assert text =~ "Ruby"
     end
@@ -179,13 +181,24 @@ defmodule Arcana.SearchTest do
       {:ok, _} = Arcana.ingest("Beta scope marker", repo: Repo, collection: "scope-beta")
 
       assert {:ok, all_results} =
-               Arcana.search("scope marker", repo: Repo, mode: :keyword, collections: :all)
+               Arcana.search("scope marker", repo: Repo, mode: :keyword, collection: :all)
 
       assert Enum.sort(Enum.map(all_results, & &1.text)) ==
                ["Alpha scope marker", "Beta scope marker"]
 
       assert {:ok, []} =
-               Arcana.search("scope marker", repo: Repo, mode: :keyword, collections: [])
+               Arcana.search("scope marker", repo: Repo, mode: :keyword, collection: [])
+    end
+
+    test "rejects the removed collections alias instead of widening" do
+      assert {:error, {:unsupported_collection_option, :collections}} =
+               Arcana.search("anything", repo: Repo, collections: ["scope-a"])
+
+      assert {:error, {:unsupported_collection_option, :collections}} =
+               ArcanaSearcher.search("anything", :all,
+                 repo: Repo,
+                 collections: ["scope-a"]
+               )
     end
   end
 
@@ -246,7 +259,7 @@ defmodule Arcana.SearchTest do
       assert {:error, {:unknown_collection, "strict-nope"}} =
                Arcana.search("Elixir",
                  repo: Repo,
-                 collections: ["strict-known", "strict-nope"],
+                 collection: ["strict-known", "strict-nope"],
                  strict_collections: true
                )
     end

--- a/test/arcana/vector_store/memory_test.exs
+++ b/test/arcana/vector_store/memory_test.exs
@@ -106,6 +106,30 @@ defmodule Arcana.VectorStore.MemoryTest do
       assert length(prod_results) == 1
       assert hd(prod_results).id == "prod-1"
     end
+
+    test "searches all collections with a global limit", %{pid: pid} do
+      exact = normalize([1.0, 0.0] ++ List.duplicate(0.0, 382))
+      close = normalize([0.9, 0.1] ++ List.duplicate(0.0, 382))
+      far = normalize([0.0, 1.0] ++ List.duplicate(0.0, 382))
+
+      :ok = Memory.store(pid, "docs", "exact", exact, %{text: "exact match"})
+      :ok = Memory.store(pid, "products", "close", close, %{text: "close match"})
+      :ok = Memory.store(pid, "products", "far", far, %{text: "far match"})
+
+      assert [%{id: "exact"}, %{id: "close"}] = Memory.search(pid, :all, exact, limit: 2)
+    end
+  end
+
+  describe "search_text/4" do
+    test "searches all collections", %{pid: pid} do
+      embedding = List.duplicate(0.5, 384)
+      :ok = Memory.store(pid, "docs", "doc", embedding, %{text: "shared docs term"})
+      :ok = Memory.store(pid, "products", "product", embedding, %{text: "shared product term"})
+      :ok = Memory.store(pid, "other", "other", embedding, %{text: "unrelated"})
+
+      assert results = Memory.search_text(pid, :all, "shared term", limit: 10)
+      assert Enum.sort(Enum.map(results, & &1.id)) == ["doc", "product"]
+    end
   end
 
   describe "delete/3" do

--- a/test/arcana/vector_store/memory_test.exs
+++ b/test/arcana/vector_store/memory_test.exs
@@ -34,6 +34,20 @@ defmodule Arcana.VectorStore.MemoryTest do
       assert :ok = Memory.store(pid, "docs", "chunk-1", embedding, %{text: "doc"})
       assert :ok = Memory.store(pid, "products", "chunk-2", embedding, %{text: "product"})
     end
+
+    test "rejects a different embedding dimension across collections", %{pid: pid} do
+      embedding = List.duplicate(0.5, 384)
+
+      assert :ok = Memory.store(pid, "docs", "chunk-1", embedding, %{text: "doc"})
+
+      assert {:error, {:dimension_mismatch, expected: 384, actual: 768}} =
+               Memory.store(pid, "products", "chunk-2", List.duplicate(0.5, 768), %{
+                 text: "product"
+               })
+
+      assert [%{id: "chunk-1"}] = Memory.search(pid, :all, embedding)
+      assert Process.alive?(pid)
+    end
   end
 
   describe "search/4" do
@@ -118,6 +132,15 @@ defmodule Arcana.VectorStore.MemoryTest do
 
       assert [%{id: "exact"}, %{id: "close"}] = Memory.search(pid, :all, exact, limit: 2)
     end
+
+    test "returns no results when the query dimension differs", %{pid: pid} do
+      embedding = List.duplicate(0.5, 384)
+      :ok = Memory.store(pid, "docs", "doc", embedding, %{text: "doc"})
+
+      assert [] = Memory.search(pid, :all, List.duplicate(0.5, 768))
+      assert [] = Memory.search(pid, "docs", List.duplicate(0.5, 768))
+      assert Process.alive?(pid)
+    end
   end
 
   describe "search_text/4" do
@@ -155,6 +178,14 @@ defmodule Arcana.VectorStore.MemoryTest do
   end
 
   describe "clear/2" do
+    test "does not guess dimensions before the first store", %{pid: pid} do
+      assert :ok = Memory.clear(pid, "docs")
+
+      embedding = List.duplicate(0.5, 768)
+      assert :ok = Memory.store(pid, "docs", "doc-1", embedding, %{text: "doc"})
+      assert [%{id: "doc-1"}] = Memory.search(pid, :all, embedding)
+    end
+
     test "removes all vectors from collection", %{pid: pid} do
       embedding = List.duplicate(0.5, 384)
       :ok = Memory.store(pid, "default", "chunk-1", embedding, %{text: "hello"})

--- a/test/arcana/vector_store/pgvector_ef_search_test.exs
+++ b/test/arcana/vector_store/pgvector_ef_search_test.exs
@@ -82,7 +82,7 @@ defmodule Arcana.VectorStore.PgvectorEfSearchTest do
       {:ok, _results} =
         Arcana.search("only chunk",
           repo: Repo,
-          collections: ["ef-through-search"],
+          collection: ["ef-through-search"],
           hnsw_ef_search: 321
         )
 
@@ -113,7 +113,7 @@ defmodule Arcana.VectorStore.PgvectorEfSearchTest do
       put_arcana_env(:search, hnsw_ef_search: 456)
 
       {:ok, _} =
-        Arcana.search("only chunk", repo: Repo, collections: ["ef-config-default"])
+        Arcana.search("only chunk", repo: Repo, collection: ["ef-config-default"])
 
       assert current_ef_search() == "456",
              "a global search default for :hnsw_ef_search never reached the backend"

--- a/test/arcana/vector_store/pgvector_test.exs
+++ b/test/arcana/vector_store/pgvector_test.exs
@@ -151,6 +151,70 @@ defmodule Arcana.VectorStore.PgvectorTest do
       assert results == []
     end
 
+    test "only completed documents are visible through every retrieval mode" do
+      repo = Arcana.TestRepo
+      {:ok, collection} = Collection.get_or_create("published-only", repo)
+      embedding = normalize([1.0] ++ List.duplicate(0.0, 383))
+
+      candidates =
+        for status <- [:completed, :processing, :failed], into: %{} do
+          document =
+            %Document{}
+            |> Document.changeset(%{
+              content: "publication invariant",
+              status: status,
+              collection_id: collection.id
+            })
+            |> repo.insert!()
+
+          chunk =
+            %Chunk{}
+            |> Chunk.changeset(%{
+              text: "publication invariant #{status}",
+              embedding: embedding,
+              document_id: document.id
+            })
+            |> repo.insert!()
+
+          {status, %{document: document, chunk: chunk}}
+        end
+
+      searches = [
+        vector: fn ->
+          Pgvector.search("published-only", embedding,
+            repo: repo,
+            limit: 10,
+            threshold: -1.0
+          )
+        end,
+        keyword: fn ->
+          Pgvector.search_text("published-only", "publication invariant", repo: repo, limit: 10)
+        end,
+        hybrid: fn ->
+          Pgvector.search_hybrid(
+            "published-only",
+            embedding,
+            "publication invariant",
+            repo: repo,
+            limit: 10,
+            threshold: -1.0
+          )
+        end
+      ]
+
+      for {mode, search} <- searches do
+        results = search.()
+        document_ids = Enum.map(results, &normalize_uuid(&1.metadata.document_id))
+        chunk_ids = Enum.map(results, &normalize_uuid(&1.id))
+
+        assert document_ids == [candidates.completed.document.id],
+               "#{mode} exposed a document that has not been published"
+
+        refute candidates.processing.chunk.id in chunk_ids
+        refute candidates.failed.chunk.id in chunk_ids
+      end
+    end
+
     test "search_text handles tsquery special characters safely" do
       repo = Arcana.TestRepo
 
@@ -580,6 +644,9 @@ defmodule Arcana.VectorStore.PgvectorTest do
   end
 
   # Helper to normalize a vector to unit length
+  defp normalize_uuid(<<_::128>> = uuid), do: Ecto.UUID.load!(uuid)
+  defp normalize_uuid(uuid), do: uuid
+
   defp normalize(vector) do
     magnitude = :math.sqrt(Enum.reduce(vector, 0.0, fn x, sum -> sum + x * x end))
 

--- a/test/arcana/vector_store/pgvector_test.exs
+++ b/test/arcana/vector_store/pgvector_test.exs
@@ -275,7 +275,7 @@ defmodule Arcana.VectorStore.PgvectorTest do
       assert [%{metadata: %{text: "pinned chunk"}}] = results
     end
 
-    test "under strict mode a direct backend call with an unknown name matches nothing" do
+    test "a direct backend call only searches globally for an explicit all scope" do
       repo = Arcana.TestRepo
 
       {:ok, collection} = Collection.get_or_create("strict-direct", repo)
@@ -293,10 +293,11 @@ defmodule Arcana.VectorStore.PgvectorTest do
       })
       |> repo.insert!()
 
-      # Non-strict keeps the historical fail-open (global) behavior
-      refute Pgvector.search("strict-nope", List.duplicate(0.5, 384), repo: repo) == []
+      assert Pgvector.search("strict-nope", List.duplicate(0.5, 384), repo: repo) == []
 
-      # Strict fails closed instead of widening to a global search
+      assert [%{metadata: %{text: "in collection"}}] =
+               Pgvector.search(:all, List.duplicate(0.5, 384), repo: repo)
+
       assert Pgvector.search("strict-nope", List.duplicate(0.5, 384),
                repo: repo,
                strict_collections: true

--- a/test/arcana_test.exs
+++ b/test/arcana_test.exs
@@ -30,7 +30,7 @@ defmodule ArcanaTest do
       model = "openai:gpt-4o-mini"
 
       # This should not raise - the protocol implementation exists
-      assert Arcana.LLM.impl_for(model) != nil
+      assert Arcana.LLM.impl_for(model) == Arcana.LLM.BitString
     end
 
     test "returns answer using retrieved context" do

--- a/test/arcana_web/background_task_test.exs
+++ b/test/arcana_web/background_task_test.exs
@@ -47,13 +47,18 @@ defmodule ArcanaWeb.BackgroundTaskTest do
              ArcanaWeb.BackgroundTask.start(
                self(),
                :finished,
-               fn -> :done end,
-               cleanup: fn -> send(test_pid, :cleaned) end
+               fn ->
+                 send(test_pid, {:worker, self()})
+                 :done
+               end,
+               cleanup: fn -> send(test_pid, {:cleaned, self()}) end
              )
 
+    assert_receive {:worker, worker}
     assert_receive {:finished, _run_ref, :done}
-    assert_receive :cleaned
-    refute_receive :cleaned
+    assert_receive {:cleaned, guardian}
+    refute Process.alive?(worker)
+    refute_receive {:cleaned, ^guardian}
   end
 
   test "runs cleanup when the owner exits and the worker is killed" do
@@ -66,7 +71,7 @@ defmodule ArcanaWeb.BackgroundTaskTest do
             self(),
             :finished,
             fn ->
-              send(test_pid, :worker_started)
+              send(test_pid, {:worker_started, self()})
               Process.sleep(:infinity)
             end,
             cleanup: fn -> send(test_pid, :cleaned) end
@@ -75,9 +80,10 @@ defmodule ArcanaWeb.BackgroundTaskTest do
         Process.sleep(:infinity)
       end)
 
-    assert_receive :worker_started
+    assert_receive {:worker_started, worker}
     Process.exit(owner, :kill)
     assert_receive :cleaned
+    refute Process.alive?(worker)
   end
 
   test "runs cleanup when the coordinator fails" do
@@ -87,14 +93,87 @@ defmodule ArcanaWeb.BackgroundTaskTest do
              ArcanaWeb.BackgroundTask.start(
                self(),
                :finished,
-               fn -> Process.sleep(:infinity) end,
+               fn ->
+                 send(test_pid, {:worker, self()})
+                 Process.sleep(:infinity)
+               end,
                cleanup: fn -> send(test_pid, :cleaned) end
              )
 
+    assert_receive {:worker, worker}
+    worker_ref = Process.monitor(worker)
     Process.exit(task.pid, :kill)
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
     assert_receive :cleaned
     assert_receive {:DOWN, monitor_ref, :process, pid, :killed}
     assert monitor_ref == task.monitor_ref
     assert pid == task.pid
+  end
+
+  test "does not start work or clean up before a registered worker dies" do
+    test_pid = self()
+    worker_state = :ets.new(:background_worker_state, [:set, :public])
+
+    assert {:ok, task} =
+             ArcanaWeb.BackgroundTask.start(
+               self(),
+               :finished,
+               fn -> send(test_pid, :worker_ran) end,
+               on_worker_registered: fn worker ->
+                 :ets.insert(worker_state, {:worker, worker})
+                 send(test_pid, {:worker_registered, worker})
+                 Process.sleep(:infinity)
+               end,
+               cleanup: fn ->
+                 [{:worker, worker}] = :ets.lookup(worker_state, :worker)
+                 send(test_pid, {:cleaned, Process.alive?(worker)})
+               end
+             )
+
+    assert_receive {:worker_registered, worker}
+    worker_ref = Process.monitor(worker)
+    Process.exit(task.pid, :kill)
+
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
+    assert_receive {:cleaned, false}
+    refute_receive :worker_ran
+  end
+
+  test "binds to the actual supervisor behind a registry name and stops with it" do
+    test_pid = self()
+    registry_name = ArcanaWeb.BackgroundTaskTest.SupervisorRegistry
+    supervisor_name = {:via, Registry, {registry_name, :task_supervisor}}
+
+    {:ok, registry} = Registry.start_link(keys: :unique, name: registry_name)
+    Process.unlink(registry)
+
+    on_exit(fn ->
+      if Process.alive?(registry), do: Supervisor.stop(registry)
+    end)
+
+    {:ok, task_supervisor} = Task.Supervisor.start_link(name: supervisor_name)
+    Process.unlink(task_supervisor)
+
+    assert {:ok, task} =
+             ArcanaWeb.BackgroundTask.start(
+               self(),
+               :finished,
+               fn ->
+                 send(test_pid, {:worker, self()})
+                 Process.sleep(:infinity)
+               end,
+               task_supervisor: supervisor_name,
+               cleanup: fn -> send(test_pid, :cleaned) end
+             )
+
+    assert_receive {:worker, worker}
+    worker_ref = Process.monitor(worker)
+    Process.exit(task_supervisor, :kill)
+
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}, 1_000
+    assert_receive {:DOWN, monitor_ref, :process, pid, :killed}, 1_000
+    assert monitor_ref == task.monitor_ref
+    assert pid == task.pid
+    assert_receive :cleaned, 1_000
   end
 end

--- a/test/arcana_web/background_task_test.exs
+++ b/test/arcana_web/background_task_test.exs
@@ -1,0 +1,100 @@
+defmodule ArcanaWeb.BackgroundTaskTest do
+  use ExUnit.Case, async: true
+
+  test "delivers a tagged result" do
+    assert {:ok, task} =
+             ArcanaWeb.BackgroundTask.start(self(), :finished, fn -> {:ok, 42} end)
+
+    assert_receive {:finished, run_ref, {:ok, 42}}
+    assert run_ref == task.run_ref
+    assert_receive {:DOWN, monitor_ref, :process, pid, :normal}
+    assert monitor_ref == task.monitor_ref
+    assert pid == task.pid
+  end
+
+  test "stops work when its owner exits" do
+    test_pid = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, _task} =
+          ArcanaWeb.BackgroundTask.start(self(), :finished, fn ->
+            send(test_pid, {:worker, self()})
+            Process.sleep(:infinity)
+          end)
+
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive {:worker, worker}
+    worker_ref = Process.monitor(worker)
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
+  end
+
+  test "turns worker exits into an error result" do
+    assert {:ok, _task} =
+             ArcanaWeb.BackgroundTask.start(self(), :finished, fn -> exit(:boom) end)
+
+    assert_receive {:finished, _run_ref, {:error, message}}
+    assert message =~ "boom"
+  end
+
+  test "runs cleanup once after normal completion" do
+    test_pid = self()
+
+    assert {:ok, _task} =
+             ArcanaWeb.BackgroundTask.start(
+               self(),
+               :finished,
+               fn -> :done end,
+               cleanup: fn -> send(test_pid, :cleaned) end
+             )
+
+    assert_receive {:finished, _run_ref, :done}
+    assert_receive :cleaned
+    refute_receive :cleaned
+  end
+
+  test "runs cleanup when the owner exits and the worker is killed" do
+    test_pid = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, _task} =
+          ArcanaWeb.BackgroundTask.start(
+            self(),
+            :finished,
+            fn ->
+              send(test_pid, :worker_started)
+              Process.sleep(:infinity)
+            end,
+            cleanup: fn -> send(test_pid, :cleaned) end
+          )
+
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive :worker_started
+    Process.exit(owner, :kill)
+    assert_receive :cleaned
+  end
+
+  test "runs cleanup when the coordinator fails" do
+    test_pid = self()
+
+    assert {:ok, task} =
+             ArcanaWeb.BackgroundTask.start(
+               self(),
+               :finished,
+               fn -> Process.sleep(:infinity) end,
+               cleanup: fn -> send(test_pid, :cleaned) end
+             )
+
+    Process.exit(task.pid, :kill)
+    assert_receive :cleaned
+    assert_receive {:DOWN, monitor_ref, :process, pid, :killed}
+    assert monitor_ref == task.monitor_ref
+    assert pid == task.pid
+  end
+end

--- a/test/arcana_web/background_task_test.exs
+++ b/test/arcana_web/background_task_test.exs
@@ -139,6 +139,40 @@ defmodule ArcanaWeb.BackgroundTaskTest do
     refute_receive :worker_ran
   end
 
+  test "owner exit cancels a worker while the registration hook is blocked" do
+    test_pid = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, task} =
+          ArcanaWeb.BackgroundTask.start(
+            self(),
+            :finished,
+            fn -> send(test_pid, :worker_ran) end,
+            on_worker_registered: fn worker ->
+              send(test_pid, {:worker_registered, worker})
+              Process.sleep(:infinity)
+            end,
+            cleanup: fn -> send(test_pid, :cleaned) end
+          )
+
+        send(test_pid, {:task, task})
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive {:task, task}
+    assert_receive {:worker_registered, worker}
+    worker_ref = Process.monitor(worker)
+    coordinator_ref = Process.monitor(task.pid)
+    Process.exit(owner, :kill)
+
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
+    assert_receive {:DOWN, ^coordinator_ref, :process, pid, :normal}
+    assert pid == task.pid
+    assert_receive :cleaned
+    refute_receive :worker_ran
+  end
+
   test "binds to the actual supervisor behind a registry name and stops with it" do
     test_pid = self()
     registry_name = ArcanaWeb.BackgroundTaskTest.SupervisorRegistry

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -4,7 +4,7 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
   import Ecto.Query
   import Phoenix.LiveViewTest
 
-  alias Arcana.Collection
+  alias Arcana.{Collection, Document}
   alias Arcana.Evaluation
   alias Arcana.Graph.Community
   alias Arcana.Graph.{Community, Entity, Relationship, RelationshipEvidence}
@@ -200,6 +200,25 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       refute html =~ ~s(<option value="">default</option>)
     end
 
+    test "lists and filters across several allowed collections", %{conn: conn} do
+      {:ok, _} = Arcana.ingest("First allowed document", repo: Repo, collection: "tenant-a")
+      {:ok, _} = Arcana.ingest("Second allowed document", repo: Repo, collection: "tenant-b")
+      {:ok, _} = Arcana.ingest("Outside document", repo: Repo, collection: "other")
+
+      {:ok, view, html} =
+        conn |> restrict(["tenant-a", "tenant-b"]) |> live("/scoped/documents")
+
+      assert html =~ "First allowed document"
+      assert html =~ "Second allowed document"
+      refute html =~ "Outside document"
+
+      html = render_click(view, "filter_by_collection", %{"collection" => "tenant-b"})
+
+      refute html =~ "First allowed document"
+      assert html =~ "Second allowed document"
+      refute html =~ "Outside document"
+    end
+
     test "rejects a forged ingest event naming a disallowed collection", %{conn: conn} do
       {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/documents")
 
@@ -238,6 +257,13 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       html = render_click(view, "view_document", %{"id" => doc.id})
 
       refute html =~ "Hidden tenant content"
+    end
+
+    test "ignores a malformed document id in the URL", %{conn: conn} do
+      assert {:ok, _view, html} =
+               conn |> restrict(["tenant-a"]) |> live("/scoped/documents?doc=not-a-uuid")
+
+      refute html =~ "Document Details"
     end
 
     # The delete carries the allowed-collection predicate in the DELETE
@@ -310,6 +336,36 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       render_click(view, "view_search_document", %{"id" => "not-a-uuid"})
 
       assert render(view) =~ "Search"
+    end
+
+    test "a forged detail id cannot open a document outside the allowed scope", %{conn: conn} do
+      {:ok, doc} =
+        Arcana.ingest("Hidden search detail", repo: Repo, collection: "other")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/search")
+
+      html = render_click(view, "view_search_document", %{"id" => doc.id})
+
+      refute html =~ "Hidden search detail"
+    end
+
+    test "a forged detail id cannot open an unpublished document", %{conn: conn} do
+      {:ok, collection} = Collection.get_or_create("tenant-a", Repo)
+
+      pending =
+        %Document{}
+        |> Document.changeset(%{
+          content: "Pending search detail",
+          status: :pending,
+          collection_id: collection.id
+        })
+        |> Repo.insert!()
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/search")
+
+      html = render_click(view, "view_search_document", %{"id" => pending.id})
+
+      refute html =~ "Pending search detail"
     end
 
     test "an empty allowed set never searches anything", %{conn: conn} do
@@ -432,6 +488,104 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
 
       assert html =~ "tenant-a"
       refute html =~ ~s(value="other")
+    end
+
+    test "title hydration uses the completed documents in the run's effective scope", %{
+      conn: conn
+    } do
+      {:ok, allowed} =
+        Arcana.ingest("Allowed title content",
+          repo: Repo,
+          collection: "tenant-a",
+          metadata: %{"title" => "Allowed title"}
+        )
+
+      {:ok, hidden} =
+        Arcana.ingest("Hidden title content",
+          repo: Repo,
+          collection: "other",
+          metadata: %{"title" => "Hidden title"}
+        )
+
+      {:ok, collection} = Collection.get_or_create("tenant-a", Repo)
+
+      pending =
+        %Document{}
+        |> Document.changeset(%{
+          content: "Pending title content",
+          status: :pending,
+          collection_id: collection.id,
+          metadata: %{"title" => "Pending title"}
+        })
+        |> Repo.insert!()
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/ask")
+
+      result = %{
+        question: "Which titles?",
+        answer: "Three chunks",
+        results: [
+          %{id: "one", text: "one", score: 0.9, document_id: allowed.id, chunk_index: 0},
+          %{id: "two", text: "two", score: 0.8, document_id: hidden.id, chunk_index: 0},
+          %{id: "three", text: "three", score: 0.7, document_id: pending.id, chunk_index: 0}
+        ],
+        collection_scope: :all,
+        selected_collections: nil
+      }
+
+      send(view.pid, {:ask_complete, {:ok, result}})
+      html = render(view)
+
+      assert html =~ "Allowed title"
+      refute html =~ "Hidden title"
+      refute html =~ "Pending title"
+    end
+
+    test "title hydration preserves a multi-collection run scope", %{conn: conn} do
+      documents =
+        for {collection, title} <- [
+              {"tenant-a", "Tenant A title"},
+              {"tenant-b", "Tenant B title"},
+              {"tenant-c", "Tenant C title"}
+            ] do
+          {:ok, document} =
+            Arcana.ingest("Content for #{collection}",
+              repo: Repo,
+              collection: collection,
+              metadata: %{"title" => title}
+            )
+
+          document
+        end
+
+      {:ok, view, _html} =
+        conn
+        |> restrict(["tenant-a", "tenant-b", "tenant-c"])
+        |> live("/scoped/ask")
+
+      result = %{
+        question: "Which titles?",
+        answer: "Three chunks",
+        results:
+          Enum.map(documents, fn document ->
+            %{
+              id: document.id,
+              text: "chunk",
+              score: 0.9,
+              document_id: document.id,
+              chunk_index: 0
+            }
+          end),
+        collection_scope: ["tenant-a", "tenant-b"],
+        selected_collections: ["tenant-a", "tenant-b"]
+      }
+
+      send(view.pid, {:ask_complete, {:ok, result}})
+      html = render(view)
+
+      assert html =~ "Tenant A title"
+      assert html =~ "Tenant B title"
+      refute html =~ "Tenant C title"
     end
   end
 

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -7,7 +7,7 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
   alias Arcana.Collection
   alias Arcana.Evaluation
   alias Arcana.Graph.Community
-  alias Arcana.Graph.{Community, Entity, Relationship}
+  alias Arcana.Graph.{Community, Entity, Relationship, RelationshipEvidence}
 
   # These tests exercise the /scoped dashboard from the test router, whose
   # :collections MFA reads the allowed list from the conn's session. Each
@@ -521,12 +521,32 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       source = Repo.get_by!(Entity, name: "SecretSource", collection_id: other.id)
       target = Repo.get_by!(Entity, name: "SecretTarget", collection_id: other.id)
 
-      Repo.insert!(%Relationship{
-        source_id: source.id,
-        target_id: target.id,
-        type: "knows",
-        strength: 8
+      relationship =
+        %Relationship{}
+        |> Relationship.changeset(%{
+          source_id: source.id,
+          target_id: target.id,
+          type: "knows",
+          strength: 8
+        })
+        |> Repo.insert!()
+
+      chunk =
+        Repo.one!(
+          from(c in Arcana.Chunk,
+            join: d in Arcana.Document,
+            on: c.document_id == d.id,
+            where: d.collection_id == ^other.id,
+            limit: 1
+          )
+        )
+
+      %RelationshipEvidence{}
+      |> RelationshipEvidence.changeset(%{
+        relationship_id: relationship.id,
+        chunk_id: chunk.id
       })
+      |> Repo.insert!()
 
       {:ok, view, _html} =
         conn |> restrict(["ghost", "tenant-a"]) |> live("/scoped/graph?tab=relationships")
@@ -743,6 +763,7 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       )
 
       refute render(view) =~ "ForeignProgressQuestionZulu"
+      render_until(view, "Evaluation completed!")
     end
 
     test "a restricted Loop evaluation runs scoped and strict", %{conn: conn} do
@@ -773,6 +794,7 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       assert_receive {:loop_scope, collections, search_opts}, 2_000
       assert collections == ["tenant-a"]
       assert search_opts[:strict_collections] == true
+      render_until(view, "Evaluation completed!")
     end
   end
 

--- a/test/arcana_web/live/allowed_collections_test.exs
+++ b/test/arcana_web/live/allowed_collections_test.exs
@@ -330,6 +330,21 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
       refute html =~ "Elixir content for others"
     end
 
+    test "rejects the whole search when a selection mixes allowed and disallowed collections",
+         %{conn: conn} do
+      {:ok, _} = Arcana.ingest("Visible mixed-scope content", repo: Repo, collection: "tenant-a")
+
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/search")
+
+      html =
+        render_submit(view, "search", %{
+          "query" => "mixed-scope",
+          "collections" => ["tenant-a", "other"]
+        })
+
+      refute html =~ "Visible mixed-scope content"
+    end
+
     test "a malformed document id is rejected instead of crashing", %{conn: conn} do
       {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/search")
 
@@ -417,6 +432,20 @@ defmodule ArcanaWeb.AllowedCollectionsTest do
           "question" => "What is hidden?",
           "sub_tab" => "advanced",
           "collections" => ["other"]
+        })
+
+      assert html =~ "not allowed"
+    end
+
+    test "rejects the whole ask when a selection mixes allowed and disallowed collections",
+         %{conn: conn} do
+      {:ok, view, _html} = conn |> restrict(["tenant-a"]) |> live("/scoped/ask")
+
+      html =
+        render_submit(view, "ask_submit", %{
+          "question" => "What is hidden?",
+          "sub_tab" => "advanced",
+          "collections" => ["tenant-a", "other"]
         })
 
       assert html =~ "not allowed"

--- a/test/arcana_web/live/ask_live_test.exs
+++ b/test/arcana_web/live/ask_live_test.exs
@@ -454,6 +454,75 @@ defmodule ArcanaWeb.AskLiveTest do
   end
 
   describe "Loop execution handler" do
+    test "concurrent asks only render telemetry emitted by their own worker", %{conn: conn} do
+      test_pid = self()
+      put_arcana_env(:llm, "zai:test-stub")
+
+      put_arcana_env(:loop_runner, fn ctx, _opts ->
+        send(test_pid, {:loop_worker, ctx.question, self()})
+
+        receive do
+          {:emit_tool_call, query, observer} ->
+            :telemetry.execute(
+              [:arcana, :loop, :tool_call],
+              %{count: 1, history_size: 1},
+              %{
+                tool: :search,
+                args: %{query: query},
+                iteration: 1,
+                summary: "searched",
+                returned_chunk_ids: []
+              }
+            )
+
+            :sys.get_state(observer)
+            send(test_pid, {:tool_call_emitted, self()})
+        end
+
+        receive do
+          :finish ->
+            {:ok,
+             %Arcana.Loop.Context{
+               question: ctx.question,
+               answer: "done",
+               tool_history: [],
+               iterations: 1,
+               terminated_by: :answered,
+               chunks: [],
+               grounding: nil
+             }}
+        end
+      end)
+
+      {:ok, first_view, _html} = live(conn, "/arcana/ask/loop")
+      {:ok, second_view, _html} = live(conn, "/arcana/ask/loop")
+
+      first_view |> form("#ask-form", %{"question" => "first"}) |> render_submit()
+      second_view |> form("#ask-form", %{"question" => "second"}) |> render_submit()
+
+      workers =
+        for _ <- 1..2, into: %{} do
+          assert_receive {:loop_worker, question, worker}
+          {question, worker}
+        end
+
+      send(workers["first"], {:emit_tool_call, "only-first-run", second_view.pid})
+      assert_receive {:tool_call_emitted, first_worker}
+      assert first_worker == workers["first"]
+
+      assert render_until(first_view, "only-first-run") =~ "only-first-run"
+      refute render(second_view) =~ "only-first-run"
+
+      send(workers["first"], :finish)
+      send(workers["second"], {:emit_tool_call, "only-second-run", first_view.pid})
+      assert_receive {:tool_call_emitted, second_worker}
+      assert second_worker == workers["second"]
+
+      assert render_until(second_view, "only-second-run") =~ "only-second-run"
+      refute render(second_view) =~ "only-first-run"
+      send(workers["second"], :finish)
+    end
+
     test "submitting the Loop form with an injected controller runs Loop.run/2", %{conn: conn} do
       # The handle_event for submit checks that :arcana, :llm is configured
       # before running anything. Set a placeholder so the handler proceeds;

--- a/test/arcana_web/live/collections_live_test.exs
+++ b/test/arcana_web/live/collections_live_test.exs
@@ -3,6 +3,8 @@ defmodule ArcanaWeb.CollectionsLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Arcana.Graph.{Community, Entity, EntityMention}
+
   describe "Collections page" do
     test "mounts successfully", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/arcana/collections")
@@ -105,5 +107,68 @@ defmodule ArcanaWeb.CollectionsLiveTest do
       assert has_element?(view, "th", "Docs")
       assert has_element?(view, "th", "Chunks")
     end
+
+    test "does not count communities backed only by unpublished entities", %{conn: conn} do
+      {:ok, published} = Arcana.ingest("Published", repo: Repo, collection: "published-graph")
+      {:ok, hidden_collection} = Arcana.Collection.get_or_create("hidden-graph", Repo)
+
+      {:ok, hidden_document} =
+        %Arcana.Document{}
+        |> Arcana.Document.changeset(%{
+          content: "Failed",
+          collection_id: hidden_collection.id,
+          status: :failed
+        })
+        |> Repo.insert()
+
+      published_chunk = Repo.get_by!(Arcana.Chunk, document_id: published.id)
+
+      hidden_chunk =
+        %Arcana.Chunk{}
+        |> Arcana.Chunk.changeset(%{
+          text: "Hidden",
+          document_id: hidden_document.id,
+          embedding: List.duplicate(0.0, 384)
+        })
+        |> Repo.insert!()
+
+      published_entity = insert_entity("Published entity", published.collection_id)
+      hidden_entity = insert_entity("Hidden entity", hidden_collection.id)
+      insert_mention(published_entity.id, published_chunk.id)
+      insert_mention(hidden_entity.id, hidden_chunk.id)
+      insert_community(published.collection_id, published_entity.id)
+      insert_community(hidden_collection.id, hidden_entity.id)
+
+      {:ok, view, _html} = live(conn, "/arcana/collections")
+
+      assert has_element?(view, "#collection-published-graph td:nth-child(7)", "1")
+      assert has_element?(view, "#collection-hidden-graph td:nth-child(7)", "0")
+    end
+  end
+
+  defp insert_entity(name, collection_id) do
+    %Entity{}
+    |> Entity.changeset(%{
+      name: name,
+      type: "concept",
+      collection_id: collection_id
+    })
+    |> Repo.insert!()
+  end
+
+  defp insert_mention(entity_id, chunk_id) do
+    %EntityMention{}
+    |> EntityMention.changeset(%{entity_id: entity_id, chunk_id: chunk_id})
+    |> Repo.insert!()
+  end
+
+  defp insert_community(collection_id, entity_id) do
+    %Community{}
+    |> Community.changeset(%{
+      collection_id: collection_id,
+      entity_ids: [entity_id],
+      level: 0
+    })
+    |> Repo.insert!()
   end
 end

--- a/test/arcana_web/live/documents_graph_live_test.exs
+++ b/test/arcana_web/live/documents_graph_live_test.exs
@@ -50,7 +50,7 @@ defmodule ArcanaWeb.DocumentsGraphLiveTest do
 
       # After clicking, button shows loading state
       assert html =~ "Building..."
-      assert wait_until(fn -> not (render(view) =~ "Building...") end)
+      assert wait_until(fn -> not (render(view) =~ "Building...") end, 300)
     end
 
     test "resets loading state after graph build completes", %{conn: conn} do
@@ -62,7 +62,7 @@ defmodule ArcanaWeb.DocumentsGraphLiveTest do
       html = view |> element("button[phx-click='build_graph']") |> render_click()
       assert html =~ "Building..."
 
-      assert wait_until(fn -> not (render(view) =~ "Building...") end)
+      assert wait_until(fn -> not (render(view) =~ "Building...") end, 300)
 
       # After the real task completes, button should be back to normal.
       html = render(view)

--- a/test/arcana_web/live/documents_graph_live_test.exs
+++ b/test/arcana_web/live/documents_graph_live_test.exs
@@ -50,6 +50,7 @@ defmodule ArcanaWeb.DocumentsGraphLiveTest do
 
       # After clicking, button shows loading state
       assert html =~ "Building..."
+      assert wait_until(fn -> not (render(view) =~ "Building...") end)
     end
 
     test "resets loading state after graph build completes", %{conn: conn} do
@@ -61,10 +62,9 @@ defmodule ArcanaWeb.DocumentsGraphLiveTest do
       html = view |> element("button[phx-click='build_graph']") |> render_click()
       assert html =~ "Building..."
 
-      # Send completion message
-      send(view.pid, {:graph_complete, {:ok, %{entity_count: 5, relationship_count: 3}}})
+      assert wait_until(fn -> not (render(view) =~ "Building...") end)
 
-      # After completion, button should be back to normal (not disabled)
+      # After the real task completes, button should be back to normal.
       html = render(view)
       refute html =~ "Building..."
       assert html =~ "Build Graph"

--- a/test/arcana_web/live/documents_live_build_graph_test.exs
+++ b/test/arcana_web/live/documents_live_build_graph_test.exs
@@ -18,6 +18,7 @@ defmodule ArcanaWeb.DocumentsLiveBuildGraphTest do
   import Phoenix.LiveViewTest
   import Arcana.ConfigCase, only: [put_arcana_env: 2]
 
+  alias Arcana.Collection
   alias Ecto.Adapters.SQL
 
   defp open_document(conn, doc), do: live(conn, "/arcana/documents?doc=#{doc.id}")
@@ -217,6 +218,26 @@ defmodule ArcanaWeb.DocumentsLiveBuildGraphTest do
 
       assert render(view) =~ "Building...",
              "the first build must still be running"
+    end
+  end
+
+  describe "the open document leaves the allowed scope" do
+    test "the build reauthorizes the document and chunks before starting", %{conn: conn} do
+      {:ok, doc} =
+        Arcana.ingest("Scoped graph content", repo: Repo, collection: "tenant-a")
+
+      put_arcana_env(:graph, enabled: true)
+
+      conn = Plug.Test.init_test_session(conn, allowed_collections: ["tenant-a"])
+      {:ok, view, _html} = live(conn, "/scoped/documents?doc=#{doc.id}")
+
+      collection = Repo.get_by!(Collection, name: "tenant-a")
+      Repo.update!(Collection.changeset(collection, %{name: "renamed-away"}))
+
+      html = click_build_graph(view)
+
+      assert html =~ "This document is no longer available."
+      refute html =~ "Building..."
     end
   end
 

--- a/test/arcana_web/router_test.exs
+++ b/test/arcana_web/router_test.exs
@@ -67,9 +67,10 @@ defmodule ArcanaWeb.RouterTest do
     assert session_opts[:on_mount] == [ArcanaWeb.Router.Scope, SomeHook]
   end
 
-  describe ":collections option" do
+  describe ":collection option" do
     defmodule Access do
       def restricted(_conn), do: ["tenant-a", "tenant-b"]
+      def one(_conn), do: "tenant-a"
       def open(_conn), do: :all
       def broken(_conn), do: {:ok, ["tenant-a"]}
       def mixed(_conn), do: ["tenant-a", :oops]
@@ -78,7 +79,7 @@ defmodule ArcanaWeb.RouterTest do
     test "appends the MFA to the session args when given" do
       {_name, session_opts, _route_opts} =
         ArcanaWeb.Router.__options__(
-          [repo: Arcana.TestRepo, collections: {Access, :restricted}],
+          [repo: Arcana.TestRepo, collection: {Access, :restricted}],
           "/arcana"
         )
 
@@ -88,10 +89,16 @@ defmodule ArcanaWeb.RouterTest do
     end
 
     test "rejects anything that is not a {module, function} tuple" do
-      for bad <- [&String.length/1, "collections", {Access, :restricted, []}] do
-        assert_raise ArgumentError, ~r/:collections must be a \{module, function\} tuple/, fn ->
-          ArcanaWeb.Router.__options__([collections: bad], "/arcana")
+      for bad <- [&String.length/1, "collection", {Access, :restricted, []}] do
+        assert_raise ArgumentError, ~r/:collection must be a \{module, function\} tuple/, fn ->
+          ArcanaWeb.Router.__options__([collection: bad], "/arcana")
         end
+      end
+    end
+
+    test "rejects the removed plural option" do
+      assert_raise ArgumentError, ~r/:collections is not supported/, fn ->
+        ArcanaWeb.Router.__options__([collections: {Access, :restricted}], "/arcana")
       end
     end
 
@@ -110,12 +117,18 @@ defmodule ArcanaWeb.RouterTest do
       assert session["allowed_collections"] == :all
     end
 
+    test "__session__/4 normalizes one collection into the allowed list" do
+      session = ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/arcana", {Access, :one})
+
+      assert session["allowed_collections"] == ["tenant-a"]
+    end
+
     test "__session__/4 fails closed on invalid returns" do
-      assert_raise ArgumentError, ~r/must return :all or a list/, fn ->
+      assert_raise ArgumentError, ~r/must return :all, a collection name/, fn ->
         ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/arcana", {Access, :broken})
       end
 
-      assert_raise ArgumentError, ~r/non-string entries/, fn ->
+      assert_raise ArgumentError, ~r/must return :all, a collection name/, fn ->
         ArcanaWeb.Router.__session__(nil, Arcana.TestRepo, "/arcana", {Access, :mixed})
       end
     end

--- a/test/arcana_web/task_supervisor_test.exs
+++ b/test/arcana_web/task_supervisor_test.exs
@@ -9,6 +9,8 @@ defmodule ArcanaWeb.TaskSupervisorTest do
   """
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   test "start_child works under the current registered name" do
     parent = self()
 
@@ -23,15 +25,27 @@ defmodule ArcanaWeb.TaskSupervisorTest do
   test "the deprecated module's own helpers still delegate" do
     parent = self()
 
-    assert {:ok, _} = Arcana.TaskSupervisor.start_child(fn -> send(parent, :ran_via_shim) end)
+    assert {:ok, _} =
+             :erlang.apply(Arcana.TaskSupervisor, :start_child, [
+               fn -> send(parent, :ran_via_shim) end
+             ])
+
     assert_receive :ran_via_shim, 1_000
   end
 
   test "the old module's child_spec still starts the supervisor under the new name" do
-    spec = Arcana.TaskSupervisor.child_spec([])
+    parent = self()
+
+    log =
+      capture_log(fn ->
+        send(parent, {:spec, :erlang.apply(Arcana.TaskSupervisor, :child_spec, [[]])})
+      end)
+
+    assert_receive {:spec, spec}
 
     assert spec.id == ArcanaWeb.TaskSupervisor
     assert {Task.Supervisor, :start_link, [[name: ArcanaWeb.TaskSupervisor]]} = spec.start
+    assert log =~ "Arcana.TaskSupervisor is deprecated"
   end
 
   test "the legacy name holds no process, so start_child on it exits" do

--- a/test/support/controlled_graph_store.ex
+++ b/test/support/controlled_graph_store.ex
@@ -1,0 +1,44 @@
+defmodule Arcana.ControlledGraphStore do
+  @moduledoc false
+
+  alias Arcana.Graph.EntityName
+
+  def with_write_lock(collection_id, opts, fun) do
+    coordinator = Keyword.fetch!(opts, :coordinator)
+    ref = make_ref()
+    send(coordinator, {:graph_lock_waiting, self(), ref, collection_id})
+
+    receive do
+      {:grant_graph_lock, ^ref} ->
+        try do
+          fun.()
+        after
+          send(coordinator, {:graph_lock_released, self(), ref, collection_id})
+        end
+    end
+  end
+
+  def persist_entities(collection_id, entities, opts) do
+    notify(opts, {:persist_entities, collection_id, Enum.map(entities, & &1.name)})
+    {:ok, Map.new(entities, fn entity -> {EntityName.normalize(entity.name), entity.name} end)}
+  end
+
+  def persist_mentions(mentions, _entity_id_map, opts) do
+    notify(opts, {:persist_mentions, Enum.map(mentions, & &1.chunk_id)})
+    :ok
+  end
+
+  def persist_relationships(chunk_id, relationships, _entity_id_map, opts) do
+    notify(opts, {:persist_relationships, chunk_id, length(relationships)})
+    :ok
+  end
+
+  def delete_by_chunks(chunk_ids, opts) do
+    notify(opts, {:delete_by_chunks, chunk_ids})
+    :ok
+  end
+
+  defp notify(opts, message) do
+    if notify = Keyword.get(opts, :notify), do: send(notify, {:controlled_graph_store, message})
+  end
+end

--- a/test/support/controlled_graph_store.ex
+++ b/test/support/controlled_graph_store.ex
@@ -15,6 +15,9 @@ defmodule Arcana.ControlledGraphStore do
         after
           send(coordinator, {:graph_lock_released, self(), ref, collection_id})
         end
+    after
+      Keyword.get(opts, :lock_timeout, 1_000) ->
+        raise "timed out waiting for the graph lock coordinator"
     end
   end
 

--- a/test/support/graph_store_stubs.ex
+++ b/test/support/graph_store_stubs.ex
@@ -31,6 +31,8 @@ defmodule Arcana.SpyGraphStore do
     :ok
   end
 
+  def with_write_lock(_collection_id, _opts, fun), do: fun.()
+
   defp notify(opts, message) do
     case Keyword.get(opts, :notify) do
       nil -> :ok
@@ -54,6 +56,47 @@ defmodule Arcana.FailingSweepGraphStore do
   def delete_by_chunks(_chunk_ids, _opts), do: :ok
 
   def sweep_orphans(_collection_id, _opts), do: {:error, :sweep_boom}
+  def with_write_lock(_collection_id, _opts, fun), do: fun.()
+end
+
+defmodule Arcana.FailingDeleteGraphStore do
+  @moduledoc false
+
+  alias Arcana.Graph.EntityName
+
+  def persist_entities(_collection_id, entities, _opts) do
+    {:ok, Map.new(entities, fn e -> {EntityName.normalize(e.name), e.name} end)}
+  end
+
+  def persist_relationships(_chunk_id, _relationships, _entity_id_map, _opts), do: :ok
+  def persist_mentions(_mentions, _entity_id_map, _opts), do: :ok
+
+  def delete_by_chunks(_chunk_ids, opts) do
+    case Keyword.get(opts, :delete_failure, :return) do
+      :ok -> :ok
+      :return -> {:error, :delete_boom}
+      :raise -> raise "delete_boom"
+      :exit -> exit(:delete_boom)
+    end
+  end
+
+  def sweep_orphans(_collection_id, _opts), do: :ok
+  def with_write_lock(_collection_id, _opts, fun), do: fun.()
+end
+
+defmodule Arcana.RaisingDeleteGraphStore do
+  @moduledoc false
+
+  def delete_by_chunks(_chunk_ids, opts) do
+    case Keyword.get(opts, :cleanup_failure, :stale) do
+      :stale -> raise %Ecto.StaleEntryError{message: "external graph cleanup failed"}
+      :exit -> exit(:external_cleanup_exit)
+      :throw -> throw(:external_cleanup_throw)
+    end
+  end
+
+  def sweep_orphans(_collection_id, _opts), do: :ok
+  def with_write_lock(_collection_id, _opts, fun), do: fun.()
 end
 
 defmodule Arcana.LegacyGraphStore do
@@ -70,6 +113,7 @@ defmodule Arcana.LegacyGraphStore do
   def persist_relationships(_chunk_id, _relationships, _entity_id_map, _opts), do: :ok
   def persist_mentions(_mentions, _entity_id_map, _opts), do: :ok
   def delete_by_chunks(_chunk_ids, _opts), do: :ok
+  def with_write_lock(_collection_id, _opts, fun), do: fun.()
 end
 
 defmodule Arcana.RaisingGraphStore do
@@ -80,4 +124,5 @@ defmodule Arcana.RaisingGraphStore do
   def persist_relationships(_chunk_id, _relationships, _entity_id_map, _opts), do: :ok
   def persist_mentions(_mentions, _entity_id_map, _opts), do: :ok
   def sweep_orphans(_collection_id, _opts), do: :ok
+  def with_write_lock(_collection_id, _opts, fun), do: fun.()
 end

--- a/test/support/graph_store_stubs.ex
+++ b/test/support/graph_store_stubs.ex
@@ -11,13 +11,18 @@ defmodule Arcana.SpyGraphStore do
     {:ok, Map.new(entities, fn e -> {EntityName.normalize(e.name), e.name} end)}
   end
 
-  def persist_relationships(relationships, _entity_id_map, opts) do
-    notify(opts, {:persist_relationships, length(relationships)})
+  def persist_relationships(chunk_id, relationships, _entity_id_map, opts) do
+    notify(opts, {:persist_relationships, chunk_id, length(relationships)})
     :ok
   end
 
   def persist_mentions(mentions, _entity_id_map, opts) do
     notify(opts, {:persist_mentions, length(mentions)})
+    :ok
+  end
+
+  def delete_by_chunks(chunk_ids, opts) do
+    notify(opts, {:delete_by_chunks, chunk_ids})
     :ok
   end
 
@@ -44,8 +49,9 @@ defmodule Arcana.FailingSweepGraphStore do
     {:ok, Map.new(entities, fn e -> {EntityName.normalize(e.name), e.name} end)}
   end
 
-  def persist_relationships(_relationships, _entity_id_map, _opts), do: :ok
+  def persist_relationships(_chunk_id, _relationships, _entity_id_map, _opts), do: :ok
   def persist_mentions(_mentions, _entity_id_map, _opts), do: :ok
+  def delete_by_chunks(_chunk_ids, _opts), do: :ok
 
   def sweep_orphans(_collection_id, _opts), do: {:error, :sweep_boom}
 end
@@ -61,8 +67,9 @@ defmodule Arcana.LegacyGraphStore do
     {:ok, Map.new(entities, fn e -> {EntityName.normalize(e.name), e.name} end)}
   end
 
-  def persist_relationships(_relationships, _entity_id_map, _opts), do: :ok
+  def persist_relationships(_chunk_id, _relationships, _entity_id_map, _opts), do: :ok
   def persist_mentions(_mentions, _entity_id_map, _opts), do: :ok
+  def delete_by_chunks(_chunk_ids, _opts), do: :ok
 end
 
 defmodule Arcana.RaisingGraphStore do
@@ -70,7 +77,7 @@ defmodule Arcana.RaisingGraphStore do
   # Graph store that blows up mid-build, for the partial-document path.
 
   def persist_entities(_collection_id, _entities, _opts), do: raise("graph store exploded")
-  def persist_relationships(_relationships, _entity_id_map, _opts), do: :ok
+  def persist_relationships(_chunk_id, _relationships, _entity_id_map, _opts), do: :ok
   def persist_mentions(_mentions, _entity_id_map, _opts), do: :ok
   def sweep_orphans(_collection_id, _opts), do: :ok
 end

--- a/test/support/invalid_json_metadata.ex
+++ b/test/support/invalid_json_metadata.ex
@@ -1,0 +1,9 @@
+defmodule Arcana.InvalidJSONMetadata do
+  @moduledoc false
+
+  defstruct [:value]
+end
+
+defimpl JSON.Encoder, for: Arcana.InvalidJSONMetadata do
+  def encode(_metadata, _encoder), do: [:invalid_iodata]
+end

--- a/test/support/stale_document_status_repo.ex
+++ b/test/support/stale_document_status_repo.ex
@@ -1,0 +1,19 @@
+defmodule Arcana.StaleDocumentStatusRepo do
+  @moduledoc false
+
+  alias Arcana.{Document, TestRepo}
+
+  def get(Document, id) do
+    case TestRepo.get(Document, id) do
+      nil -> nil
+      document -> %{document | status: :processing}
+    end
+  end
+
+  def transaction(fun), do: TestRepo.transaction(fun)
+  def in_transaction?, do: TestRepo.in_transaction?()
+  def one(query), do: TestRepo.one(query)
+  def all(query), do: TestRepo.all(query)
+  def delete(struct), do: TestRepo.delete(struct)
+  def rollback(reason), do: TestRepo.rollback(reason)
+end

--- a/test/support/test_router.ex
+++ b/test/support/test_router.ex
@@ -37,7 +37,7 @@ defmodule ArcanaWeb.TestRouter do
     arcana_dashboard("/scoped",
       repo: Arcana.TestRepo,
       live_session_name: :arcana_dashboard_scoped,
-      collections: {ArcanaWeb.TestRouter.Allowed, :for_conn}
+      collection: {ArcanaWeb.TestRouter.Allowed, :for_conn}
     )
   end
 end


### PR DESCRIPTION
This rebuilds Arcana's publication, graph, and collection-scope lifecycle around a few explicit invariants. Only completed documents are public, every relationship fact carries chunk evidence, delete or replace operations update graph state through one lifecycle contract, and every read uses the same `:all` / one / many / none collection model.

The previous design let failed and replaced documents leak into retrieval, represented relationship provenance implicitly, spread migration ownership across copied lists, and interpreted collection options differently across Search, Ask, Pipeline, Loop, maintenance, evaluation, and the dashboard.

## Breaking changes

- Collection-scoped reads now use one `collection:` option accepting `:all`, a name, a list of names, or `[]`. The removed `collections:` option is rejected so stale callers can't silently widen their scope. Unknown names match nothing unless strict mode asks for an explicit error.
- Custom `Arcana.Searcher` and `Arcana.VectorStore` implementations receive `:all` for unrestricted retrieval and must rank and limit globally across the corpus.
- `GraphStore.persist_relationships/4` now requires the supporting chunk ID.
- `GraphStore.delete_by_chunks/2` and `GraphStore.with_write_lock/3` are required backend lifecycle callbacks. The lock must serialize graph writes for one collection across every reference to the same backend instance.
- Graph migration v2 adds canonical relationship fingerprints and per-chunk evidence. Legacy relationship rows are cleared because their provenance can't be reconstructed safely.
- Graph v2 can't roll back to v1. A full graph uninstall to version 0 remains supported.
- External graph cleanup failures are reported after the database commit with the collection, affected chunks, and published-chunk snapshot needed for an idempotent retry.

## What changed

- Adds `Arcana.CollectionScope` as the shared normalization, authorization, and intersection contract, then uses it across Documents, Search, Ask, Pipeline, Loop, maintenance, evaluation, and the dashboard.
- Adds `Arcana.get_document_metadata/2`, a completed-only, explicitly scoped batch attribution read that returns `id`, `source_id`, and `metadata` without loading document content.
- Resolves many collection names in one catalog query, preserves caller order, and never widens an empty, unknown, unauthorized, or outdated scope.
- Keeps Pipeline follow-up retrieval on the original scope and backend options, while isolating options when callers replace the follow-up searcher.
- Carries collection authorization and completed status into the dashboard's final document and chunk SQL, including graph-build reauthorization.
- Centralizes completed-only reads in `RetrievalScope` and applies them across vector search, graph traversal, Ask, evaluation, maintenance, and dashboard counts.
- Enforces one embedding dimension per in-memory vector store process so cross-collection `:all` queries can't mix incompatible HNSW indexes.
- Splits canonical relationship facts from their chunk evidence in both Ecto and memory stores.
- Serializes graph persistence with delete and replace cleanup, then rechecks chunk existence inside the lock so queued stale work can't republish retired graph data.
- Makes identical-fact replacement preserve valid community summaries while predecessor-only facts are retired and affected summaries are dirtied.
- Replaces raw LiveView tasks with supervised, correlated work tied to the actual supervisor process, including cancellation-safe telemetry cleanup and start-failure handling.
- Centralizes migration stream and version ownership, anchors each stream to one resolved schema, makes graph v2 atomic, and preflights host-owned PostgreSQL dependencies before uninstall DDL.
- Refuses unsafe rollback ordering with actionable errors and never uses `DROP CASCADE` against host objects.

Closes #180 and #185. This also subsumes the rollback and search-path fixes in #181 and #183.

Verified with 1,528 passing tests, including 5 doctests, with 78 excluded, plus 17 memory-backend tests. Formatting, warnings-as-errors compilation, strict Credo, diff checks, and three adversarial review passes are clean.
