### PR TITLE
test: Restore migration helper search_path

### DIFF
--- a/test/arcana/migration_test.exs
+++ b/test/arcana/migration_test.exs
@@ -1148,12 +1148,45 @@ defmodule Arcana.MigrationTest do
 
     defp with_tenant_first(fun) do
       Repo.checkout(fn ->
-        SQL.query!(Repo, ~s(SET search_path TO "tenant_first", public), [])
+        original = current_search_path()
 
         try do
+          SQL.query!(Repo, ~s(SET search_path TO "tenant_first", public), [])
           fun.()
         after
-          SQL.query!(Repo, "SET search_path TO public", [])
+          restore_search_path(original)
+        end
+      end)
+    end
+
+    defp current_search_path do
+      %{rows: [[search_path]]} = SQL.query!(Repo, "SHOW search_path", [])
+      search_path
+    end
+
+    defp restore_search_path(search_path) do
+      SQL.query!(Repo, "SELECT set_config('search_path', $1, false)", [search_path])
+    end
+
+    test "the helper restores the connection's previous search_path" do
+      Repo.checkout(fn ->
+        original = current_search_path()
+
+        try do
+          SQL.query!(Repo, "SET search_path TO pg_catalog, public", [])
+          assert current_search_path() == "pg_catalog, public"
+
+          assert with_tenant_first(fn -> current_search_path() end) == "tenant_first, public"
+
+          assert current_search_path() == "pg_catalog, public"
+
+          assert_raise RuntimeError, "boom", fn ->
+            with_tenant_first(fn -> raise "boom" end)
+          end
+
+          assert current_search_path() == "pg_catalog, public"
+        after
+          restore_search_path(original)
         end
       end)
     end


### PR DESCRIPTION
The tenant-first migration helper now restores the exact `search_path` it borrowed instead of hard-resetting the checked-out connection to `public`.

The regression starts the connection at `pg_catalog, public`, proves the helper temporarily sees `tenant_first, public`, then verifies the original path survives both normal cleanup and a raised callback. Restoration uses parameterized `set_config/3`, so quoted schema paths stay data rather than SQL.

Verified against the focused regression, the complete migration test file, and the full suite.

Closes #186.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the tenant-first migration test helper's original search_path so the checked-out connection is left exactly as it was, instead of being reset to `public`. This regression fix also adds a test that verifies the original path survives both normal cleanup and raised callbacks. Closes #186.

<sup>Written for commit 060a943a159d74d7027fd29e5b2d3f8582e0e635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/arcana/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

